### PR TITLE
fix(streaming): correct the reasoning field name in LiteLLM parsing 

### DIFF
--- a/backend/arena/litellm.py
+++ b/backend/arena/litellm.py
@@ -215,7 +215,7 @@ def litellm_stream_iter(
                 if content := choice.delta.get("content"):
                     data["content"] += content
                 # Get reasoning content (for reasoning models)
-                if reasoning := delta.get("reasoning_content"):
+                if reasoning := delta.get("reasoning_content") or delta.get("reasoning"):
                     data["reasoning"] += reasoning
 
             # Check for generation completion signal


### PR DESCRIPTION
The code was reading `delta.get("reasoning")`, but the field on LiteLLM’s Delta object is called `reasoning_content`. As a result, the models’ reasoning output (GLM-5, DeepSeek R1, Qwen 3.5, etc.) was silently lost during streaming.

This also explains why, in the exported dataset, messages with `reasoning_content` consistently have an empty `content` field (#296): since the reasoning was never captured during streaming, the data saved in the database was already incomplete.

Tested locally with GLM-5, DeepSeek R1 0528, Qwen 3.5 397B, Kimi K2.5, MiniMax M2.5, and Olmo 3 32B Think. Reasoning and content are now correctly captured and persisted.
