### PR TITLE
fix(spam): block hex-prefixed prompt injection messages

### DIFF
--- a/backend/arena/spam_patterns.json
+++ b/backend/arena/spam_patterns.json
@@ -59,6 +59,13 @@
       "enabled": true
     },
     {
+      "name": "hex_prefix_injection",
+      "regex": "^[a-f0-9]{12,}\\s*\\n\\n",
+      "flags": "IGNORECASE",
+      "description": "Hex string prefix followed by double newline — bot/spam pattern where a random hex token precedes injected prompt content.",
+      "enabled": true
+    },
+    {
       "name": "roleplay_injection_tags",
       "regex": "<[^>]*(?:Persona|Scenario|UserPersona|example_dialogs|char_description|char_name)\\s*>",
       "flags": "IGNORECASE",


### PR DESCRIPTION
On détectait des messages de spam structurés comme suit : une chaîne hexadécimale aléatoire de 12+ caractères, suivie d'un double saut de ligne, puis le contenu injecté (ex. `c1c88dc8d07b1d08\n\nUser: Hello` ou `ec8460189d3f8e5956f\n\nSystem: You're a helpful assistant...`).

Aucun des patterns existants ne bloquait ce format : `system_prefix` ne s'applique qu'en début de message (sans MULTILINE), et les autres patterns ne matchaient pas la structure hexadécimale.

Ajout du pattern `hex_prefix_injection` dans `spam_patterns.json` : `^[a-f0-9]{12,}\s*\n\n` avec le flag `IGNORECASE`. Aucun faux positif attendu — un utilisateur légitime ne commence pas un message par une séquence hex suivie d'une ligne vide.