### PR TITLE
Check missing translations on PRs

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -1,0 +1,95 @@
+name: Check Missing Translations
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/locales/messages/fr.json'
+      - 'frontend/locales/messages/en.json'
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-translations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check missing translations
+        id: check
+        run: |
+          python3 << 'EOF'
+          import json
+          import os
+
+          def get_leaf_keys(d, parent_key=""):
+              keys = set()
+              for k, v in d.items():
+                  key = f"{parent_key}.{k}" if parent_key else k
+                  if isinstance(v, dict):
+                      keys |= get_leaf_keys(v, key)
+                  else:
+                      keys.add(key)
+              return keys
+
+          fr = json.loads(open("frontend/locales/messages/fr.json").read())
+          da = json.loads(open("frontend/locales/messages/da.json").read())
+
+          fr_keys = get_leaf_keys(fr)
+          da_keys = get_leaf_keys(da)
+
+          missing_in_da = sorted(fr_keys - da_keys)
+          missing_in_fr = sorted(da_keys - fr_keys)
+
+          body_parts = []
+
+          if missing_in_da:
+              items = "\n".join(f"- `{k}`" for k in missing_in_da)
+              body_parts.append(
+                  f"### Danish (`da.json`) is missing {len(missing_in_da)} key(s) present in `fr.json`\n\n"
+                  f"@KennethEnevoldsen could you add the Danish translations for these keys?\n\n"
+                  f"{items}"
+              )
+
+          if missing_in_fr:
+              items = "\n".join(f"- `{k}`" for k in missing_in_fr)
+              body_parts.append(
+                  f"### French (`fr.json`) is missing {len(missing_in_fr)} key(s) present in `da.json`\n\n"
+                  f"@simonaszilinskas could you add the French translations for these keys?\n\n"
+                  f"{items}"
+              )
+
+          if body_parts:
+              body = "## Missing Translations\n\n" + "\n\n".join(body_parts)
+              status = "found"
+          else:
+              body = ""
+              status = "ok"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"status={status}\n")
+
+          # Write body to a file to avoid escaping issues
+          with open("/tmp/comment-body.md", "w") as f:
+              f.write(body)
+          EOF
+
+      - name: Find existing comment
+        if: steps.check.outputs.status == 'found'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## Missing Translations'
+
+      - name: Post or update PR comment
+        if: steps.check.outputs.status == 'found'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: /tmp/comment-body.md
+          edit-mode: replace

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'frontend/locales/messages/fr.json'
       - 'frontend/locales/messages/en.json'
+      - '.github/workflows/check-translations.yml'
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -30,7 +30,7 @@ jobs:
                   key = f"{parent_key}.{k}" if parent_key else k
                   if isinstance(v, dict):
                       keys |= get_leaf_keys(v, key)
-                  else:
+                  elif v:  # skip empty strings
                       keys.add(key)
               return keys
 

--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -2,9 +2,9 @@ name: Check Missing Translations
 
 on:
   pull_request:
+    branches: [main]
     paths:
-      - 'frontend/locales/messages/fr.json'
-      - 'frontend/locales/messages/en.json'
+      - 'frontend/locales/messages/*.json'
       - '.github/workflows/check-translations.yml'
     types: [opened, synchronize, reopened]
 
@@ -19,11 +19,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check missing translations
-        id: check
         run: |
           python3 << 'EOF'
           import json
           import os
+          import glob
 
           def get_leaf_keys(d, parent_key=""):
               keys = set()
@@ -36,49 +36,46 @@ jobs:
               return keys
 
           fr = json.loads(open("frontend/locales/messages/fr.json").read())
-          da = json.loads(open("frontend/locales/messages/da.json").read())
-
           fr_keys = get_leaf_keys(fr)
-          da_keys = get_leaf_keys(da)
 
-          missing_in_da = sorted(fr_keys - da_keys)
-          missing_in_fr = sorted(da_keys - fr_keys)
-
+          locale_files = sorted(glob.glob("frontend/locales/messages/*.json"))
           body_parts = []
 
-          if missing_in_da:
-              items = "\n".join(f"- `{k}`" for k in missing_in_da)
-              body_parts.append(
-                  f"### Danish (`da.json`) is missing {len(missing_in_da)} key(s) present in `fr.json`\n\n"
-                  f"@KennethEnevoldsen could you add the Danish translations for these keys?\n\n"
-                  f"{items}"
-              )
+          for filepath in locale_files:
+              lang_code = os.path.basename(filepath).replace(".json", "")
+              if lang_code == "fr":
+                  continue
 
-          if missing_in_fr:
-              items = "\n".join(f"- `{k}`" for k in missing_in_fr)
-              body_parts.append(
-                  f"### French (`fr.json`) is missing {len(missing_in_fr)} key(s) present in `da.json`\n\n"
-                  f"@simonaszilinskas could you add the French translations for these keys?\n\n"
-                  f"{items}"
-              )
+              other = json.loads(open(filepath).read())
+              other_keys = get_leaf_keys(other)
+
+              missing = sorted(fr_keys - other_keys)
+              obsolete = sorted(other_keys - fr_keys)
+
+              if missing:
+                  items = "\n".join(f"- `{k}`" for k in missing)
+                  body_parts.append(
+                      f"### `{lang_code}.json` is missing {len(missing)} key(s) present in `fr.json`\n\n"
+                      f"{items}"
+                  )
+
+              if obsolete:
+                  items = "\n".join(f"- `{k}`" for k in obsolete)
+                  body_parts.append(
+                      f"### `{lang_code}.json` has {len(obsolete)} obsolete key(s) not in `fr.json` (should be removed)\n\n"
+                      f"{items}"
+                  )
 
           if body_parts:
               body = "## Missing Translations\n\n" + "\n\n".join(body_parts)
-              status = "found"
           else:
-              body = ""
-              status = "ok"
+              body = "## Missing Translations\n\nAll locale files are in sync with `fr.json`!"
 
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"status={status}\n")
-
-          # Write body to a file to avoid escaping issues
           with open("/tmp/comment-body.md", "w") as f:
               f.write(body)
           EOF
 
       - name: Find existing comment
-        if: steps.check.outputs.status == 'found'
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
@@ -87,7 +84,6 @@ jobs:
           body-includes: '## Missing Translations'
 
       - name: Post or update PR comment
-        if: steps.check.outputs.status == 'found'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1,4 +1,5 @@
 {
+    "_ci_test": "clé temporaire pour tester le workflow CI",
     "a11y": {
         "externalLink": "{text}"
     },

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1,5 +1,4 @@
 {
-    "_ci_test": "clé temporaire pour tester le workflow CI",
     "a11y": {
         "externalLink": "{text}"
     },


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs on PRs touching `fr.json` or `en.json`
- Compares translation keys between French and Danish locale files
- Posts a PR comment listing missing keys and tags the right people to translate them
- Includes a temporary test key in `fr.json` to trigger the workflow on this PR (to remove after testing)

## Test plan

- [ ] Verify the workflow runs on this PR
- [ ] Check the PR comment lists the missing `_ci_test` key for Danish
- [ ] Remove the test key from `fr.json` after validation