### PR TITLE
feat(spam): detect bot prompts prefixed with fake session IDs

### DIFF
--- a/backend/arena/spam_patterns.json
+++ b/backend/arena/spam_patterns.json
@@ -66,6 +66,13 @@
       "enabled": true
     },
     {
+      "name": "fake_session_id_prefix",
+      "regex": "^\\s*[\\[\\(]\\s*(?:session\\s+)?[a-z]{2,10}[-_][0-9a-f]{6,}\\s*[\\]\\)]\\s*(?:User|Q|Assistant|System)\\s*:",
+      "flags": "IGNORECASE|MULTILINE",
+      "description": "Bot-generated prompts prefixed with fake session/trace IDs like '[trace-01598e97...] User: hi' or '(session ref-f7b8a24f...) Q: say OK'. Legitimate users don't prefix messages with hex session IDs.",
+      "enabled": true
+    },
+    {
       "name": "roleplay_injection_tags",
       "regex": "<[^>]*(?:Persona|Scenario|UserPersona|example_dialogs|char_description|char_name)\\s*>",
       "flags": "IGNORECASE",


### PR DESCRIPTION
New wave of spam votes uses prompts like `[trace-01598e97...] User: hi` or `(session sid-8cafb533...) Q: say OK`, a bracketed fake session ID followed by a self-applied role tag. Legitimate users never write that.

Adds one regex to spam_patterns.json matching `[word-hex]` / `(session word-hex)` (word is 2-10 lowercase letters, hex 6+ chars) followed by `User:`, `Q:`, `Assistant:`, or `System:`. Generalized the prefix word so we don't have to update the rule each time the spammer rotates between `trace`, `sid`, `req`, `ctx`, etc.

Verified against 15 recent spam samples (all match) and realistic legit inputs like `[TODO] fix this` or `[ref-12345] Paper: ...` (none match).