### PR TITLE
feat(comms): add model card visual generator

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Generated model card visuals
+/static/visuals/

--- a/frontend/scripts/generate-model-card.ts
+++ b/frontend/scripts/generate-model-card.ts
@@ -1,0 +1,149 @@
+/**
+ * Generate a social media visual (1080x1080 PNG) for a model card.
+ *
+ * This script is used for communication purposes: producing ready-to-post images
+ * when a new model is added to the catalog (social media, press, etc.).
+ *
+ * Usage:
+ *   npx tsx scripts/generate-model-card.ts <modelId> [--bg <color>] [--locale <code>]
+ *   npx tsx scripts/generate-model-card.ts glm-5.1
+ *   npx tsx scripts/generate-model-card.ts glm-5.1 --bg "#6A6AF4"
+ *   npx tsx scripts/generate-model-card.ts glm-5.1 --locale en
+ *   npx tsx scripts/generate-model-card.ts glm-5.1 --bg "#6A6AF4" --locale en
+ *
+ * Supported locales: da, en, fr, lt, sv (default: fr)
+ * Output: static/visuals/<modelId>-<locale>.png (omits locale suffix for fr)
+ *
+ * Prerequisites:
+ *   - playwright-core installed: npm install -D playwright-core
+ *   - the frontend dev server must be running: npm run dev
+ *
+ * If --bg is not specified, the script reads the model's organisation from the
+ * rendered page and picks a colour from the ORG_COLORS map below.
+ */
+
+import { chromium } from 'playwright-core'
+import path from 'node:path'
+import fs from 'node:fs'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const OUTPUT_DIR = path.resolve(import.meta.dirname, '..', 'static', 'visuals')
+const DEFAULT_LOCALE = 'fr'
+const SUPPORTED_LOCALES = ['da', 'en', 'fr', 'lt', 'sv']
+
+// Organisation → background color mapping
+// Palette derived from compar:IA UI colors and DSFR design tokens
+const ORG_COLORS: Record<string, string> = {
+  // French/EU ecosystem — compar:IA brand yellow
+  'Mistral AI': '#FFD500',
+  EuroLLM: '#FFD500',
+
+  // US big tech — blue-france / purple tones
+  OpenAI: '#6A6AF4',
+  Anthropic: '#D2956A',
+  Google: '#4285F4',
+  Microsoft: '#00A4EF',
+  xAI: '#1D1D1F',
+
+  // Open-source / research — greens & teals
+  Meta: '#0668E1',
+  'Swiss AI': '#E8423F',
+  Ai2: '#2FB572',
+  Nous: '#58B77D',
+  Nvidia: '#76B900',
+
+  // Asian labs — warm tones
+  Alibaba: '#FF6A00',
+  DeepSeek: '#4D6BFE',
+  Zhipu: '#4A6CF7',
+  'Moonshot AI': '#6C5CE7',
+  MiniMax: '#FF9575',
+  '01-ai': '#ED6C02',
+
+  // Others
+  Cohere: '#39594D',
+  AI21: '#9F5AE5',
+  Arcee: '#FF6B6B',
+  Liquid: '#00D2FF',
+  jpacifico: '#A96AFE',
+}
+
+const DEFAULT_COLOR = '#6A6AF4'
+
+function parseArgs(argv: string[]) {
+  const args = argv.slice(2)
+  let bg: string | undefined
+  let locale: string = DEFAULT_LOCALE
+  const modelIds: string[] = []
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--bg' && args[i + 1]) {
+      bg = args[++i]
+    } else if (args[i] === '--locale' && args[i + 1]) {
+      locale = args[++i]
+    } else if (!args[i].startsWith('--')) {
+      modelIds.push(args[i])
+    }
+  }
+
+  return { modelIds, bg, locale }
+}
+
+async function generateCard(modelId: string, locale: string, bgOverride?: string) {
+  if (!SUPPORTED_LOCALES.includes(locale)) {
+    console.error(`ERROR: Unsupported locale "${locale}". Supported: ${SUPPORTED_LOCALES.join(', ')}`)
+    process.exit(1)
+  }
+
+  const browser = await chromium.launch({ channel: 'chrome' })
+  const page = await browser.newPage({
+    viewport: { width: 1080, height: 1080 },
+    deviceScaleFactor: 2
+  })
+
+  const localeParam = `locale=${locale}`
+
+  let bg = bgOverride
+  if (!bg) {
+    await page.goto(`${BASE_URL}/card-preview/${modelId}?${localeParam}`, { waitUntil: 'networkidle' })
+    const orgText = await page
+      .locator('#card-preview .fr-card__title')
+      .innerText()
+      .catch(() => '')
+    const org = orgText.split('/')[0]?.trim()
+    bg = (org && ORG_COLORS[org]) || DEFAULT_COLOR
+  }
+
+  await page.goto(
+    `${BASE_URL}/card-preview/${modelId}?bg=${encodeURIComponent(bg)}&${localeParam}`,
+    { waitUntil: 'networkidle' }
+  )
+
+  const card = page.locator('#card-preview')
+  const visible = await card.isVisible().catch(() => false)
+
+  if (!visible) {
+    console.error(`ERROR: Model "${modelId}" not found or card did not render.`)
+    await browser.close()
+    process.exit(1)
+  }
+
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+
+  const suffix = locale === DEFAULT_LOCALE ? '' : `-${locale}`
+  const outputPath = path.join(OUTPUT_DIR, `${modelId}${suffix}.png`)
+  await card.screenshot({ path: outputPath })
+
+  console.log(`Generated: ${outputPath} (bg: ${bg}, locale: ${locale})`)
+  await browser.close()
+}
+
+const { modelIds, bg, locale } = parseArgs(process.argv)
+if (modelIds.length === 0) {
+  console.error('Usage: npx tsx scripts/generate-model-card.ts <modelId> [--bg <color>] [--locale <code>]')
+  process.exit(1)
+}
+
+for (const modelId of modelIds) {
+  await generateCard(modelId, locale, bg)
+}

--- a/frontend/src/routes/card-preview/[modelId]/+page.svelte
+++ b/frontend/src/routes/card-preview/[modelId]/+page.svelte
@@ -1,0 +1,55 @@
+<!--
+  Card preview route — used to generate social media visuals for model announcements.
+  Renders a single ModelCard at 1080x1080 with a configurable background color.
+
+  Query params:
+    bg     — background hex color (default: #FFD500)
+    locale — language code: da, en, fr, lt, sv (default: fr, handled by Paraglide middleware)
+
+  Example: /card-preview/glm-5.1?bg=%234A6CF7&locale=en
+
+  To generate a PNG, run: npx tsx scripts/generate-model-card.ts <modelId> [--bg <color>] [--locale <code>]
+-->
+<script lang="ts">
+  import ModelCard from '$components/ModelCard.svelte'
+  import { page } from '$app/state'
+  import { getModelsContext } from '$lib/models'
+
+  const { models } = getModelsContext()
+  const model = $derived(models.find((m) => m.id === page.params.modelId))
+  const bg = $derived(page.url.searchParams.get('bg') ?? '#FFD500')
+</script>
+
+<svelte:head>
+  <style>
+    /* Hide root layout extras */
+    #tooltips {
+      display: none;
+    }
+    html,
+    body {
+      min-height: auto !important;
+      background: transparent !important;
+    }
+  </style>
+</svelte:head>
+
+{#if model}
+  <div
+    id="card-preview"
+    class="flex items-center justify-center"
+    style="background-color: {bg}; width: 1080px; height: 1080px;"
+  >
+    <div class="origin-center scale-[2.2]">
+      <div
+        class="w-[340px] [&>.fr-card]:min-h-[380px] [&>.fr-card]:border-[--border-default-grey]! [&>.fr-card]:shadow-lg"
+      >
+        <ModelCard {model} onModelSelected={() => {}} modalId="preview-modal" />
+      </div>
+    </div>
+  </div>
+{:else}
+  <div class="flex items-center justify-center p-12 text-2xl text-red-600">
+    Model "{page.params.modelId}" not found
+  </div>
+{/if}


### PR DESCRIPTION
On produit des visuels pour les réseaux sociaux à chaque fois qu'on ajoute un modèle au catalogue, et le processus était manuel. Ce PR ajoute une route `/card-preview/[modelId]` qui affiche une carte modèle en 1080x1080 avec une couleur de fond configurable, et un script Playwright (`scripts/generate-model-card.ts`) qui en prend une capture d'écran dans `static/visuals/`. Le script prend en charge `--locale` pour nos cinq langues et choisit automatiquement une couleur de fond par organisation si aucune n'est précisée. Les PNG générés sont dans le `.gitignore`.

J'ouvre ça aussi pour en discuter : c'est un outil de communication, pas une fonctionnalité produit. Est-ce que c'est le bon endroit, ou est-ce que le script devrait plutôt vivre ailleurs (doc interne, gist, etc.) pour ne pas encombrer le repo de choses que les contributeurs externes n'ont pas besoin de voir ?