### PR TITLE
chore: archive OLMo 3 32B Think model

### DIFF
--- a/utils/models/generated-models.json
+++ b/utils/models/generated-models.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1775660479.348297,
+  "timestamp": 1775666052.857101,
   "models": {
     "Apertus-70B-Instruct-2509": {
       "active_params": null,
@@ -3197,7 +3197,7 @@
       "reuse": true,
       "simple_name": "Olmo 3 32B Think",
       "specific_portals": null,
-      "status": "enabled",
+      "status": "archived",
       "url": "https://allenai.org/blog/olmo2-32b",
       "wh_per_million_token": 118.27374467771611
     },

--- a/utils/models/models.json
+++ b/utils/models/models.json
@@ -1959,6 +1959,7 @@
     "icon_path": "ai2.svg",
     "models": [
       {
+        "status": "archived",
         "id": "olmo-3-32b-think",
         "simple_name": "Olmo 3 32B Think",
         "license": "Apache 2.0",


### PR DESCRIPTION
## Summary

- Archive OLMo 3 32B Think model (no active endpoints on OpenRouter)

## Changes

- `utils/models/models.json`: Set status to archived
- `utils/models/generated-models.json`: Rebuild with archived status