### PR TITLE
Model update 9 octobre 2025

### DIFF
--- a/utils/models/models.json
+++ b/utils/models/models.json
@@ -841,22 +841,23 @@
     "icon_path": "moonshot-ai.webp",
     "models": [
       {
-        "new": true,
-        "id": "kimi-k2",
         "simple_name": "Kimi K2",
         "license": "MIT",
-        "release_date": "11/2025",
+        "id": "kimi-k2",
+        "release_date": "09/2025",
         "params": 1000,
         "active_params": 32,
         "arch": "moe",
-        "reasoning": true,
-        "endpoint": {
-          "api_type": "openrouter",
-          "api_model_id": "moonshotai/kimi-k2"
-        },
+        "url": "https://huggingface.co/moonshotai/Kimi-K2-Instruct",
         "desc": "Développé par Moonshot AI (亦称「月之暗面」/ Yue Zhi An Mian), une société basée à Pékin, Kimi K2 est un très grand modèle orienté code et usages agentiques. Il est reconnu pour les tâches de développement dans des contextes agentiques (par ex. dans Cursor ou Windsurf) notamment pour son rôle en tant qu’orchestrateur. Il n’expose pas de “mode raisonnement” explicite, mais pour les grandes tâches il sous-divise sa réponse en étapes et alterne entre actions (appels d’outils) et rédaction de texte.",
         "size_desc": "Avec 1 billion de paramètres, ce modèle est un des plus grands modèles qui existe. Grâce à une architecture de mélange d’experts (MoE, Mixture of Experts) il est plus efficace que certains autres modèles de taille similaire, mais il nécessite quand-même un serveur doté de plusieurs cartes graphiques très puissantes pour être hébergé. Sa fenêtre de contexte va jusqu’à 128 000 jetons, ce qui permet de traiter des documents assez longs.",
-        "fyi": "Pour stabiliser l’entraînement à très grande échelle, Moonshot AI a introduit MuonClip, un “limiteur de vitesse” pour l’entraînement qui permet d’entraîner un modèle de cette taille et sur un corpus de 15,5 trillions de jetons sans dérailler dans l’apprentissage.\n\nCôté données, K2 a beaucoup pratiqué en “simulateur” avec de vrais outils (navigateur, terminal, exécuteurs de code, API…). Comme un pilote sur simulateur, il apprend à planifier, essayer, rater puis réessayer, et à enchaîner plusieurs actions pour atteindre un objectif. Résultat: il est particulièrement bon pour orchestrer des outils et réussir des tâches en plusieurs étapes."
+        "fyi": "Pour stabiliser l’entraînement à très grande échelle, Moonshot AI a introduit MuonClip, un “limiteur de vitesse” pour l’entraînement qui permet d’entraîner un modèle de cette taille et sur un corpus de 15,5 trillions de jetons sans dérailler dans l’apprentissage.\n\nCôté données, K2 a beaucoup pratiqué en “simulateur” avec de vrais outils (navigateur, terminal, exécuteurs de code, API…). Comme un pilote sur simulateur, il apprend à planifier, essayer, rater puis réessayer, et à enchaîner plusieurs actions pour atteindre un objectif. Résultat: il est particulièrement bon pour orchestrer des outils et réussir des tâches en plusieurs étapes.",
+        "reasoning": true,
+        "new": true,
+        "endpoint": {
+          "api_type": "openrouter",
+          "api_model_id": "moonshotai/kimi-k2-0905"
+        }
       }
     ]
   },
@@ -1381,22 +1382,37 @@
     "icon_path": "zhipu.svg",
     "models": [
       {
-        "new": true,
-        "id": "glm-4.5",
         "simple_name": "GLM 4.5",
         "license": "MIT",
+        "id": "glm-4.5",
         "release_date": "07/2025",
         "params": 355,
         "active_params": 32,
         "arch": "moe",
-        "reasoning": true,
+        "desc": "Très grand modèle créé par Zhipu AI, un éditeur de modèles d’IA Chinois créé en 2019 par des professeurs de l’université de Tsinghua et soutenu par des grands acteurs comme Alibaba et Tencent.  Le modèle a deux modalités de réponses: l’utilisateur peut choisir entre un mode de raisonnement, pour des réponses plus approfondies, ou un mode rapide, pour générer directement la réponse finale.",
+        "size_desc": "Avec 355 milliards de paramètres, ce modèle se place dans la catégorie des très grands modèles. Grâce à une architecture de mélange d’experts (MoE, Mixture of Experts) il est plus efficace que certains autres modèles de taille similaire, mais il nécessite quand-même un serveur doté de plusieurs cartes graphiques très puissantes pour être hébergé. Sa fenêtre de contexte va jusqu’à 128 000 jetons, ce qui permet de traiter des documents assez longs.",
+        "fyi": "Ce modèle a de bonnes capacités agentiques, lui permettant d'effectuer des appels de fonctions avec une grande fiabilité. Ses performances en codage sont élevées et le modèle a une bonne capacité de créer des applications web complètes et de générer des artefacts, qui sont des programmes d’un seul fichier utilisable à l’intérieur même des interfaces des agents conversationnels. Pour l'entraînement, une infrastructure d'apprentissage par renforcement spécifique, nommée slime, a été conçue pour optimiser les performances sur des tâches complexes et agentiques en gérant de manière efficiente les flux de travail longs - le modèle est capable de traiter des tâches complexes et de longue durée, comme la création d'une application de A à Z, en utilisant au mieux ses outils et en restant cohérent du début à la fin.",
         "endpoint": {
           "api_type": "openrouter",
           "api_model_id": "z-ai/glm-4.5"
-        },
-        "desc": "Très grand modèle créé par Zhipu AI, un éditeur de modèles d’IA Chinois créé en 2019 par des professeurs de l’université de Tsinghua et soutenu par des grands acteurs comme Alibaba et Tencent.  Le modèle a deux modalités de réponses: l’utilisateur peut choisir entre un mode de raisonnement, pour des réponses plus approfondies, ou un mode rapide, pour générer directement la réponse finale.",
-        "size_desc": "Avec 355 milliards de paramètres, ce modèle se place dans la catégorie des très grands modèles. Grâce à une architecture de mélange d’experts (MoE, Mixture of Experts) il est plus efficace que certains autres modèles de taille similaire, mais il nécessite quand-même un serveur doté de plusieurs cartes graphiques très puissantes pour être hébergé. Sa fenêtre de contexte va jusqu’à 128 000 jetons, ce qui permet de traiter des documents assez longs.",
-        "fyi": "Ce modèle a de bonnes capacités agentiques, lui permettant d'effectuer des appels de fonctions avec une grande fiabilité. Ses performances en codage sont élevées et le modèle a une bonne capacité de créer des applications web complètes et de générer des artefacts, qui sont des programmes d’un seul fichier utilisable à l’intérieur même des interfaces des agents conversationnels. Pour l'entraînement, une infrastructure d'apprentissage par renforcement spécifique, nommée slime, a été conçue pour optimiser les performances sur des tâches complexes et agentiques en gérant de manière efficiente les flux de travail longs - le modèle est capable de traiter des tâches complexes et de longue durée, comme la création d'une application de A à Z, en utilisant au mieux ses outils et en restant cohérent du début à la fin."
+        }
+      },
+      {
+        "simple_name": "GLM 4.6",
+        "license": "MIT",
+        "id": "glm-4.6",
+        "release_date": "09/2025",
+        "params": 357,
+        "active_params": 32,
+        "arch": "dense",
+        "desc": "Mise à jour du grand modèle créé par Zhipu AI - GLM 4.6, un éditeur de modèles d’IA Chinois créé en 2019 par des professeurs de l’université de Tsinghua et soutenu par des grands acteurs comme Alibaba et Tencent. Cette mise à jour augmente la taille de la fenêtre de contexte, améliore sa performance en code, s'aligne plus avec les préférences humaines et est plus capable en cas d'usages agentiques/utilisation d'outils.",
+        "size_desc": "Avec 357 milliards de paramètres, ce modèle se place dans la catégorie des très grands modèles. Grâce à une architecture de mélange d’experts (MoE, Mixture of Experts) il est plus efficace que certains autres modèles de taille similaire, mais il nécessite quand-même un serveur doté de plusieurs cartes graphiques très puissantes pour être hébergé. Sa fenêtre de contexte va jusqu’à 200 000 jetons, ce qui permet de traiter de très longs documents.",
+        "fyi": "Ce modèle a de bonnes capacités agentiques, lui permettant d'effectuer des appels de fonctions avec une grande fiabilité. Ses performances en codage sont élevées et le modèle a une bonne capacité de créer des applications web complètes et de générer des artefacts, qui sont des programmes d’un seul fichier utilisable à l’intérieur même des interfaces des agents conversationnels. Pour l'entraînement, une infrastructure d'apprentissage par renforcement spécifique, nommée slime, a été conçue pour optimiser les performances sur des tâches complexes et agentiques en gérant de manière efficiente les flux de travail longs - le modèle est capable de traiter des tâches complexes et de longue durée, comme la création d'une application de A à Z, en utilisant au mieux ses outils et en restant cohérent du début à la fin.",
+        "new": true,
+        "endpoint": {
+          "api_type": "openrouter",
+          "api_model_id": "z-ai/glm-4.6"
+        }
       }
     ]
   },
@@ -1571,6 +1587,30 @@
         "desc": "Yi 1.5 est un modèle de l'entreprise chinoise 01-ai, spécialisé en code, maths, raisonnement, suivi d'instructions, avec une solide compréhension du langage.",
         "size_desc": "Un modèle de petit gabarit est moins complexe et coûteux en ressources par rapport aux modèles plus grands, tout en offrant une performance suffisante pour diverses tâches (résumé, traduction, classification de texte...)",
         "fyi": "Yi 1.5 est un modèle de l'entreprise chinoise 01-ai, spécialisé en code, maths, raisonnement, suivi d'instructions, avec une solide compréhension du langage."
+      }
+    ]
+  },
+  {
+    "name": "Swiss AI",
+    "icon_path": "swiss-ai.png",
+    "models": [
+      {
+        "simple_name": "Apertus 8B Instruct",
+        "license": "Apache 2.0",
+        "id": "Apertus-8B-Instruct-2509",
+        "release_date": "09/2025",
+        "params": 8,
+        "arch": "dense",
+        "url": "https://huggingface.co/swiss-ai/Apertus-8B-Instruct-2509",
+        "desc": "Petit modèle entièrement open source, incluant ses données, ses poids et son code d’entraînement, développé par un consortium d’institutions suisses. Il a été entraîné sur plus de 1 800 langues à partir de 15 000 milliards de tokens issus exclusivement de sources publiques et à licences ouvertes, garantissant une transparence totale. Entraîné sur le supercalculateur Alps du CSCS à Lugano, alimenté par une énergie hydroélectrique neutre en carbone, il incarne une approche plus durable et éthique du développement de l’IA. Il a été conçu dès le départ pour être conforme à l’AI Act.",
+        "size_desc": "Avec 8 milliards de paramètres, ce modèle fait partie des petits modèles. Il peut être utilisé localement sur un ordinateur puissant, garantissant la confidentialité des données, ou hébergé sur un serveur équipé d’une seule carte graphique, ce qui limite les coûts d’infrastructure. Sa fenêtre de contexte de 65 536 jetons ce qui permet de traiter d'assez longs documents.",
+        "fyi": "Le modèle a été entraîné sur le supercalculateur Alps à Lugano, utilisant plus de 10 millions d’heures GPU alimentées par une énergie hydroélectrique neutre en carbone. Le modèle a été préentraîné sur 15 000 milliards de tokens issus exclusivement de sources publiques et permissives, couvrant plus de 1 800 langues, dont une part importante de langues peu représentées.\n\nApertus s’appuie sur un tokenizer byte-level BPE de 131 000 entrées, dérivé du tokenizer « tekken » de Mistral AI, optimisé pour le multilinguisme, le code et les expressions mathématiques. L’architecture combine plusieurs innovations : Rotary Positional Embeddings (RoPE) avec base étendue et ajustement NTK-aware pour les longs contextes, Grouped Query Attention (GQA) pour une meilleure efficacité mémoire, normalisation QK-Norm pour stabiliser l’entraînement, et une fonction d’activation xIELU (extended Integrated ELU) améliorant la performance des MLP.\n\nL’affinage final du modèle repose sur un algorithme d’alignement appelé QRPO (Quantile Reward-Preferring Optimization), une alternative au RLHF classique, qui utilise des signaux de récompense absolus pour un apprentissage plus stable et mieux aligné sur les préférences humaines. Bien qu’il ne rivalise pas directement avec les modèles propriétaires les plus avancés, Apertus se distingue par son ouverture totale, sa rigueur scientifique et son approche exemplaire en matière de transparence et de conformité réglementaire.",
+        "new": true,
+        "endpoint": {
+          "api_type": "HF Inference Providers",
+          "api_model_id": "swiss-ai/Apertus-8B-Instruct-2509:publicai",
+          "api_base": "https://router.huggingface.co/v1"
+        }
       }
     ]
   }


### PR DESCRIPTION
Warning : do not merge before configuring the Swiss AI logo + the HF inference providers endpoint

+ Added company: Swiss AI with 1 model - Apertus 8B

@ Moonshot AI:
  ~ Modified Kimi K2: release date

@ Zhipu:
  + Added model: GLM 4.6
