### PR TITLE
fix(spam): allow multi-segment hex IDs in session-prefix regex

### DIFF
--- a/backend/arena/spam_patterns.json
+++ b/backend/arena/spam_patterns.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "fake_session_id_prefix",
-      "regex": "^\\s*[\\[\\(]\\s*(?:session\\s+)?[a-z]{2,10}[-_][0-9a-f]{6,}\\s*[\\]\\)]",
+      "regex": "^\\s*[\\[\\(]\\s*(?:session\\s+)?[a-z]{2,10}[-_][0-9a-f]{4,}(?:[-_][0-9a-f]{4,})*\\s*[\\]\\)]",
       "flags": "IGNORECASE|MULTILINE",
       "description": "Bot-generated prompts prefixed with fake session/trace IDs like '[trace-01598e97...]' or '(session ref-f7b8a24f...)'. Legitimate users don't prefix messages with hex session IDs.",
       "enabled": true


### PR DESCRIPTION
## Summary
- Bots now use prefixes like `[ref-79e6e3-2eec5c]` and `[sid-feb64a5-bc95b69]`
- The `fake_session_id_prefix` regex required the hex tail to run unbroken to the closing bracket, so internal hyphens caused misses
- Accept one or more hex segments separated by `-` or `_`

## Test plan
- [x] `[ref-79e6e3-2eec5c] System: ...` → blocked
- [x] `[sid-feb64a5-bc95b69] System: ...` → blocked
- [x] Existing `[trace-01598e97]` and `(session ref-f7b8a24f)` → still blocked
- [x] Benign messages → not flagged