### PR TITLE
feat(arena): weight model selection toward under-voted models

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -34,6 +34,14 @@ class Settings(BaseSettings):
     HF_PUSH_DATASET_KEY_DA: str = ""
 
     RANKING_INTERVAL_SECONDS: int = 3600  # 1 hour
+
+    # Weighted model sampling: bias selection toward models with fewer votes
+    # so vote counts converge. Weight w_i = 1 / (n_match_i + smoothing)^alpha,
+    # clipped so max/min weight ratio <= max_ratio.
+    WEIGHTED_SAMPLING_ENABLED: bool = True
+    WEIGHTED_SAMPLING_ALPHA: float = 0.4
+    WEIGHTED_SAMPLING_SMOOTHING: int = 50
+    WEIGHTED_SAMPLING_MAX_RATIO: float = 3.0
     REPO_ORG: str = "ministere-culture"
     ALTCHA_HMAC_KEY: str = ""
 

--- a/backend/llms/data.py
+++ b/backend/llms/data.py
@@ -14,7 +14,12 @@ from backend.config import (
     SelectionMode,
 )
 from backend.llms.models import LLMDataArchived, LLMDataEnabled
+from backend.llms.weighting import compute_weights
+from backend.utils.countries import get_country_portal_ranking
+from utils.ranking.compute import RankingResult
 from utils.utils import LLMS_GENERATED_DATA_FILE
+
+_UNSET: Any = object()
 
 logger = logging.getLogger("languia")
 
@@ -24,6 +29,7 @@ class LLMsData(BaseModel):
         str,
         Annotated[LLMDataEnabled | LLMDataArchived, Field(discriminator="status")],
     ]
+    country_portal: CountryPortal
 
     @field_validator("all", mode="before")
     @classmethod
@@ -99,21 +105,18 @@ class LLMsData(BaseModel):
         """
         return [model.id for model in self.enabled.values() if model.pricey]
 
-    def pick_one(self, models: list[str], excluded: list[str] = []) -> str:
+    def pick_one(
+        self,
+        models: list[str],
+        excluded: list[str] = [],
+        ranking: RankingResult | None = _UNSET,
+    ) -> str:
         """
-        Randomly select a model from a list, excluding specified models.
-
-        Args:
-            models: List of available model names to choose from
-            excluded: List of model names to exclude from selection
-
-        Returns:
-            str: Selected model name
-
-        Raises:
-            Error: If no models are available after filtering
+        Randomly select a model, optionally weighted toward under-voted
+        models using n_match from the cached ranking data. Pass an
+        explicit `ranking` (including None) to skip the Redis lookup;
+        callers picking multiple models should fetch once and reuse.
         """
-        # Filter out excluded models
         models_pool = [_id for _id in models if _id not in excluded]
 
         logger.debug("chosing from:" + str(models_pool))
@@ -139,9 +142,21 @@ class LLMsData(BaseModel):
                 # FIXME hmm readding excluded models ?
                 models_pool = models
 
-        # Random selection from available models
-        picked_index = np.random.choice(len(models_pool), p=None)
-        return models_pool[picked_index]
+        if ranking is _UNSET:
+            ranking = get_country_portal_ranking(self.country_portal)
+
+        weights = compute_weights(models_pool, ranking)
+        picked_index = np.random.choice(len(models_pool), p=weights)
+        picked = models_pool[picked_index]
+        if weights is not None:
+            logger.debug(
+                "weighted_pick: model=%s weight=%.4f portal=%s pool_size=%d",
+                picked,
+                float(weights[picked_index]),
+                self.country_portal,
+                len(models_pool),
+            )
+        return picked
 
     def pick_two(
         self,
@@ -170,40 +185,50 @@ class LLMsData(BaseModel):
 
         # FIXME rework unavailable_models, models should be available if endpoint is defined or use class attribute to store unavailable models
 
+        ranking = get_country_portal_ranking(self.country_portal)
+
         if mode == "big-vs-small":
-            # Compare large models against small models
-            model_a_id = self.pick_one(self.big_models, excluded=unavailable_models)
-            model_b_id = self.pick_one(self.small_models, excluded=unavailable_models)
+            model_a_id = self.pick_one(
+                self.big_models, excluded=unavailable_models, ranking=ranking
+            )
+            model_b_id = self.pick_one(
+                self.small_models, excluded=unavailable_models, ranking=ranking
+            )
 
         elif mode == "small-models":
-            # Compare two small models
-            model_a_id = self.pick_one(self.small_models, excluded=unavailable_models)
+            model_a_id = self.pick_one(
+                self.small_models, excluded=unavailable_models, ranking=ranking
+            )
             model_b_id = self.pick_one(
-                self.small_models, excluded=[*unavailable_models, model_a_id]
+                self.small_models,
+                excluded=[*unavailable_models, model_a_id],
+                ranking=ranking,
             )
 
         elif mode == "custom" and custom_selection and len(custom_selection) > 0:
-            # User-selected models
             # FIXME: input sanitization needed
             # if any(mode[1], not in models):
             #     raise Exception(f"Model choice from value {str(model_dropdown_scoped)} not among possibilities")
 
             if len(custom_selection) == 1:
-                # One model chosen by user, pair with random model
                 model_a_id = custom_selection[0]
                 model_b_id = self.pick_one(
-                    self.random_models, excluded=[*unavailable_models, model_a_id]
+                    self.random_models,
+                    excluded=[*unavailable_models, model_a_id],
+                    ranking=ranking,
                 )
             elif len(custom_selection) == 2:
-                # Two models chosen by user
                 model_a_id = custom_selection[0]
                 model_b_id = custom_selection[1]
 
         else:
-            # Default to random mode
-            model_a_id = self.pick_one(self.random_models, excluded=unavailable_models)
+            model_a_id = self.pick_one(
+                self.random_models, excluded=unavailable_models, ranking=ranking
+            )
             model_b_id = self.pick_one(
-                self.random_models, excluded=[*unavailable_models, model_a_id]
+                self.random_models,
+                excluded=[*unavailable_models, model_a_id],
+                ranking=ranking,
             )
 
         # Randomly swap models to avoid position bias
@@ -222,5 +247,6 @@ def get_llms_data(country_portal: CountryPortal) -> LLMsData:
     data = json.loads(LLMS_GENERATED_DATA_FILE.read_text())
 
     return LLMsData.model_validate(
-        {"all": data["models"]}, context={"country_portal": country_portal}
+        {"all": data["models"], "country_portal": country_portal},
+        context={"country_portal": country_portal},
     )

--- a/backend/llms/tests/test_weighting.py
+++ b/backend/llms/tests/test_weighting.py
@@ -1,0 +1,89 @@
+"""
+Tests for weighted model sampling.
+
+Run with:
+    .venv/bin/python -m unittest backend.llms.tests.test_weighting
+"""
+
+import unittest
+from collections import Counter
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from backend.config import settings
+from backend.llms.weighting import compute_weights
+
+
+def _mock_ranking(counts: dict[str, int]):
+    rankings = {m: SimpleNamespace(n_match=n) for m, n in counts.items()}
+    return SimpleNamespace(rankings=rankings)
+
+
+class ComputeWeightsTest(unittest.TestCase):
+    def setUp(self):
+        self._prev_enabled = settings.WEIGHTED_SAMPLING_ENABLED
+        settings.WEIGHTED_SAMPLING_ENABLED = True
+
+    def tearDown(self):
+        settings.WEIGHTED_SAMPLING_ENABLED = self._prev_enabled
+
+    def test_under_voted_model_gets_higher_weight(self):
+        ranking = _mock_ranking({"new": 10, "mid": 500, "old": 5000})
+        w = compute_weights(["new", "mid", "old"], ranking)
+        assert w is not None
+        self.assertGreater(w[0], w[1])
+        self.assertGreater(w[1], w[2])
+        self.assertAlmostEqual(float(w.sum()), 1.0, places=9)
+
+    def test_max_ratio_clip_enforced(self):
+        ranking = _mock_ranking({"brand_new": 0, "ancient": 1_000_000})
+        w = compute_weights(["brand_new", "ancient"], ranking)
+        assert w is not None
+        self.assertLessEqual(
+            w.max() / w.min(), settings.WEIGHTED_SAMPLING_MAX_RATIO + 1e-9
+        )
+
+    def test_zero_vote_model_doesnt_blow_up(self):
+        ranking = _mock_ranking({"a": 0, "b": 0})
+        w = compute_weights(["a", "b"], ranking)
+        assert w is not None
+        self.assertTrue(np.isfinite(w).all())
+        self.assertAlmostEqual(float(w[0]), 0.5)
+        self.assertAlmostEqual(float(w[1]), 0.5)
+
+    def test_flag_off_returns_none(self):
+        settings.WEIGHTED_SAMPLING_ENABLED = False
+        self.assertIsNone(compute_weights(["a", "b"], _mock_ranking({"a": 10})))
+
+    def test_missing_ranking_returns_none(self):
+        self.assertIsNone(compute_weights(["a", "b"], None))
+
+    def test_model_missing_from_ranking_uses_zero_matches(self):
+        # A brand-new model won't be in the ranking yet; it should still
+        # get a weight (treated as 0 matches = highest weight).
+        ranking = _mock_ranking({"known": 1000})
+        w = compute_weights(["brand_new", "known"], ranking)
+        assert w is not None
+        self.assertGreater(w[0], w[1])
+
+
+class SamplingDistributionTest(unittest.TestCase):
+    def test_empirical_distribution_matches_weights(self):
+        ranking = _mock_ranking({"new": 10, "mid": 500, "old": 5000})
+        pool = ["new", "mid", "old"]
+        w = compute_weights(pool, ranking)
+
+        assert w is not None
+        rng = np.random.default_rng(42)
+        picks = Counter(pool[rng.choice(len(pool), p=w)] for _ in range(10_000))
+
+        for i, m in enumerate(pool):
+            empirical = picks[m] / 10_000
+            expected = float(w[i])
+            self.assertAlmostEqual(empirical, expected, delta=0.02)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/llms/weighting.py
+++ b/backend/llms/weighting.py
@@ -1,0 +1,63 @@
+"""
+Weighted sampling for model selection.
+
+Biases random model picking toward models with fewer recorded battles so
+vote counts converge across the catalog. Consumes per-model `n_match`
+already computed by the ranking pipeline (utils/ranking/compute.py) and
+cached in Redis under `rankings_and_prefs:{country_portal}`, so selection
+never hits the DB.
+
+Weight per model:
+    w_i = 1 / (n_match_i + smoothing) ** alpha
+
+then normalized and clipped so max/min weight ratio <= max_ratio.
+
+alpha = 0 gives uniform sampling. alpha ~ 0.4 gives a mild catch-up
+bias while keeping the sampling distribution close enough to uniform
+that Bradley-Terry / Elo computations downstream remain trustworthy.
+"""
+
+import numpy as np
+
+from backend.config import settings
+from utils.ranking.compute import RankingResult
+
+
+def compute_weights(
+    models_pool: list[str],
+    ranking: RankingResult | None,
+) -> np.ndarray | None:
+    """
+    Normalized sampling weights for `models_pool`, or None when
+    weighting is disabled / ranking data is unavailable (caller falls
+    back to uniform sampling).
+    """
+    if not settings.WEIGHTED_SAMPLING_ENABLED:
+        return None
+
+    if len(models_pool) <= 1 or ranking is None or not ranking.rankings:
+        return None
+
+    alpha = settings.WEIGHTED_SAMPLING_ALPHA
+    smoothing = settings.WEIGHTED_SAMPLING_SMOOTHING
+    max_ratio = settings.WEIGHTED_SAMPLING_MAX_RATIO
+
+    counts = np.array(
+        [
+            ranking.rankings[m].n_match if m in ranking.rankings else 0
+            for m in models_pool
+        ],
+        dtype=np.float64,
+    )
+
+    weights = 1.0 / np.power(counts + smoothing, alpha)
+
+    if max_ratio > 1.0:
+        w_min = weights.min()
+        weights = np.minimum(weights, w_min * max_ratio)
+
+    total = weights.sum()
+    if total <= 0 or not np.isfinite(total):
+        return None
+
+    return weights / total

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -1737,6 +1737,13 @@
                     "title": "Bias-forstærkende svar"
                 }
             },
+            "sampling": {
+                "desc": {
+                    "1": "For at hjælpe nye eller mindre evaluerede modeller med at indhente forspringet udvælges modelparrene med en <strong>let skævvridning til fordel for modeller, der har modtaget færre stemmer</strong>. Alle modeller kan stadig vælges i en hvilken som helst sammenligning – de mest populære modeller bliver blot lidt mindre sandsynlige end ved en rent tilfældig udvælgelse.",
+                    "2": "Konkret er hver models udvælgelsesvægt omvendt proportional med dens registrerede antal kampe (med en udjævning, så helt nye modeller ikke dominerer trækningen), og forholdet mellem to modellers vægte er begrænset til 3×. Denne skævvridning er lille nok til, at Bradley-Terry-rangeringen ovenfor forbliver statistisk pålidelig, samtidig med at stemmetallene kan konvergere over tid, så sammenligninger mellem modeller bygger på sammenlignelige stikprøvestørrelser."
+                },
+                "title": "Sådan udvælges modellerne til sammenligninger"
+            },
             "tabLabel": "Det oprindelige problem",
             "title": "Respekterer samtalebaserede AI-modeller <span {props}>mangfoldigheden</span> i de europæiske sprog?"
         },

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -1704,6 +1704,13 @@
                     "title": "Bias-reinforcing answers"
                 }
             },
+            "sampling": {
+                "desc": {
+                    "1": "To help newer or less-evaluated models catch up, model pairs are drawn with a <strong>mild bias toward models that have received fewer votes</strong>. Every model can still be picked in any matchup — popular models just become slightly less likely than they would be under pure uniform random selection.",
+                    "2": "Concretely, each model's selection weight is inversely proportional to its recorded match count (with smoothing so brand-new models don't dominate), and the ratio between any two models' weights is capped at 3×. This bias is small enough that the Bradley-Terry ranking above remains statistically reliable, while helping vote counts converge over time so comparisons between models are based on similar sample sizes."
+                },
+                "title": "How models are selected for matchups"
+            },
             "tabLabel": "The initial problem",
             "title": "Do conversational AI models respect the <span {props}>diversity</span> of European languages?"
         },

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1972,6 +1972,13 @@
                     "title": "Classement par taux de victoire"
                 }
             },
+            "sampling": {
+                "desc": {
+                    "1": "Pour aider les modèles récents ou peu évalués à rattraper leur retard, les paires de modèles sont tirées avec un <strong>léger biais en faveur des modèles ayant reçu moins de votes</strong>. Chaque modèle peut toujours être sélectionné dans n'importe quelle confrontation — les modèles les plus populaires deviennent simplement un peu moins probables qu'avec un tirage purement aléatoire.",
+                    "2": "Concrètement, le poids de sélection de chaque modèle est inversement proportionnel à son nombre de matchs enregistrés (avec un lissage pour éviter qu'un modèle tout nouveau ne domine le tirage), et le rapport entre les poids de deux modèles est plafonné à 3×. Ce biais reste assez faible pour que le classement Bradley-Terry ci-dessus demeure statistiquement fiable, tout en permettant aux volumes de votes de converger dans le temps afin que les comparaisons entre modèles reposent sur des tailles d'échantillon comparables."
+                },
+                "title": "Comment les modèles sont sélectionnés pour les confrontations"
+            },
             "tabLabel": "Méthodologie",
             "title": "Comment choisir la méthode de classement des modèles ?"
         },

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -1269,6 +1269,13 @@
                     "title": "Stereotypa svar"
                 }
             },
+            "sampling": {
+                "desc": {
+                    "1": "För att hjälpa nyare eller mindre utvärderade modeller att komma ikapp dras modellparen med en <strong>lätt snedvridning till förmån för modeller som har fått färre röster</strong>. Varje modell kan fortfarande väljas i vilken som helst jämförelse — de populäraste modellerna blir bara något mindre sannolika än vid en rent slumpmässig urval.",
+                    "2": "Konkret är varje modells urvalsvikt omvänt proportionell mot dess registrerade antal matcher (med en utjämning så att helt nya modeller inte dominerar dragningen), och förhållandet mellan två modellers vikter är begränsat till 3×. Denna snedvridning är tillräckligt liten för att Bradley-Terry-rankningen ovan ska förbli statistiskt tillförlitlig, samtidigt som röstantalen kan konvergera över tid så att jämförelser mellan modeller bygger på jämförbara stickprovsstorlekar."
+                },
+                "title": "Så väljs modellerna ut för jämförelser"
+            },
             "tabLabel": "Det inledande problemet",
             "title": "Respekterar konversationsbaserade AI-modeller <span {props}>mångfalden</span> av europeiska språk?"
         },

--- a/frontend/src/routes/(pages)/ranking/components/Methodology.svelte
+++ b/frontend/src/routes/(pages)/ranking/components/Methodology.svelte
@@ -179,4 +179,14 @@
       </div>
     </div>
   </section>
+
+  <section class="mt-16">
+    <h3 class="fr-h6 mb-4!">{m['ranking.methodo.sampling.title']()}</h3>
+    <p class="mb-3! text-dark-grey text-[14px]!">
+      {@html sanitize(m['ranking.methodo.sampling.desc.1']())}
+    </p>
+    <p class="text-dark-grey text-[14px]!">
+      {@html sanitize(m['ranking.methodo.sampling.desc.2']())}
+    </p>
+  </section>
 </div>


### PR DESCRIPTION
Leaderboard stats get unreliable when some models have 10k battles and others ~100. This tilts selection slightly toward under-voted models so vote counts converge and comparisons rest on similar sample sizes.

Selection uses `w_i = 1 / (n_match_i + smoothing)^alpha`, normalized, with the max/min weight ratio capped at 3x. `n_match` comes from the `RankingResult` already cached in Redis by the leaderboard pipeline, so no new DB load. `pick_two` fetches the ranking once per call and reuses it across both `pick_one` picks.

Defaults are `alpha=0.4`, `smoothing=50`, `max_ratio=3.0`, all tunable via `WEIGHTED_SAMPLING_*` settings, with an `ENABLED` kill-switch in case anything looks off in prod.

The Methodology tab on the ranking page has a short new section explaining the bias (fr/en/da/sv).

Draft for now, want to eyeball real staging numbers before marking ready. Plan:
- deploy to staging, check logs (`weighted_pick` at debug) for a day or two
- verify n_match spread starts narrowing across low-vote models
- then flip to ready

Tests: `backend/llms/tests/test_weighting.py` covers ordering, ratio clip, zero-vote smoothing, flag-off, and a Monte-Carlo distribution check. Run with `.venv/bin/python -m unittest backend.llms.tests.test_weighting`.