### PR TITLE
fix: stop treating output truncation as context-too-long error

### DIFF
--- a/backend/arena/conversation.py
+++ b/backend/arena/conversation.py
@@ -31,7 +31,7 @@ async def bot_response_async(
     state: Conversation,
     request: Request,
     temperature=0.7,
-    max_new_tokens=4096,
+    max_new_tokens=16384,
 ) -> AsyncGenerator[list[AnyMessage]]:
     """
     Stream a response from an AI model asynchronously.


### PR DESCRIPTION
## Summary
- `finish_reason=\"length\"` means the model's **output** was truncated at `max_tokens`, not that the input context was too long. The code was incorrectly raising `ContextTooLongError` and throwing away valid responses (2.2k Sentry events).
- Now accepts truncated responses normally instead of erroring
- Catches `litellm.ContextWindowExceededError` (the real input-too-long error) and converts it to `ContextTooLongError` for proper frontend handling
- Raised `max_new_tokens` from 4096 to 16384 so models rarely hit the output cap

## Test plan
- [ ] Run with `MOCK_RESPONSE` set, verify normal flow works
- [ ] Temporarily set `max_new_tokens=10`, verify truncated response is displayed (not an error)
- [ ] After deploy, monitor Sentry for drop in ContextTooLongError events