### PR TITLE
fix(ranking): handle degenerate models in Bradley-Terry bootstrap

### DIFF
--- a/utils/ranking/bradley_terry.py
+++ b/utils/ranking/bradley_terry.py
@@ -33,15 +33,27 @@ def _fit_from_arrays(
     """
     Core MM solver on pre-indexed arrays. Returns Elo ratings.
 
+    Models that are absent, undefeated, or winless return NaN, so callers
+    (especially the bootstrap) can ignore them rather than treating their
+    rating as a wildly negative outlier.
+
     Wins are constant across iterations so we compute them once.
     Uses np.bincount (histogram) instead of np.add.at (scatter-add) for speed.
     """
     wins = np.bincount(ia, weights=winner_is_a, minlength=n) + np.bincount(
         ib, weights=~winner_is_a, minlength=n
     )
+    appearances = np.bincount(ia, minlength=n) + np.bincount(ib, minlength=n)
+    # MLE is degenerate (±infinity) for models that never won or never lost,
+    # so exclude them from this fit instead of letting the solver clamp them
+    # to wild outliers that wreck the bootstrap percentiles.
+    present = (appearances > 0) & (wins > 0) & (wins < appearances)
+
+    if not present.any():
+        return np.full(n, np.nan)
 
     p = np.ones(n)
-    log_p = np.zeros(n)  # log(p), starts at log(1) = 0
+    log_p = np.zeros(n)
 
     for _ in range(max_iter):
         inv_psum = 1.0 / (p[ia] + p[ib])
@@ -51,18 +63,19 @@ def _fit_from_arrays(
 
         p = wins / np.maximum(denom, 1e-12)
 
-        # Normalize so geometric mean = 1, and track log(p) for convergence
-        log_p_new = np.log(np.maximum(p, 1e-12))
-        log_p_new -= log_p_new.mean()
-        p = np.exp(log_p_new)
+        # Normalize over present models only so absent ones don't skew the mean
+        log_p_new = np.zeros(n)
+        log_p_new[present] = np.log(np.maximum(p[present], 1e-12))
+        log_p_new[present] -= log_p_new[present].mean()
+        p = np.where(present, np.exp(log_p_new), 1.0)
 
-        # Convergence: max change in log-strengths
-        if np.max(np.abs(log_p_new - log_p)) < tol:
+        if np.max(np.abs(log_p_new[present] - log_p[present])) < tol:
             break
         log_p = log_p_new
 
-    # Convert to Elo scale: Elo = 400 * log10(p) + 1000
-    return 400.0 * np.log10(np.maximum(p, 1e-12)) + 1000.0
+    elo = 400.0 * np.log10(np.maximum(p, 1e-12)) + 1000.0
+    elo[~present] = np.nan
+    return elo
 
 
 def fit_bradley_terry(
@@ -92,19 +105,26 @@ def fit_bradley_terry(
 
 def bootstrap_confidence_intervals(
     battles: list[tuple[str, str, str]],
-    n_samples: int = 100,
+    n_samples: int = 500,
 ) -> dict[str, tuple[float, float, float]]:
     """
-    Compute bootstrap confidence intervals for Bradley-Terry ratings.
+    Compute Bradley-Terry ratings with bootstrap confidence intervals.
 
-    Pre-indexes battles once, then resamples index arrays only.
+    The displayed Elo is the point estimate from a single fit on the full
+    data, not the bootstrap median; the two can drift apart when the
+    bootstrap distribution is skewed (e.g. for sparsely-observed models).
+    The bootstrap is used only for the CI bounds.
+
+    Bootstrap rounds where a model has no battles, never won, or never lost
+    return NaN for that model and are excluded from its percentile, instead
+    of being pinned to a huge negative outlier.
 
     Args:
         battles: List of (model_a, model_b, winner) tuples.
         n_samples: Number of bootstrap samples.
 
     Returns:
-        Dict mapping model name to (median_rating, lower_2.5, upper_97.5).
+        Dict mapping model name to (point_rating, lower_2.5, upper_97.5).
     """
     if not battles:
         return {}
@@ -113,6 +133,8 @@ def bootstrap_confidence_intervals(
     n_models = len(models)
     n_battles = len(battles)
 
+    point_elo = _fit_from_arrays(ia, ib, winner_is_a, n_models)
+
     all_elos = np.empty((n_samples, n_models))
     rng = np.random.default_rng()
 
@@ -120,11 +142,10 @@ def bootstrap_confidence_intervals(
         idx = rng.integers(0, n_battles, size=n_battles)
         all_elos[s] = _fit_from_arrays(ia[idx], ib[idx], winner_is_a[idx], n_models)
 
-    medians = np.median(all_elos, axis=0)
-    lowers = np.percentile(all_elos, 2.5, axis=0)
-    uppers = np.percentile(all_elos, 97.5, axis=0)
+    lowers = np.nanpercentile(all_elos, 2.5, axis=0)
+    uppers = np.nanpercentile(all_elos, 97.5, axis=0)
 
     return {
-        models[i]: (float(medians[i]), float(lowers[i]), float(uppers[i]))
+        models[i]: (float(point_elo[i]), float(lowers[i]), float(uppers[i]))
         for i in range(n_models)
     }

--- a/utils/ranking/compute.py
+++ b/utils/ranking/compute.py
@@ -131,8 +131,8 @@ def _compute_rankings_for_group(
     if not all_battles:
         return RankingResult(timestamp=time.time())
 
-    # Bootstrap gives (median, lower_2.5, upper_97.5) per model
-    ci = bootstrap_confidence_intervals(all_battles, n_samples=100)
+    # (point_estimate, lower_2.5, upper_97.5) per model
+    ci = bootstrap_confidence_intervals(all_battles)
 
     # Count matches and wins per model
     match_counts: dict[str, int] = defaultdict(int)
@@ -142,13 +142,13 @@ def _compute_rankings_for_group(
         match_counts[b] += 1
         win_counts[winner] += 1
 
-    # Sort by bootstrap median Elo descending
+    # Sort by point-estimate Elo descending
     sorted_models = sorted(ci, key=lambda m: -ci[m][0])
     n_total = len(sorted_models)
 
     rankings: dict[str, DatasetData] = {}
     for rank, model in enumerate(sorted_models, 1):
-        elo_median, elo_lower, elo_upper = ci[model]
+        elo_point, elo_lower, elo_upper = ci[model]
         n_match = match_counts.get(model, 0)
         wins = win_counts.get(model, 0)
 
@@ -166,7 +166,7 @@ def _compute_rankings_for_group(
                 rank_worst -= 1
 
         # Mean win probability: P(i beats j) = s_i / (s_i + s_j), averaged
-        strength_i = 10 ** ((elo_median - 1000) / 400)
+        strength_i = 10 ** ((elo_point - 1000) / 400)
         win_probs = []
         for other in sorted_models:
             if other == model:
@@ -176,7 +176,7 @@ def _compute_rankings_for_group(
         mean_win_prob = sum(win_probs) / len(win_probs) if win_probs else 0.5
 
         rankings[model] = DatasetData(
-            elo=round(elo_median),
+            elo=round(elo_point),
             score_p2_5=round(elo_lower),
             score_p97_5=round(elo_upper),
             rank=rank,

--- a/utils/ranking/compute.py
+++ b/utils/ranking/compute.py
@@ -7,6 +7,7 @@ and PreferencesData shapes from backend/llms/models.py.
 """
 
 import logging
+import math
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -141,6 +142,9 @@ def _compute_rankings_for_group(
         match_counts[a] += 1
         match_counts[b] += 1
         win_counts[winner] += 1
+
+    # Drop degenerate models (never won or never lost in the full data)
+    ci = {m: v for m, v in ci.items() if not any(math.isnan(x) for x in v)}
 
     # Sort by point-estimate Elo descending
     sorted_models = sorted(ci, key=lambda m: -ci[m][0])


### PR DESCRIPTION
The bootstrap CI on the ranking page produced absurdly wide bars (and dots that didn't sit inside their own intervals) for sparsely-observed models.

Two causes:

1. When a model had no battles, only wins, or only losses in a bootstrap round, the MM solver returned a degenerate Elo around -3800. Those outliers were dragging the 2.5th percentile far below the actual range.
2. The displayed Elo was the bootstrap median, which drifts from the point estimate when the bootstrap distribution is skewed.

Tag degenerate cases as NaN inside the solver and use nanpercentile, display the point estimate from a single fit on the full data, and bump the bootstrap from 100 to 500 samples for steadier tails. Cost is negligible (500 bootstraps on 2000 battles run in ~0.2s locally).

Complementary to #469 (which raised the frontend trust_range threshold to hide the symptom); with this in we can revisit lowering that threshold if desired.