### PR TITLE
Switch to Gemini 3.1 Flash Lite for topic/PII analysis

### DIFF
--- a/utils/topics_pii.py
+++ b/utils/topics_pii.py
@@ -16,8 +16,7 @@ from vertexai.generative_models import GenerativeModel
 class Config:
     PROJECT_ID = "languia-430909"
     LOCATION = "europe-west1"
-    # MODEL_NAME = "gemini-2.0-flash-lite"
-    MODEL_NAME = "gemini-2.0-flash-001"
+    MODEL_NAME = "gemini-3.1-flash-lite-preview"
     MAX_RETRIES = 3
     RETRY_DELAY = 1
 


### PR DESCRIPTION
## Summary
- Switches the model used in `utils/topics_pii.py` from `gemini-2.0-flash-001` to
  `gemini-3.1-flash-lite-preview` for conversation categorization, summarization, and PII detection.

## Note
Ideally, we should use the Mistral models via the Albert API for this task, but we need to test that a bit
more thoroughly before making that switch.

## Test plan
- [ ] Run `topics_pii.py` on a batch of conversations and verify output quality (categories, summaries, PII detection)
- [ ] Check that the structured JSON response schema is still respected by the new model