### PR TITLE
Persist spam detection in DB like PII

### DIFF
--- a/utils/schemas/conversations.sql
+++ b/utils/schemas/conversations.sql
@@ -86,5 +86,6 @@ ALTER TABLE conversations ADD COLUMN cached_response_a BOOLEAN DEFAULT FALSE;
 ALTER TABLE conversations ADD COLUMN cached_response_b BOOLEAN DEFAULT FALSE;
 
 -- 19/03/2026
--- Persist spam detection results (like PII, analyzed during post-processing)
-ALTER TABLE conversations ADD COLUMN contains_spam BOOLEAN DEFAULT FALSE;
+-- Persist spam/NSFW detection results (like PII, analyzed during post-processing)
+-- NULL = not yet checked, FALSE = checked and clean, TRUE = checked and is spam/NSFW
+ALTER TABLE conversations ADD COLUMN contains_spam BOOLEAN DEFAULT NULL;

--- a/utils/schemas/conversations.sql
+++ b/utils/schemas/conversations.sql
@@ -84,3 +84,7 @@ ALTER TABLE conversations ADD COLUMN country_portal VARCHAR(255);
 -- Track whether responses were served from cache
 ALTER TABLE conversations ADD COLUMN cached_response_a BOOLEAN DEFAULT FALSE;
 ALTER TABLE conversations ADD COLUMN cached_response_b BOOLEAN DEFAULT FALSE;
+
+-- 19/03/2026
+-- Persist spam detection results (like PII, analyzed during post-processing)
+ALTER TABLE conversations ADD COLUMN contains_spam BOOLEAN DEFAULT FALSE;

--- a/utils/storage/queries.py
+++ b/utils/storage/queries.py
@@ -5,9 +5,10 @@ from backend.config import CountryPortal
 Columns = tuple[str, ...]
 
 EXCLUDE_PPI = """
--- Filter out rows potentially containing PII
+-- Filter out rows potentially containing PII or spam
 AND c.pii_analyzed = TRUE
 AND c.contains_pii = FALSE
+AND c.contains_spam = FALSE
 AND c.postprocess_failed = FALSE
 """
 EXCLUDE_COHORTS = """

--- a/utils/topics_pii.py
+++ b/utils/topics_pii.py
@@ -92,13 +92,14 @@ class Config:
 
             Conversation A: {conversation_a}
             Conversation B: {conversation_b}
-
-            Return the response in the following JSON schema:
-            {json.dumps(self.response_schema, indent=2)}
             """
 
             response = model.generate_content(
-                prompt, generation_config={"response_mime_type": "application/json"}
+                prompt,
+                generation_config={
+                    "response_mime_type": "application/json",
+                    "response_schema": self.response_schema,
+                },
             )
             print("Gemini API response received.")
             try:

--- a/utils/topics_pii.py
+++ b/utils/topics_pii.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
@@ -9,12 +8,6 @@ from typing import List, Optional, Tuple
 import psycopg2
 import vertexai
 from vertexai.generative_models import GenerativeModel
-
-# Add the parent directory to the Python path for backend imports
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.abspath(os.path.join(SCRIPT_DIR, "..")))
-
-from backend.arena.spam_detection import is_spam
 
 # Used in kubernetes (cron job)
 # FIXME: change model for cheeper model? (still gemini)
@@ -57,6 +50,7 @@ class Config:
             "type": "OBJECT",
             "properties": {
                 "contains_pii": {"type": "BOOLEAN"},
+                "contains_spam": {"type": "BOOLEAN"},
                 "categories": {
                     "type": "ARRAY",
                     "items": {
@@ -70,6 +64,7 @@ class Config:
             },
             "required": [
                 "contains_pii",
+                "contains_spam",
                 "categories",
                 "keywords",
                 "short_summary",
@@ -87,7 +82,14 @@ class Config:
             model = GenerativeModel(self.MODEL_NAME)
 
             prompt = f"""
-            Analyze the following two conversations and determine if they contain personal info (names, emails, addresses) or sensitive info (medical, financial), categorize them, extract keywords (5 to 7, careful not to use PIIs in it), provide a short summary (don't use PIIs in summary), and identify the languages used (2-letter codes).
+            Analyze the following two conversations and determine:
+            - contains_pii: whether they contain personal info (names, emails, addresses) or sensitive info (medical, financial)
+            - contains_spam: whether the conversation is spam, a prompt injection attempt (e.g. pasting a system prompt, jailbreak, or roleplay persona definition), or contains NSFW/sexual/violent content that should not be published in a public dataset
+            - categories: categorize them
+            - keywords: extract keywords (5 to 7, careful not to use PIIs in it)
+            - short_summary: provide a short summary (don't use PIIs in summary)
+            - languages: identify the languages used (2-letter codes)
+
             Conversation A: {conversation_a}
             Conversation B: {conversation_b}
 
@@ -119,8 +121,9 @@ class Config:
         conversation_b: List[dict],
         conversation_pair_id: int,
     ) -> Tuple[
-        Optional[List[dict]],
-        Optional[List[dict]],
+        Optional[bool],
+        Optional[bool],
+        Optional[List[str]],
         Optional[List[str]],
         Optional[str],
         Optional[List[str]],
@@ -129,26 +132,15 @@ class Config:
         analysis_result = self._analyze_conversation(conversation_a, conversation_b)
         if analysis_result:
             contains_pii = analysis_result.get("contains_pii")
+            contains_spam = analysis_result.get("contains_spam", False)
             categories = analysis_result.get("categories")
             keywords = analysis_result.get("keywords")
             short_summary = analysis_result.get("short_summary")
             languages = analysis_result.get("languages")
 
-            return contains_pii, categories, keywords, short_summary, languages
+            return contains_pii, contains_spam, categories, keywords, short_summary, languages
         else:
-            return None, None, None, None, None
-
-
-def conversation_contains_spam(messages: List[dict]) -> bool:
-    """Check if any user message in a conversation matches spam patterns."""
-    if not messages or not isinstance(messages, list):
-        return False
-    for message in messages:
-        if isinstance(message, dict) and message.get("role") == "user":
-            content = message.get("content", "")
-            if content and is_spam(str(content)):
-                return True
-    return False
+            return None, None, None, None, None, None
 
 
 def process_conversation(conversation, analyzer, db_params):
@@ -190,30 +182,25 @@ def process_conversation(conversation, analyzer, db_params):
             print(
                 f"Attempt {attempt + 1}/{Config.MAX_RETRIES} for conversation pair ID: {conversation_pair_id}"
             )
-            contains_pii, categories, keywords, short_summary, languages = (
+            contains_pii, contains_spam, categories, keywords, short_summary, languages = (
                 analyzer.analyze_conversations(
                     conversation_a, conversation_b, conversation_pair_id
                 )
             )
             # If llm call worked, insert metadata in db
             if contains_pii is not None:
-                # Run spam detection (regex-based, no API call)
-                has_spam = conversation_contains_spam(
-                    conversation_a
-                ) or conversation_contains_spam(conversation_b)
-
                 print(f"Data to be inserted for {conversation_pair_id}:")
                 print(f"  Short Summary: {short_summary}")
                 print(f"  Keywords: {keywords}")
                 print(f"  Languages: {languages}")
                 print(f"  categories: {categories}")
                 print(f"  Contains PII: {contains_pii}")
-                print(f"  Contains Spam: {has_spam}")
+                print(f"  Contains Spam: {contains_spam}")
                 cursor.execute(
                     "UPDATE conversations SET pii_analyzed = TRUE, contains_pii = %s, contains_spam = %s, short_summary = %s, keywords = %s, categories = %s, languages = %s, postprocess_failed = FALSE WHERE conversation_pair_id = %s;",
                     (
                         contains_pii,
-                        has_spam,
+                        contains_spam,
                         short_summary,
                         json.dumps(keywords),
                         json.dumps(categories),

--- a/utils/topics_pii.py
+++ b/utils/topics_pii.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
@@ -8,6 +9,12 @@ from typing import List, Optional, Tuple
 import psycopg2
 import vertexai
 from vertexai.generative_models import GenerativeModel
+
+# Add the parent directory to the Python path for backend imports
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(SCRIPT_DIR, "..")))
+
+from backend.arena.spam_detection import is_spam
 
 # Used in kubernetes (cron job)
 # FIXME: change model for cheeper model? (still gemini)
@@ -132,6 +139,18 @@ class Config:
             return None, None, None, None, None
 
 
+def conversation_contains_spam(messages: List[dict]) -> bool:
+    """Check if any user message in a conversation matches spam patterns."""
+    if not messages or not isinstance(messages, list):
+        return False
+    for message in messages:
+        if isinstance(message, dict) and message.get("role") == "user":
+            content = message.get("content", "")
+            if content and is_spam(str(content)):
+                return True
+    return False
+
+
 def process_conversation(conversation, analyzer, db_params):
     conn = None
     conversation_pair_id = conversation[0]  # Extract ID early
@@ -178,16 +197,23 @@ def process_conversation(conversation, analyzer, db_params):
             )
             # If llm call worked, insert metadata in db
             if contains_pii is not None:
+                # Run spam detection (regex-based, no API call)
+                has_spam = conversation_contains_spam(
+                    conversation_a
+                ) or conversation_contains_spam(conversation_b)
+
                 print(f"Data to be inserted for {conversation_pair_id}:")
                 print(f"  Short Summary: {short_summary}")
                 print(f"  Keywords: {keywords}")
                 print(f"  Languages: {languages}")
                 print(f"  categories: {categories}")
                 print(f"  Contains PII: {contains_pii}")
+                print(f"  Contains Spam: {has_spam}")
                 cursor.execute(
-                    "UPDATE conversations SET pii_analyzed = TRUE, contains_pii = %s, short_summary = %s, keywords = %s, categories = %s, languages = %s, postprocess_failed = FALSE WHERE conversation_pair_id = %s;",
+                    "UPDATE conversations SET pii_analyzed = TRUE, contains_pii = %s, contains_spam = %s, short_summary = %s, keywords = %s, categories = %s, languages = %s, postprocess_failed = FALSE WHERE conversation_pair_id = %s;",
                     (
                         contains_pii,
+                        has_spam,
                         short_summary,
                         json.dumps(keywords),
                         json.dumps(categories),
@@ -306,6 +332,14 @@ def process_conversations(db_params, analyzer: Config):
         pii_analyzed_true_count = cursor.fetchone()[0]
         print(
             f"{pii_analyzed_true_count} conversations with pii_analyzed = TRUE and not marked as failed."
+        )
+
+        cursor.execute(
+            "SELECT count(*) FROM conversations WHERE contains_spam = TRUE AND postprocess_failed = FALSE;"
+        )
+        contains_spam_true_count = cursor.fetchone()[0]
+        print(
+            f"{contains_spam_true_count} conversations with contains_spam = TRUE and not marked as failed."
         )
 
         # Include the postprocess_failed field in the select statement and filter

--- a/utils/topics_pii.py
+++ b/utils/topics_pii.py
@@ -252,83 +252,38 @@ def process_conversations(db_params, analyzer: Config):
         conn = psycopg2.connect(db_params)
         cursor = conn.cursor()
 
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE short_summary IS NULL AND postprocess_failed = FALSE;"
-        )
-        no_summary_count = cursor.fetchone()[0]
-        print(
-            f"{no_summary_count} conversations with no short summary and not marked as failed."
-        )
+        cursor.execute("""
+            SELECT
+                COUNT(*) FILTER (WHERE short_summary IS NULL AND NOT postprocess_failed) AS no_summary,
+                COUNT(*) FILTER (WHERE short_summary IS NOT NULL AND NOT postprocess_failed) AS has_summary,
+                COUNT(*) FILTER (WHERE keywords IS NULL AND NOT postprocess_failed) AS no_keywords,
+                COUNT(*) FILTER (WHERE keywords IS NOT NULL AND NOT postprocess_failed) AS has_keywords,
+                COUNT(*) FILTER (WHERE contains_pii = FALSE AND NOT postprocess_failed) AS pii_false,
+                COUNT(*) FILTER (WHERE contains_pii = TRUE AND NOT postprocess_failed) AS pii_true,
+                COUNT(*) FILTER (WHERE contains_pii IS NULL AND NOT postprocess_failed) AS pii_null,
+                COUNT(*) FILTER (WHERE NOT pii_analyzed AND NOT postprocess_failed) AS pii_not_analyzed,
+                COUNT(*) FILTER (WHERE pii_analyzed AND NOT postprocess_failed) AS pii_analyzed,
+                COUNT(*) FILTER (WHERE contains_spam = TRUE AND NOT postprocess_failed) AS spam_true
+            FROM conversations;
+        """)
+        (
+            no_summary_count, summary_count,
+            no_keywords_count, keywords_count,
+            contains_pii_false_count, contains_pii_true_count, contains_pii_null_count,
+            pii_analyzed_false_count, pii_analyzed_true_count,
+            contains_spam_true_count,
+        ) = cursor.fetchone()
 
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE keywords IS NULL AND postprocess_failed = FALSE;"
-        )
-        no_keywords_count = cursor.fetchone()[0]
-        print(
-            f"{no_keywords_count} conversations with no keywords and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE short_summary IS NOT NULL AND postprocess_failed = FALSE;"
-        )
-        summary_count = cursor.fetchone()[0]
-        print(
-            f"{summary_count} conversations with a short summary and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE keywords IS NOT NULL AND postprocess_failed = FALSE;"
-        )
-        keywords_count = cursor.fetchone()[0]
+        print(f"{no_summary_count} conversations with no short summary and not marked as failed.")
+        print(f"{summary_count} conversations with a short summary and not marked as failed.")
+        print(f"{no_keywords_count} conversations with no keywords and not marked as failed.")
         print(f"{keywords_count} conversations with keywords and not marked as failed.")
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE contains_pii = FALSE AND postprocess_failed = FALSE;"
-        )
-        contains_pii_false_count = cursor.fetchone()[0]
-        print(
-            f"{contains_pii_false_count} conversations with contains_pii = FALSE and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE contains_pii = TRUE AND postprocess_failed = FALSE;"
-        )
-        contains_pii_true_count = cursor.fetchone()[0]
-        print(
-            f"{contains_pii_true_count} conversations with contains_pii = TRUE and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE contains_pii IS NULL AND postprocess_failed = FALSE;"
-        )
-        contains_pii_null_count = cursor.fetchone()[0]
-        print(
-            f"{contains_pii_null_count} conversations with contains_pii = NULL and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE pii_analyzed = FALSE AND postprocess_failed = FALSE;"
-        )
-        pii_analyzed_false_count = cursor.fetchone()[0]
-        print(
-            f"{pii_analyzed_false_count} conversations with pii_analyzed = FALSE and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE pii_analyzed = TRUE AND postprocess_failed = FALSE;"
-        )
-        pii_analyzed_true_count = cursor.fetchone()[0]
-        print(
-            f"{pii_analyzed_true_count} conversations with pii_analyzed = TRUE and not marked as failed."
-        )
-
-        cursor.execute(
-            "SELECT count(*) FROM conversations WHERE contains_spam = TRUE AND postprocess_failed = FALSE;"
-        )
-        contains_spam_true_count = cursor.fetchone()[0]
-        print(
-            f"{contains_spam_true_count} conversations with contains_spam = TRUE and not marked as failed."
-        )
+        print(f"{contains_pii_false_count} conversations with contains_pii = FALSE and not marked as failed.")
+        print(f"{contains_pii_true_count} conversations with contains_pii = TRUE and not marked as failed.")
+        print(f"{contains_pii_null_count} conversations with contains_pii = NULL and not marked as failed.")
+        print(f"{pii_analyzed_false_count} conversations with pii_analyzed = FALSE and not marked as failed.")
+        print(f"{pii_analyzed_true_count} conversations with pii_analyzed = TRUE and not marked as failed.")
+        print(f"{contains_spam_true_count} conversations with contains_spam = TRUE and not marked as failed.")
 
         # Include the postprocess_failed field in the select statement and filter
         cursor.execute(


### PR DESCRIPTION
Adds a `contains_spam` boolean column to the conversations table, mirroring how `contains_pii` works. Spam detection (regex-based, no API call) now runs during the post-processing cron job alongside PII analysis, and the result is persisted in the database.

Spam-flagged conversations are filtered out in all the same places as PII: dataset exports, ranking queries, and the shared storage query helpers. The existing Python-side spam filtering in the export script is kept as a safety net.

Migration: `ALTER TABLE conversations ADD COLUMN contains_spam BOOLEAN DEFAULT FALSE;`

Depends on #397 for the new spam patterns.