### PR TITLE
migrate DB layer to psycopg3 async with connection pool

### DIFF
--- a/backend/arena/persistence.py
+++ b/backend/arena/persistence.py
@@ -11,11 +11,11 @@ This module handles:
 
 import json
 import logging
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Annotated, Any, Iterator
+from typing import Annotated, Any, AsyncIterator
 
-import psycopg2
+import psycopg
 from fastapi import Request
 from pydantic import BaseModel, Field, PlainSerializer, WrapSerializer
 
@@ -39,16 +39,13 @@ def is_not(v: Any) -> bool:
     return not v
 
 
-@contextmanager
-def db(
+@asynccontextmanager
+async def db(
     data: dict,
     action: str,
-) -> Iterator[tuple[Any, str, str]]:
+) -> AsyncIterator[tuple[Any, str, str]]:
     """
-    Simple db context manager yielding cursor and data field/values strings.
-    Also log error for convinience.
-    Important: Every keys/values from `data` will be passed to the query string,
-    make sure `data` datastructure reflects the related db model.
+    Async db context manager yielding cursor and data field/values strings.
 
     Args:
         data: Pydantic model dump that will be passed to query
@@ -56,183 +53,97 @@ def db(
 
     Yields:
         Tuple with:
-            - cursor: db connection cursor
+            - cursor: async db connection cursor
             - str: comma separated list of field keys
             - str: comma separated list of fields Values keys (%(key)s)
-
-    Raises:
-        psycopg2.Error: If database operation fails
     """
     try:
         logger.debug(f"[DB] Try to {action} data")
 
-        with psycopg2.connect(settings.COMPARIA_DB_URI) as conn:
-            with conn.cursor() as cursor:
+        async with await psycopg.AsyncConnection.connect(settings.COMPARIA_DB_URI) as conn:
+            async with conn.cursor() as cursor:
                 data_keys = list(data.keys())
                 field_keys = ", ".join(data_keys)
                 value_keys = ", ".join(f"%({k})s" for k in data_keys)
                 yield (cursor, field_keys, value_keys)
 
-    except psycopg2.Error as e:
+    except psycopg.Error as e:
         logger.error(f"[DB] Error couldn't {action} data: {e}", exc_info=True)
-        # FIXME Previous code never raise db error, raise it?
 
 
-def save_vote_to_db(data: dict) -> dict:
-    """
-    Save a vote to the database.
-
-    Inserts or updates a vote record with comprehensive preference data.
-    This function handles the final vote when a user selects a preferred model
-    or marks them as equal, along with detailed preference ratings.
-
-    Args:
-        data: Vote data dict with all fields
-
-    Returns:
-        dict: The saved vote data with conversation_pair_id
-
-    Raises:
-        psycopg2.Error: If database operation fails
-    """
-
-    with db(data, "save 'vote'") as (cursor, fields, values):
-        # SQL INSERT for votes table
-        insert_statement = psycopg2.sql.SQL(f"""
-            INSERT INTO votes ({fields})
-            VALUES ({values})
-        """)
-
-        cursor.execute(insert_statement, data)
-
-        # TODO: also increment redis counter
-        # if data.get("country_portal") == "da":
-        #     from languia.session import r
-
-        #     if r:
-        #         try:
-        #             r.incr("danish_count")
-        #         except Exception as e:
-        #             logger.error(f"Error incrementing danish count in Redis: {e}")
+async def save_vote_to_db(data: dict) -> dict:
+    async with db(data, "save 'vote'") as (cursor, fields, values):
+        await cursor.execute(
+            psycopg.sql.SQL(f"INSERT INTO votes ({fields}) VALUES ({values})"),
+            data,
+        )
 
     logger.info(f"[DB] Saved vote for {data['conversation_pair_id']}")
-
     return data
 
 
-def upsert_reaction_to_db(data: dict) -> dict:
-    """
-    UPSERT a reaction to the database.
-
-    Uses ON CONFLICT to update existing reactions or insert new ones.
-
-    Args:
-        data: Reaction data dict (see record_reaction for fields)
-
-    Returns:
-        dict: The saved reaction data
-
-    Database Operation:
-        - Uses PostgreSQL UPSERT (INSERT ... ON CONFLICT ... DO UPDATE)
-        - Key conflict: (refers_to_conv_id, msg_index)
-        - Updates all fields except timestamps on conflict
-    """
-    with db(data, "upsert 'reaction'") as (cursor, fields, values):
-        data_keys = list(data.keys())
-        # SQL UPSERT for reactions table
-        query = psycopg2.sql.SQL(f"""
-            INSERT INTO reactions ({fields})
-            VALUES ({values})
-            ON CONFLICT (refers_to_conv_id, msg_index) 
-            DO UPDATE SET
-                model_a_name = EXCLUDED.model_a_name,
-                model_b_name = EXCLUDED.model_b_name,
-                refers_to_model = EXCLUDED.refers_to_model,
-                opening_msg = EXCLUDED.opening_msg,
-                conversation_a = EXCLUDED.conversation_a,
-                conversation_b = EXCLUDED.conversation_b,
-                model_pos = EXCLUDED.model_pos,
-                conv_turns = EXCLUDED.conv_turns,
-                system_prompt = EXCLUDED.system_prompt,
-                conv_a_id = EXCLUDED.conv_a_id,
-                conv_b_id = EXCLUDED.conv_b_id,
-                conversation_pair_id = EXCLUDED.conversation_pair_id,
-                session_hash = EXCLUDED.session_hash,
-                visitor_id = EXCLUDED.visitor_id,
-                ip = EXCLUDED.ip,
-                response_content = EXCLUDED.response_content,
-                question_content = EXCLUDED.question_content,
-                liked = EXCLUDED.liked,
-                disliked = EXCLUDED.disliked,
-                comment = EXCLUDED.comment,
-                useful = EXCLUDED.useful,
-                complete = EXCLUDED.complete,
-                creative = EXCLUDED.creative,
-                clear_formatting = EXCLUDED.clear_formatting,
-                incorrect = EXCLUDED.incorrect,
-                superficial = EXCLUDED.superficial,
-                instructions_not_followed = EXCLUDED.instructions_not_followed,
-                model_pair_name = EXCLUDED.model_pair_name,
-                msg_rank = EXCLUDED.msg_rank,
-                chatbot_index = EXCLUDED.chatbot_index,
-                question_id = EXCLUDED.question_id;
-        """)
-        # TODO: fixes some edge case
-        #     RETURNING
-        # (CASE
-        #     WHEN (pg_trigger_depth() = 0) THEN 'inserted'
-        #     ELSE 'updated'
-        # END) AS operation;
-
-        cursor.execute(query, data)
-
-        # TODO: also increment redis counter
-        # country_portal = request.query_params.get(
-        #     "country_portal"
-        # ) or request.query_params.get("locale")
-        # if country_portal == "da":
-        #     from languia.session import r
-
-        #     if r:
-        #         try:
-        #             r.incr("danish_count")
-        #         except Exception as e:
-        #             logger.error(f"Error incrementing danish count in Redis: {e}")
+async def upsert_reaction_to_db(data: dict) -> dict:
+    async with db(data, "upsert 'reaction'") as (cursor, fields, values):
+        await cursor.execute(
+            psycopg.sql.SQL(f"""
+                INSERT INTO reactions ({fields})
+                VALUES ({values})
+                ON CONFLICT (refers_to_conv_id, msg_index)
+                DO UPDATE SET
+                    model_a_name = EXCLUDED.model_a_name,
+                    model_b_name = EXCLUDED.model_b_name,
+                    refers_to_model = EXCLUDED.refers_to_model,
+                    opening_msg = EXCLUDED.opening_msg,
+                    conversation_a = EXCLUDED.conversation_a,
+                    conversation_b = EXCLUDED.conversation_b,
+                    model_pos = EXCLUDED.model_pos,
+                    conv_turns = EXCLUDED.conv_turns,
+                    system_prompt = EXCLUDED.system_prompt,
+                    conv_a_id = EXCLUDED.conv_a_id,
+                    conv_b_id = EXCLUDED.conv_b_id,
+                    conversation_pair_id = EXCLUDED.conversation_pair_id,
+                    session_hash = EXCLUDED.session_hash,
+                    visitor_id = EXCLUDED.visitor_id,
+                    ip = EXCLUDED.ip,
+                    response_content = EXCLUDED.response_content,
+                    question_content = EXCLUDED.question_content,
+                    liked = EXCLUDED.liked,
+                    disliked = EXCLUDED.disliked,
+                    comment = EXCLUDED.comment,
+                    useful = EXCLUDED.useful,
+                    complete = EXCLUDED.complete,
+                    creative = EXCLUDED.creative,
+                    clear_formatting = EXCLUDED.clear_formatting,
+                    incorrect = EXCLUDED.incorrect,
+                    superficial = EXCLUDED.superficial,
+                    instructions_not_followed = EXCLUDED.instructions_not_followed,
+                    model_pair_name = EXCLUDED.model_pair_name,
+                    msg_rank = EXCLUDED.msg_rank,
+                    chatbot_index = EXCLUDED.chatbot_index,
+                    question_id = EXCLUDED.question_id
+            """),
+            data,
+        )
 
     logger.info(
         f"[DB] Upserted reaction for {data['refers_to_conv_id']} msg_index={data['msg_index']}"
     )
-
     return data
 
 
-def delete_reaction_in_db(msg_index: int, refers_to_conv_id: str) -> dict:
-    """
-    Delete a reaction from the database.
-
-    Args:
-        msg_index: Message index (position in conversation)
-        refers_to_conv_id: Conversation ID this reaction refers to
-
-    Returns:
-        dict: Result with deleted count
-
-    Raises:
-        psycopg2.Error: If database operation fails
-    """
-    with db({}, "delete 'reaction'") as (cursor, _, __):
-        delete_query = psycopg2.sql.SQL("""
-            DELETE FROM reactions
-            WHERE refers_to_conv_id = %s AND msg_index = %s
-    """)
-
-        cursor.execute(delete_query, (refers_to_conv_id, msg_index))
+async def delete_reaction_in_db(msg_index: int, refers_to_conv_id: str) -> dict:
+    async with db({}, "delete 'reaction'") as (cursor, _, __):
+        await cursor.execute(
+            psycopg.sql.SQL(
+                "DELETE FROM reactions WHERE refers_to_conv_id = %s AND msg_index = %s"
+            ),
+            (refers_to_conv_id, msg_index),
+        )
         deleted_count = cursor.rowcount
 
     logger.info(
         f"[DB] Deleted reaction for {refers_to_conv_id} msg_index={msg_index} (count={deleted_count})"
     )
-
     return {
         "deleted": deleted_count,
         "refers_to_conv_id": refers_to_conv_id,
@@ -240,53 +151,28 @@ def delete_reaction_in_db(msg_index: int, refers_to_conv_id: str) -> dict:
     }
 
 
-def upsert_conv_to_db(data: dict) -> dict:
-    """
-    Insert or update a conversation record in PostgreSQL using UPSERT.
-
-    Allows conversation data to be updated as users continue chatting.
-    Uses conversation_pair_id as the unique key. Updates token counts and
-    message histories while preserving other metadata.
-
-    Args:
-        data: Conversation data dict with all fields
-
-    Returns:
-        dict: The saved conversation data
-
-    Raises:
-        psycopg2.Error: If database operation fails
-
-    Database Operation:
-        - Key: conversation_pair_id (text, unique)
-        - On conflict: Updates message histories and token counts
-        - On conflict: Updates country_portal only if EXCLUDED value exists
-        - Preserves initial timestamps on updates
-    """
-    with db(data, "upsert 'conversations'") as (cursor, fields, values):
-        # FIXME add tstamp?
-        data_keys = list(data.keys())
-        # SQL UPSERT for conversations table
-        upsert_query = psycopg2.sql.SQL(f"""
-            INSERT INTO conversations ({fields})
-            VALUES ({values})
-            ON CONFLICT (conversation_pair_id)
-            DO UPDATE SET
-                country_portal =  coalesce(EXCLUDED.country_portal, conversations.country_portal),
-                conversation_a = EXCLUDED.conversation_a,
-                conversation_b = EXCLUDED.conversation_b,
-                conv_turns = EXCLUDED.conv_turns,
-                total_conv_a_output_tokens = EXCLUDED.total_conv_a_output_tokens,
-                total_conv_b_output_tokens = EXCLUDED.total_conv_b_output_tokens,
-                cached_response_a = EXCLUDED.cached_response_a,
-                cached_response_b = EXCLUDED.cached_response_b,
-                cohorts = EXCLUDED.cohorts
-        """)
-
-        cursor.execute(upsert_query, data)
+async def upsert_conv_to_db(data: dict) -> dict:
+    async with db(data, "upsert 'conversations'") as (cursor, fields, values):
+        await cursor.execute(
+            psycopg.sql.SQL(f"""
+                INSERT INTO conversations ({fields})
+                VALUES ({values})
+                ON CONFLICT (conversation_pair_id)
+                DO UPDATE SET
+                    country_portal = coalesce(EXCLUDED.country_portal, conversations.country_portal),
+                    conversation_a = EXCLUDED.conversation_a,
+                    conversation_b = EXCLUDED.conversation_b,
+                    conv_turns = EXCLUDED.conv_turns,
+                    total_conv_a_output_tokens = EXCLUDED.total_conv_a_output_tokens,
+                    total_conv_b_output_tokens = EXCLUDED.total_conv_b_output_tokens,
+                    cached_response_a = EXCLUDED.cached_response_a,
+                    cached_response_b = EXCLUDED.cached_response_b,
+                    cohorts = EXCLUDED.cohorts
+            """),
+            data,
+        )
 
     logger.info(f"[DB] Upserted conversation {data['conversation_pair_id']}")
-
     return data
 
 
@@ -365,7 +251,7 @@ class VoteRecord(BaseModel):
     # archived: bool = False
 
 
-def record_vote(
+async def record_vote(
     conversations: Conversations,
     vote: VoteBody,
     request: Request,
@@ -442,7 +328,7 @@ def record_vote(
                 )
         fout.write(json.dumps(db_data) + "\n")
 
-    return save_vote_to_db(db_data)
+    return await save_vote_to_db(db_data)
 
 
 # TODO since we can postprocess data from Conversations we could remove:
@@ -525,7 +411,7 @@ class ReactionRecord(BaseModel):
     # cohorts: str
 
 
-def delete_reaction(conv: Conversation, msg_index: int) -> dict:
+async def delete_reaction(conv: Conversation, msg_index: int) -> dict:
     """
     Delete a single message's reaction when the user removes feedback (like == None).
 
@@ -535,7 +421,7 @@ def delete_reaction(conv: Conversation, msg_index: int) -> dict:
      Returns:
         dict: delete result
     """
-    delete_reaction_in_db(msg_index=msg_index, refers_to_conv_id=conv.conv_id)
+    await delete_reaction_in_db(msg_index=msg_index, refers_to_conv_id=conv.conv_id)
 
     return {
         "msg_index": msg_index,
@@ -543,7 +429,7 @@ def delete_reaction(conv: Conversation, msg_index: int) -> dict:
     }
 
 
-def record_reaction(
+async def record_reaction(
     conversations: Conversations,
     reaction: ReactionData,
     msg_index: int,
@@ -623,7 +509,7 @@ def record_reaction(
         fout.write(json.dumps(db_data) + "\n")
     logger.info(f"saved_reaction: {json.dumps(db_data)}", extra={"request": request})
 
-    return upsert_reaction_to_db(db_data)
+    return await upsert_reaction_to_db(db_data)
 
 
 class ConversationMessageRecord(BaseModel):
@@ -726,7 +612,7 @@ class ConversationsRecord(BaseModel):
     # TODO: add `error: boolean` or `error_message: str`, `conv_a|b_error: str`?
 
 
-def record_conversations(
+async def record_conversations(
     conversations: Conversations,
 ) -> dict:
     """
@@ -772,4 +658,4 @@ def record_conversations(
     # Always rewrite the file
     conv_log_path.write_text(json.dumps(db_data) + "\n")
 
-    return upsert_conv_to_db(db_data)
+    return await upsert_conv_to_db(db_data)

--- a/backend/arena/persistence.py
+++ b/backend/arena/persistence.py
@@ -28,6 +28,7 @@ from backend.arena.models import (
     VoteBody,
 )
 from backend.config import ALL_PREFS, CountryPortal, SelectionMode, settings
+from utils.storage.db import async_db_cursor
 
 logger = logging.getLogger("languia")
 
@@ -57,18 +58,11 @@ async def db(
             - str: comma separated list of field keys
             - str: comma separated list of fields Values keys (%(key)s)
     """
-    try:
-        logger.debug(f"[DB] Try to {action} data")
-
-        async with await psycopg.AsyncConnection.connect(settings.COMPARIA_DB_URI) as conn:
-            async with conn.cursor() as cursor:
-                data_keys = list(data.keys())
-                field_keys = ", ".join(data_keys)
-                value_keys = ", ".join(f"%({k})s" for k in data_keys)
-                yield (cursor, field_keys, value_keys)
-
-    except psycopg.Error as e:
-        logger.error(f"[DB] Error couldn't {action} data: {e}", exc_info=True)
+    data_keys = list(data.keys())
+    field_keys = ", ".join(data_keys)
+    value_keys = ", ".join(f"%({k})s" for k in data_keys)
+    async with async_db_cursor(action, logger) as cursor:
+        yield (cursor, field_keys, value_keys)
 
 
 async def save_vote_to_db(data: dict) -> dict:

--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -187,7 +187,7 @@ async def add_first_text(
     # Store Conversations to redis/db/logs
     conversations.store_to_session()
     # Record for questions only dataset and stats on ppl abandoning before generation completion
-    record_conversations(conversations)
+    await record_conversations(conversations)
 
     # Stream responses
     async def event_stream() -> AsyncGenerator[str]:
@@ -208,7 +208,7 @@ async def add_first_text(
         conversations.is_streaming = False
         # After streaming completes, store Conversations to redis/db/logs
         conversations.store_to_session()
-        record_conversations(conversations)
+        await record_conversations(conversations)
 
     return create_sse_response(event_stream())
 
@@ -247,7 +247,7 @@ async def add_text(
     # Store Conversations to redis/db/logs
     conversations.store_to_session()
     # Record for questions only dataset and stats on ppl abandoning before generation completion
-    record_conversations(conversations)
+    await record_conversations(conversations)
 
     # Stream responses
     async def event_stream() -> AsyncGenerator[str]:
@@ -262,7 +262,7 @@ async def add_text(
         conversations.is_streaming = False
         # After streaming completes, store Conversations to redis/db/logs
         conversations.store_to_session()
-        record_conversations(conversations)
+        await record_conversations(conversations)
 
     return create_sse_response(event_stream())
 
@@ -364,7 +364,7 @@ async def retry(
     # Store Conversations to redis/db/logs
     conversations.store_to_session()
     # Record for questions only dataset and stats on ppl abandoning before generation completion
-    record_conversations(conversations)
+    await record_conversations(conversations)
 
     logger.info(
         f"retry with user message: {last_user_msg.content}", extra={"request": request}
@@ -383,7 +383,7 @@ async def retry(
         conversations.is_streaming = False
         # After streaming completes, store Conversations to redis/db/logs
         conversations.store_to_session()
-        record_conversations(conversations)
+        await record_conversations(conversations)
 
     return create_sse_response(event_stream())
 
@@ -445,7 +445,7 @@ async def react(
         # Store conversations with removed reaction
         conversations.store_to_session()
         # Delete db reaction
-        delete_reaction(conv, msg_index)
+        await delete_reaction(conv, msg_index)
 
         return {"reaction": None}
 
@@ -457,7 +457,7 @@ async def react(
     # Store conversations with updated reaction to redis
     conversations.store_to_session()
     # Store reaction to db/logs
-    reaction_record = record_reaction(
+    reaction_record = await record_reaction(
         conversations=conversations,
         reaction=reaction,
         msg_index=msg_index,
@@ -510,7 +510,7 @@ async def vote(
     conversations.store_to_session()
 
     # Save vote to database with prefs and comments
-    record_vote(
+    await record_vote(
         conversations=conversations,
         vote=vote_body,
         request=request,

--- a/backend/logger.py
+++ b/backend/logger.py
@@ -6,7 +6,7 @@ import sys
 from logging.handlers import WatchedFileHandler
 from typing import Any
 
-import psycopg2
+import psycopg
 from fastapi import Request
 from logging_loki import LokiHandler as BaseLokiHandler
 
@@ -20,7 +20,7 @@ class LokiHandler(BaseLokiHandler):
 
     def handleError(self, record: logging.LogRecord) -> None:
         pass
-from psycopg2 import sql
+from psycopg import sql
 from rich.logging import RichHandler
 
 from backend.config import settings
@@ -93,8 +93,8 @@ class PostgresHandler(logging.Handler):
         """Connect to PostgreSQL database, reconnecting if connection is closed."""
         if not self.connection or self.connection.closed:
             try:
-                self.connection = psycopg2.connect(self.dsn)
-            except psycopg2.Error as e:
+                self.connection = psycopg.connect(self.dsn)
+            except psycopg.Error as e:
                 print(f"Error connecting to database: {e}")
 
     def emit(self, record) -> None:
@@ -147,7 +147,7 @@ class PostgresHandler(logging.Handler):
 
                     cursor.execute(insert_statement, values)
                     self.connection.commit()
-        except psycopg2.Error as e:
+        except psycopg.Error as e:
             # Don't use logger on purpose to avoid endless loops
             print(f"Error logging to Postgres: {e}")
             # Could do:

--- a/backend/main.py
+++ b/backend/main.py
@@ -46,6 +46,6 @@ app.include_router(arena_router)
 @app.get("/counter")
 async def get_counter(country_portal: CountryPortalAnno):
     return {
-        "count": get_country_portal_count(country_portal),
+        "count": await get_country_portal_count(country_portal),
         "objective": OBJECTIVES[country_portal],
     }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -8,8 +10,17 @@ from backend.llms.router import router as models_router
 from backend.logger import configure_logger, configure_uvicorn_logging
 from backend.sentry import init_sentry
 from backend.utils.countries import CountryPortalAnno, get_country_portal_count
+from utils.storage.db import close_async_pool, open_async_pool
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await open_async_pool()
+    yield
+    await close_async_pool()
+
+
+app = FastAPI(lifespan=lifespan)
 
 logger = configure_logger()
 configure_uvicorn_logging()

--- a/backend/utils/countries.py
+++ b/backend/utils/countries.py
@@ -11,7 +11,7 @@ from backend.config import (
     settings,
 )
 from utils.ranking.compute import RankingResult
-from utils.storage.db import db_cursor
+from utils.storage.db import async_db_cursor
 from utils.storage.redis import (
     REDIS_RANKING_KEY,
     REDIS_VOTE_COUNT_KEY,
@@ -49,7 +49,7 @@ def country_portal_from_locale(locale: str = Header(..., alias="X-Locale")) -> s
 CountryPortalAnno = Annotated[CountryPortal, Depends(country_portal_from_locale)]
 
 
-def get_country_portal_count(country_code: CountryPortal, ttl: int = 120) -> int:
+async def get_country_portal_count(country_code: CountryPortal, ttl: int = 120) -> int:
     """
     Get the count of votes and reactions for conversations with a specific country portal.
 
@@ -60,7 +60,7 @@ def get_country_portal_count(country_code: CountryPortal, ttl: int = 120) -> int
     Returns:
         The count of votes and reactions for the specified country portal
     """
-    from psycopg2 import sql
+    from psycopg import sql
 
     cache_key = REDIS_VOTE_COUNT_KEY.format(country_code=country_code)
     # Try Redis first
@@ -79,8 +79,8 @@ def get_country_portal_count(country_code: CountryPortal, ttl: int = 120) -> int
         return 0
 
     # Count votes and reactions linked to conversations with country_portal
-    with db_cursor("get votes and reactions count", logger) as cursor:
-        cursor.execute(
+    async with async_db_cursor("get votes and reactions count", logger) as cursor:
+        await cursor.execute(
             sql.SQL("""
                 SELECT
                     (SELECT COUNT(*) FROM votes v
@@ -94,7 +94,7 @@ def get_country_portal_count(country_code: CountryPortal, ttl: int = 120) -> int
             (country_code, country_code),
         )
         # FIXME raise error if None?
-        res = cursor.fetchone()
+        res = await cursor.fetchone()
         result = res[0] if res and res[0] is not None else 0
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "sentry-sdk>=2.50.0",
     "uvicorn>=0.40.0",
     "altcha>=1.0.0",
+    "psycopg-pool>=3.2.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "markdown>=3.10.1",
     "numpy>=2.4.1",
     "prometheus-fastapi-instrumentator>=7.0.0",
-    "psycopg2-binary>=2.9.11",
+    "psycopg[binary]>=3.2.0",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.12.0",
     "python-logging-loki>=0.3.1",
@@ -30,7 +30,7 @@ data = [
     "duckdb>=1.1.0",
     "pandas>=3.0.0",
     "polars>=1.37.1",
-    "psycopg2-binary>=2.9.11",
+    "psycopg[binary]>=3.2.0",
     "pyarrow>=23.0.0",
     "sqlalchemy>=2.0.46",
     "huggingface_hub>=1.4",
@@ -44,7 +44,7 @@ dev = [
     "mypy>=1.19.1",
     "python-jenkins>=1.8.3",
     "types-markdown>=3.10.0.20251106",
-    "types-psycopg2>=2.9.21.20251012",
+    "psycopg[binary]>=3.2.0",
     "types-requests>=2.32.4.20260107",
 ]
 

--- a/utils/ranking/queries.py
+++ b/utils/ranking/queries.py
@@ -1,13 +1,6 @@
-"""
-Database queries for fetching vote and reaction data for ranking computation.
-
-Uses psycopg2 with RealDictCursor, matching the existing pattern
-from backend/arena/persistence.py and backend/utils/countries.py.
-"""
-
 import logging
 
-from psycopg2.extras import RealDictCursor
+from psycopg.rows import dict_row
 
 from utils.storage.db import db_cursor
 from utils.storage.queries import get_reactions_db_query, get_votes_db_query
@@ -27,7 +20,7 @@ def fetch_votes() -> list[dict]:
         conv_incorrect_a, conv_incorrect_b, conv_superficial_a, conv_superficial_b,
         conv_instructions_not_followed_a, conv_instructions_not_followed_b, country_portal.
     """
-    with db_cursor("get votes", logger, cursor_factory=RealDictCursor) as cursor:
+    with db_cursor("get votes", logger, cursor_factory=dict_row) as cursor:
         cursor.execute(
             get_votes_db_query(
                 columns={
@@ -69,7 +62,7 @@ def fetch_reactions() -> list[dict]:
         List of dicts with keys: model_a_name, model_b_name, refers_to_model,
         liked, disliked, country_portal.
     """
-    with db_cursor("get reactions", logger, cursor_factory=RealDictCursor) as cursor:
+    with db_cursor("get reactions", logger, cursor_factory=dict_row) as cursor:
         cursor.execute(
             get_reactions_db_query(
                 columns={

--- a/utils/storage/db.py
+++ b/utils/storage/db.py
@@ -3,8 +3,24 @@ from logging import Logger
 from typing import Any
 
 import psycopg
+from psycopg_pool import AsyncConnectionPool
 
 from backend.config import settings
+
+_async_pool: AsyncConnectionPool | None = None
+
+
+async def open_async_pool() -> None:
+    global _async_pool
+    _async_pool = AsyncConnectionPool(settings.COMPARIA_DB_URI, open=False)
+    await _async_pool.open()
+
+
+async def close_async_pool() -> None:
+    global _async_pool
+    if _async_pool is not None:
+        await _async_pool.close()
+        _async_pool = None
 
 
 @contextmanager
@@ -23,11 +39,13 @@ def db_cursor(action: str, logger: Logger, cursor_factory: Any = None) -> Any:
 
 @asynccontextmanager
 async def async_db_cursor(action: str, logger: Logger) -> Any:
-    """Async db cursor for FastAPI async endpoints."""
+    """Async db cursor using connection pool for FastAPI async endpoints."""
+    if _async_pool is None:
+        raise RuntimeError("Async connection pool is not initialized")
     try:
         logger.debug(f"[DB] Try to {action} data")
 
-        async with await psycopg.AsyncConnection.connect(settings.COMPARIA_DB_URI) as conn:
+        async with _async_pool.connection() as conn:
             async with conn.cursor() as cursor:
                 yield cursor
 

--- a/utils/storage/db.py
+++ b/utils/storage/db.py
@@ -1,24 +1,35 @@
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from logging import Logger
 from typing import Any
 
-import psycopg2
+import psycopg
 
 from backend.config import settings
 
 
 @contextmanager
 def db_cursor(action: str, logger: Logger, cursor_factory: Any = None) -> Any:
-    """
-    FIXME
-    """
+    """Sync db cursor for non-async contexts (ranking scripts, etc.)."""
     try:
         logger.debug(f"[DB] Try to {action} data")
 
-        with psycopg2.connect(settings.COMPARIA_DB_URI) as conn:
-            with conn.cursor(cursor_factory=cursor_factory) as cursor:
+        with psycopg.connect(settings.COMPARIA_DB_URI) as conn:
+            with conn.cursor(row_factory=cursor_factory) as cursor:
                 yield cursor
 
-    except psycopg2.Error as e:
+    except psycopg.Error as e:
         logger.error(f"[DB] Error couldn't {action} data: {e}", exc_info=True)
-        # FIXME Previous code never raise db error, raise it?
+
+
+@asynccontextmanager
+async def async_db_cursor(action: str, logger: Logger) -> Any:
+    """Async db cursor for FastAPI async endpoints."""
+    try:
+        logger.debug(f"[DB] Try to {action} data")
+
+        async with await psycopg.AsyncConnection.connect(settings.COMPARIA_DB_URI) as conn:
+            async with conn.cursor() as cursor:
+                yield cursor
+
+    except psycopg.Error as e:
+        logger.error(f"[DB] Error couldn't {action} data: {e}", exc_info=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1138,6 +1138,7 @@ dependencies = [
     { name = "numpy" },
     { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg", extra = ["binary"] },
+    { name = "psycopg-pool" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-logging-loki" },
@@ -1183,6 +1184,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
+    { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-logging-loki", specifier = ">=0.3.1" },
@@ -1833,6 +1835,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
     { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
     { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1137,7 +1137,7 @@ dependencies = [
     { name = "markdown" },
     { name = "numpy" },
     { name = "prometheus-fastapi-instrumentator" },
-    { name = "psycopg2-binary" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-logging-loki" },
@@ -1156,7 +1156,7 @@ data = [
     { name = "huggingface-hub" },
     { name = "pandas" },
     { name = "polars" },
-    { name = "psycopg2-binary" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pyarrow" },
     { name = "sqlalchemy" },
 ]
@@ -1165,9 +1165,9 @@ dev = [
     { name = "black" },
     { name = "isort" },
     { name = "mypy" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "python-jenkins" },
     { name = "types-markdown" },
-    { name = "types-psycopg2" },
     { name = "types-requests" },
 ]
 
@@ -1182,7 +1182,7 @@ requires-dist = [
     { name = "markdown", specifier = ">=3.10.1" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
-    { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-logging-loki", specifier = ">=0.3.1" },
@@ -1201,7 +1201,7 @@ data = [
     { name = "huggingface-hub", specifier = ">=1.4" },
     { name = "pandas", specifier = ">=3.0.0" },
     { name = "polars", specifier = ">=1.37.1" },
-    { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
 ]
@@ -1210,9 +1210,9 @@ dev = [
     { name = "black", specifier = ">=26.1.0" },
     { name = "isort", specifier = ">=7.0.0" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "python-jenkins", specifier = ">=1.8.3" },
     { name = "types-markdown", specifier = ">=3.10.0.20251106" },
-    { name = "types-psycopg2", specifier = ">=2.9.21.20251012" },
     { name = "types-requests", specifier = ">=2.32.4.20260107" },
 ]
 
@@ -1790,33 +1790,49 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2-binary"
-version = "2.9.11"
+name = "psycopg"
+version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/6c/8767aaa597ba424643dc87348c6f1754dd9f48e80fdc1b9f7ca5c3a7c213/psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c", size = 379620, upload-time = "2025-10-10T11:14:48.041Z" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/a8/a2709681b3ac11b0b1786def10006b8995125ba268c9a54bea6f5ae8bd3e/psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c", size = 3756572, upload-time = "2025-10-10T11:12:32.873Z" },
-    { url = "https://files.pythonhosted.org/packages/62/e1/c2b38d256d0dafd32713e9f31982a5b028f4a3651f446be70785f484f472/psycopg2_binary-2.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:366df99e710a2acd90efed3764bb1e28df6c675d33a7fb40df9b7281694432ee", size = 3864529, upload-time = "2025-10-10T11:12:36.791Z" },
-    { url = "https://files.pythonhosted.org/packages/11/32/b2ffe8f3853c181e88f0a157c5fb4e383102238d73c52ac6d93a5c8bffe6/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0", size = 4411242, upload-time = "2025-10-10T11:12:42.388Z" },
-    { url = "https://files.pythonhosted.org/packages/10/04/6ca7477e6160ae258dc96f67c371157776564679aefd247b66f4661501a2/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766", size = 4468258, upload-time = "2025-10-10T11:12:48.654Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/7e/6a1a38f86412df101435809f225d57c1a021307dd0689f7a5e7fe83588b1/psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3", size = 4166295, upload-time = "2025-10-10T11:12:52.525Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/7d/c07374c501b45f3579a9eb761cbf2604ddef3d96ad48679112c2c5aa9c25/psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f", size = 3983133, upload-time = "2025-10-30T02:55:24.329Z" },
-    { url = "https://files.pythonhosted.org/packages/82/56/993b7104cb8345ad7d4516538ccf8f0d0ac640b1ebd8c754a7b024e76878/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4", size = 3652383, upload-time = "2025-10-10T11:12:56.387Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ac/eaeb6029362fd8d454a27374d84c6866c82c33bfc24587b4face5a8e43ef/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c", size = 3298168, upload-time = "2025-10-10T11:13:00.403Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/39/50c3facc66bded9ada5cbc0de867499a703dc6bca6be03070b4e3b65da6c/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60", size = 3044712, upload-time = "2025-10-30T02:55:27.975Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8e/b7de019a1f562f72ada81081a12823d3c1590bedc48d7d2559410a2763fe/psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1", size = 3347549, upload-time = "2025-10-10T11:13:03.971Z" },
-    { url = "https://files.pythonhosted.org/packages/80/2d/1bb683f64737bbb1f86c82b7359db1eb2be4e2c0c13b947f80efefa7d3e5/psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa", size = 2714215, upload-time = "2025-10-10T11:13:07.14Z" },
-    { url = "https://files.pythonhosted.org/packages/64/12/93ef0098590cf51d9732b4f139533732565704f45bdc1ffa741b7c95fb54/psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1", size = 3756567, upload-time = "2025-10-10T11:13:11.885Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a9/9d55c614a891288f15ca4b5209b09f0f01e3124056924e17b81b9fa054cc/psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f", size = 3864755, upload-time = "2025-10-10T11:13:17.727Z" },
-    { url = "https://files.pythonhosted.org/packages/13/1e/98874ce72fd29cbde93209977b196a2edae03f8490d1bd8158e7f1daf3a0/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5", size = 4411646, upload-time = "2025-10-10T11:13:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/bd/a335ce6645334fb8d758cc358810defca14a1d19ffbc8a10bd38a2328565/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8", size = 4468701, upload-time = "2025-10-10T11:13:29.266Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d6/c8b4f53f34e295e45709b7568bf9b9407a612ea30387d35eb9fa84f269b4/psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c", size = 4166293, upload-time = "2025-10-10T11:13:33.336Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/e0/f8cc36eadd1b716ab36bb290618a3292e009867e5c97ce4aba908cb99644/psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f", size = 3983184, upload-time = "2025-10-30T02:55:32.483Z" },
-    { url = "https://files.pythonhosted.org/packages/53/3e/2a8fe18a4e61cfb3417da67b6318e12691772c0696d79434184a511906dc/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747", size = 3652650, upload-time = "2025-10-10T11:13:38.181Z" },
-    { url = "https://files.pythonhosted.org/packages/76/36/03801461b31b29fe58d228c24388f999fe814dfc302856e0d17f97d7c54d/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f", size = 3298663, upload-time = "2025-10-10T11:13:44.878Z" },
-    { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
-    { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
 ]
 
 [[package]]
@@ -2541,15 +2557,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/2e/35b30a09f6ee8a69142408d3ceb248c4454aa638c0a414d8704a3ef79563/types_markdown-3.10.2.20260211.tar.gz", hash = "sha256:66164310f88c11a58c6c706094c6f8c537c418e3525d33b76276a5fbd66b01ce", size = 19768, upload-time = "2026-02-11T04:19:29.497Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/c9/659fa2df04b232b0bfcd05d2418e683080e91ec68f636f3c0a5a267350e7/types_markdown-3.10.2.20260211-py3-none-any.whl", hash = "sha256:2d94d08587e3738203b3c4479c449845112b171abe8b5cadc9b0c12fcf3e99da", size = 25854, upload-time = "2026-02-11T04:19:28.647Z" },
-]
-
-[[package]]
-name = "types-psycopg2"
-version = "2.9.21.20260223"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/1f/4daff0ce5e8e191844e65aaa793ed1b9cb40027dc2700906ecf2b6bcc0ed/types_psycopg2-2.9.21.20260223.tar.gz", hash = "sha256:78ed70de2e56bc6b5c26c8c1da8e9af54e49fdc3c94d1504609f3519e2b84f02", size = 27090, upload-time = "2026-02-23T04:11:18.177Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/e7/c566df58410bc0728348b514e718f0b38fa0d248b5c10599a11494ba25d2/types_psycopg2-2.9.21.20260223-py3-none-any.whl", hash = "sha256:c6228ade72d813b0624f4c03feeb89471950ac27cd0506b5debed6f053086bc8", size = 24919, upload-time = "2026-02-23T04:11:17.214Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace psycopg2 with psycopg3 (`psycopg`) throughout the codebase
- All DB calls in FastAPI endpoints are now async (no more event loop blocking)
- Add `AsyncConnectionPool` via `psycopg-pool` to reuse connections across requests
- Pool lifecycle managed via FastAPI lifespan (open on startup, close on shutdown)
- Ranking scripts (`utils/ranking/`) keep a sync psycopg3 connection (separate process, no pool needed)
- Fix Loki handler to suppress emit errors gracefully in envs without Loki

## Changes

- `pyproject.toml`: replace `psycopg2-binary` with `psycopg[binary]>=3.2.0`, add `psycopg-pool>=3.2.0`
- `utils/storage/db.py`: add `AsyncConnectionPool`, `open_async_pool()`, `close_async_pool()`, update `async_db_cursor` to use pool
- `backend/main.py`: add lifespan to initialize/close the pool
- `backend/arena/persistence.py`: full async migration, use `async_db_cursor` from pool instead of direct connections
- `backend/arena/router.py`: await all persistence calls
- `backend/utils/countries.py`: make `get_country_portal_count` async, use `async_db_cursor`
- `backend/logger.py`: migrate `PostgresHandler` to psycopg3, add `LokiHandler` wrapper to silence emit errors
- `utils/ranking/queries.py`: replace `psycopg2.extras.RealDictCursor` with `psycopg.rows.dict_row`