### PR TITLE
Require shared Altcha HMAC key in prod, fail closed on Redis errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,12 @@ export HF_PUSH_DATASET_KEY_DA=""
 # CACHE_PROBABILITY=0.5        # 0.0-1.0: chance of serving cached response on hit
 # CACHE_TTL=172800              # Cache lifetime in seconds (default 48h)
 # CACHE_MAX_RESPONSES=5         # Max cached responses per (model, prompt) pair
-# Altcha CAPTCHA HMAC key (auto-generated if empty, set explicitly in production)
+# Altcha CAPTCHA HMAC key — REQUIRED in non-debug mode, must be the same across
+# all workers/pods. Only auto-generated when LANGUIA_DEBUG=true.
 # ALTCHA_HMAC_KEY=""
+# When Redis is unreachable, replay protection is skipped if this is true.
+# Default false (fail closed). Only enable as a deliberate degraded-mode fallback.
+# ALTCHA_FAIL_OPEN_ON_REDIS_ERROR=false
 
 export SENTRY_SAMPLE_RATE="1.0"
 export SENTRY_ENV="dev"

--- a/backend/arena/captcha.py
+++ b/backend/arena/captcha.py
@@ -70,7 +70,8 @@ def verify_altcha_token(payload: str) -> tuple[bool, str | None]:
             logger.warning("Altcha replay detected")
             return False, "Challenge already used"
     except Exception as e:
-        # If Redis is down, allow the request (fail open) but log it
         logger.error(f"Altcha replay check failed (Redis error): {e}")
+        if not settings.ALTCHA_FAIL_OPEN_ON_REDIS_ERROR:
+            return False, "Replay check unavailable"
 
     return True, None

--- a/backend/config.py
+++ b/backend/config.py
@@ -36,6 +36,10 @@ class Settings(BaseSettings):
     RANKING_INTERVAL_SECONDS: int = 3600  # 1 hour
     REPO_ORG: str = "ministere-culture"
     ALTCHA_HMAC_KEY: str = ""
+    # When Redis is unreachable, replay protection cannot be enforced.
+    # Default: fail closed (reject the request). Set to True only as a
+    # deliberate degraded-mode fallback.
+    ALTCHA_FAIL_OPEN_ON_REDIS_ERROR: bool = False
 
 # Response caching
     CACHE_ENABLED: bool = False
@@ -46,11 +50,23 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-# Generate a random HMAC key if not configured (dev mode)
+# In production, ALTCHA_HMAC_KEY must be set: every worker/pod needs the same
+# value so a challenge issued by one process verifies on another. Falling back
+# to a random key only makes sense in dev (single process, restart-friendly).
 if not settings.ALTCHA_HMAC_KEY:
+    if not settings.LANGUIA_DEBUG:
+        raise RuntimeError(
+            "ALTCHA_HMAC_KEY is required in non-debug mode. "
+            "Set it in the environment so all workers share the same key."
+        )
     import secrets
 
     settings.ALTCHA_HMAC_KEY = secrets.token_hex(32)
+    import logging
+
+    logging.getLogger("languia").warning(
+        "ALTCHA_HMAC_KEY not set; generated an ephemeral key (dev mode only)."
+    )
 
 # Create directory for JSON backup files
 os.makedirs(settings.LOGDIR, exist_ok=True)


### PR DESCRIPTION
## Why

Two things bothered me while looking at the Altcha code path:

1. If `ALTCHA_HMAC_KEY` is unset, each backend process generates its own random key. In any multi-worker / multi-pod setup that means a challenge issued by one process can fail verification on another, and every restart silently invalidates pending challenges. Right now this fails open in a confusing way.
2. When Redis is unreachable, the replay check is skipped and verification still returns success. So a captured Altcha payload remains replayable for the rest of the challenge expiry window — exactly the protection we lose under the conditions where we'd most want it.

## What

- `backend/config.py`: refuse to start in non-debug mode when `ALTCHA_HMAC_KEY` is empty. Dev still gets the auto-generated key, with a warning so it's obvious it's ephemeral.
- `backend/arena/captcha.py`: when the Redis call raises, return `(False, "Replay check unavailable")` instead of allowing the request through. Old fail-open behavior is still available behind a new env flag (`ALTCHA_FAIL_OPEN_ON_REDIS_ERROR`) for deliberate degraded-mode operation.
- `.env.example`: documents both flags.

## Test plan

- [x] Boot with `LANGUIA_DEBUG=false ALTCHA_HMAC_KEY=""` → raises (verified)
- [x] Boot with `LANGUIA_DEBUG=true ALTCHA_HMAC_KEY=""` → ephemeral key + warning (verified)
- [x] Verify with mocked Redis: error + default → reject; error + opt-in flag → accept; healthy + first use → accept; healthy + replay → reject (all verified)
- [ ] Sanity check on staging that prod-like deploy still boots with the key set