### PR TITLE
fix(ranking): raise trust_range display threshold from 10 to 30

### DIFF
--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -173,7 +173,7 @@ export function getModelsWithDataContext() {
       models.filter((m) => {
         if (m.data == null) return false
         if (m.prefs == null) return false
-        if (m.data.trust_range[0] > 10 || m.data.trust_range[1] > 10) return false
+        if (m.data.trust_range[0] > 30 || m.data.trust_range[1] > 30) return false
         return true
       }) as BotModelWithData[]
     )


### PR DESCRIPTION
## Summary

- Raises the `trust_range` filter threshold in the ranking page from 10 to 30
- The previous threshold was calibrated for a smaller model pool (~30-50 models)
- With ~119 models in the current pool, rank confidence intervals are more compressed and most well-established models were incorrectly hidden
- Models with trust_range > 30 on either side (typically fewer than ~80 votes) remain filtered

## Changes

- `frontend/src/lib/models.ts`: change threshold from 10 to 30 in `getModelsWithDataContext`