### PR TITLE
chore(duel): update kit facilitateur form link

### DIFF
--- a/frontend/src/routes/(pages)/duel/+page.svelte
+++ b/frontend/src/routes/(pages)/duel/+page.svelte
@@ -94,7 +94,7 @@
 
           <Link
             button
-            href="https://comparia.getgrist.com/forms/h2i36mSYhJsAyb5r4Bee5c/29"
+            href="https://formulaire.beta.numerique.gouv.fr/duels-de-l-ia"
             text="Recevoir le kit facilitateur"
             size="lg"
             class="w-full!"
@@ -202,7 +202,7 @@
 
           <Link
             button
-            href="https://comparia.getgrist.com/forms/h2i36mSYhJsAyb5r4Bee5c/29"
+            href="https://formulaire.beta.numerique.gouv.fr/duels-de-l-ia"
             text="Recevoir le kit facilitateur"
             size="lg"
           />


### PR DESCRIPTION
## Summary
- Replace the Grist form link on the `/duel` page with `https://formulaire.beta.numerique.gouv.fr/duels-de-l-ia` for both "Recevoir le kit facilitateur" CTAs.

## Test plan
- [ ] Visit `/duel` and click both "Recevoir le kit facilitateur" buttons; verify they open the new form URL.