### PR TITLE
Refresh Altcha token before it expires

### DIFF
--- a/frontend/src/lib/captcha.svelte.ts
+++ b/frontend/src/lib/captcha.svelte.ts
@@ -16,26 +16,48 @@ interface AltchaChallenge {
   signature: string
 }
 
+// Server expiry is 600s. Refresh comfortably before that.
+const TOKEN_STALE_AFTER_MS = 8 * 60 * 1000
+
+export class CaptchaError extends Error {
+  constructor(message: string, public cause?: unknown) {
+    super(message)
+    this.name = 'CaptchaError'
+  }
+}
+
 let altchaToken = $state<string | null>(null)
-let solving = $state(false)
+let tokenCreatedAt = 0
+let inflight: Promise<void> | null = null
+
+function isStale(): boolean {
+  return !altchaToken || Date.now() - tokenCreatedAt > TOKEN_STALE_AFTER_MS
+}
 
 export function getAltchaToken(): string | null {
   return altchaToken
 }
 
 /**
- * Consume the current token and start solving a new one.
+ * Return a fresh token and start solving the next one.
+ * Throws CaptchaError if no token can be produced — callers should surface
+ * this to the user rather than POST a null token to the backend.
  */
-export function consumeAltchaToken(): string | null {
+export async function consumeAltchaToken(): Promise<string> {
+  if (isStale()) {
+    await fetchAndSolve()
+  }
   const token = altchaToken
+  if (!token) {
+    throw new CaptchaError('Captcha token unavailable')
+  }
   altchaToken = null
-  fetchAndSolve()
+  tokenCreatedAt = 0
+  // Start the next solve so the following request is instant.
+  void fetchAndSolveSilently()
   return token
 }
 
-/**
- * Solve a SHA-256 proof-of-work challenge using Web Crypto API.
- */
 async function solveChallenge(
   challenge: string,
   salt: string,
@@ -53,23 +75,27 @@ async function solveChallenge(
 }
 
 /**
- * Fetch a challenge from the backend and solve it.
+ * Fetch a challenge and solve it. Concurrent calls share the in-flight promise.
+ * Rejects on network or solve failure — callers that want fire-and-forget
+ * behaviour should use fetchAndSolveSilently().
  */
-export async function fetchAndSolve(): Promise<void> {
-  if (!browser || solving || altchaToken) return
+export function fetchAndSolve(): Promise<void> {
+  if (!browser) return Promise.resolve()
+  if (inflight) return inflight
+  if (altchaToken && !isStale()) return Promise.resolve()
 
-  solving = true
-  try {
-    const challenge = await api.request<AltchaChallenge>('/arena/challenge')
-
-    const number = await solveChallenge(
-      challenge.challenge,
-      challenge.salt,
-      challenge.algorithm,
-      challenge.maxNumber
-    )
-
-    if (number !== null) {
+  inflight = (async () => {
+    try {
+      const challenge = await api.request<AltchaChallenge>('/arena/challenge')
+      const number = await solveChallenge(
+        challenge.challenge,
+        challenge.salt,
+        challenge.algorithm,
+        challenge.maxNumber
+      )
+      if (number === null) {
+        throw new CaptchaError('Failed to solve challenge within maxNumber range')
+      }
       const payload = {
         algorithm: challenge.algorithm,
         challenge: challenge.challenge,
@@ -78,13 +104,29 @@ export async function fetchAndSolve(): Promise<void> {
         signature: challenge.signature
       }
       altchaToken = btoa(JSON.stringify(payload))
+      tokenCreatedAt = Date.now()
       console.debug('[ALTCHA] Challenge solved')
-    } else {
-      console.error('[ALTCHA] Failed to solve challenge')
+    } finally {
+      inflight = null
     }
-  } catch (error) {
-    console.error('[ALTCHA] Error:', error)
-  } finally {
-    solving = false
-  }
+  })()
+
+  return inflight
+}
+
+/**
+ * Background variant for page-load and visibility refresh: never throws.
+ */
+export function fetchAndSolveSilently(): Promise<void> {
+  return fetchAndSolve().catch((error) => {
+    console.error('[ALTCHA] Background solve failed:', error)
+  })
+}
+
+if (browser) {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && isStale()) {
+      void fetchAndSolveSilently()
+    }
+  })
 }

--- a/frontend/src/lib/captcha.svelte.ts
+++ b/frontend/src/lib/captcha.svelte.ts
@@ -86,7 +86,12 @@ export function fetchAndSolve(): Promise<void> {
 
   inflight = (async () => {
     try {
-      const challenge = await api.request<AltchaChallenge>('/arena/challenge')
+      let challenge: AltchaChallenge
+      try {
+        challenge = await api.request<AltchaChallenge>('/arena/challenge')
+      } catch (err) {
+        throw new CaptchaError('Failed to fetch captcha challenge', err)
+      }
       const number = await solveChallenge(
         challenge.challenge,
         challenge.salt,

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -1,4 +1,4 @@
-import { consumeAltchaToken } from '$lib/captcha.svelte'
+import { CaptchaError, consumeAltchaToken } from '$lib/captcha.svelte'
 import { api, ValidationError } from '$lib/fastapi-client'
 import { m } from '$lib/i18n/messages'
 import type { APIBotModel, BotModel } from '$lib/models'
@@ -283,7 +283,9 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
 
     let receivedEvent = false
     try {
-      for await (const event of api.stream(url, body)) {
+      const altcha_token = await consumeAltchaToken()
+
+      for await (const event of api.stream(url, { ...body, altcha_token })) {
         receivedEvent = true
         if (event.type === 'init') {
           const id = event.comparison.id.toString()
@@ -327,6 +329,8 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
     } catch (err) {
       if (err instanceof ValidationError) {
         promptError = err.message in ERROR_MESSAGES ? m[ERROR_MESSAGES[err.message]]() : err.message
+      } else if (err instanceof CaptchaError) {
+        promptError = 'Vérification anti-robot indisponible, veuillez réessayer.'
       } else {
         throw err
       }
@@ -370,17 +374,13 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
         mode: args.mode,
         custom_models_selection: args.mode === 'custom' ? args.custom_models_selection : null,
         web_search: args.web_search,
-        cohorts,
-        altcha_token: consumeAltchaToken()
+        cohorts
       })
     },
 
     async ask(text: string) {
       if (!comparison?.turns.every((turn) => !!turn.choice)) return
-      return await ask('/arena/add_text', {
-        message: text,
-        altcha_token: consumeAltchaToken()
-      })
+      return await ask('/arena/add_text', { message: text })
     },
 
     async retry() {

--- a/frontend/src/routes/arene/+page.svelte
+++ b/frontend/src/routes/arene/+page.svelte
@@ -2,7 +2,7 @@
   import { Link } from '$components/dsfr'
   import Header from '$components/header/Header.svelte'
   import SeoHead from '$components/SEOHead.svelte'
-  import { fetchAndSolve } from '$lib/captcha.svelte'
+  import { fetchAndSolveSilently } from '$lib/captcha.svelte'
   import { getComparison, initComparisonsContext } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
   import { TOSModal, ViewChat, ViewPrompt } from './components'
@@ -10,7 +10,7 @@
   // TODO query user comparisons
   initComparisonsContext([])
   // Start solving Altcha challenge on page load (runs in background)
-  fetchAndSolve()
+  fetchAndSolveSilently()
 
   const comparator = getComparison(undefined)
   const showInitialPrompt = $derived(!comparator.comparisonId)


### PR DESCRIPTION
## Why

Users were getting `Vérification anti-robot échouée : Altcha payload expired` when they came back to the tab after a while or hit send right after a long generation. The token was solved once on page load and reused, so anything past the 10 min server expiry blew up. Server expiry shouldn't be loosened (it's there on purpose), so the fix is on the client.

## What

- Track when the cached token was solved. On consume, if it's older than 8 min, throw it away and solve a fresh one before returning. PoW is ~0.5 s so the user doesn't notice.
- Refresh on `visibilitychange` when the tab regains focus and the cached token is stale — covers \"back from inactivity\".
- Dedupe concurrent solves via a shared in-flight promise.
- Make `consumeAltchaToken` async and have it throw `CaptchaError` on failure instead of silently returning `null` (which used to surface as the same generic backend error). `chatService` catches that and sets `arena.chat.error` with a clear message.
- Page-load and visibility refreshes use `fetchAndSolveSilently` so they don't crash the page if the captcha endpoint is briefly down.

Security stays the same: PoW still required, server still enforces `check_expires`, replay protection unchanged, HMAC key never leaves the server.

## Test plan

- [x] Logic test: page-load solve, fresh consume, stale consume forces re-solve, concurrent calls dedupe (verified via Playwright with a mocked challenge endpoint)
- [x] Logic test: network failure → `CaptchaError`, solve failure → `CaptchaError`, recovery still works
- [x] `svelte-check` passes on the touched files
- [ ] Manual: open arena, leave the tab >10 min, send a message — should not show the expired-payload error
- [ ] Manual: long generation, then send a follow-up — should not show the expired-payload error
- [ ] Manual: kill the captcha endpoint mid-session, send a message — should show the new client-side error message instead of the generic one