### PR TITLE
fix(spam): block roleplay jailbreak templates and zero-width evasion

### DIFF
--- a/backend/arena/spam_detection.py
+++ b/backend/arena/spam_detection.py
@@ -15,6 +15,10 @@ logger = logging.getLogger("languia")
 
 _compiled_patterns: Optional[list[re.Pattern]] = None
 
+# Zero-width and invisible characters used by bots to evade regex matching
+# (e.g. inserting U+200D between letters of 'say' so 'say ok' patterns miss).
+_INVISIBLE_CHARS = re.compile("[​-‏‪-‮⁠-⁯﻿]")
+
 
 def _load_spam_patterns() -> list[re.Pattern]:
     """Load and compile spam patterns from JSON file."""
@@ -77,4 +81,5 @@ def is_spam(prompt: str) -> bool:
     if _compiled_patterns is None:
         _compiled_patterns = _load_spam_patterns()
 
-    return any(pattern.search(prompt) for pattern in _compiled_patterns)
+    normalized = _INVISIBLE_CHARS.sub("", prompt)
+    return any(pattern.search(normalized) for pattern in _compiled_patterns)

--- a/backend/arena/spam_patterns.json
+++ b/backend/arena/spam_patterns.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.5",
   "description": "Regex patterns to detect prompt injection spam. Blocks structured prompt template formats that no legitimate user would type.",
   "patterns": [
     {
@@ -112,6 +112,34 @@
       "regex": "<[^>]*(?:Persona|Scenario|UserPersona|example_dialogs|char_description|char_name)\\s*>",
       "flags": "IGNORECASE",
       "description": "Roleplay injection XML tags: <...Persona>, <Scenario>, <UserPersona>, <example_dialogs>, etc. Used in jailbreak prompts pasted from character.ai-style platforms.",
+      "enabled": true
+    },
+    {
+      "name": "qa_named_chat_replay",
+      "regex": "(?:^|\\n)\\s*Q:\\s+\\w+:[\\s\\S]{0,4000}?(?:^|\\n)\\s*A:\\s+\\w+:",
+      "flags": "",
+      "description": "Pasted chat history using 'Q: <name>:' and 'A: <name>:' alternation (character.ai / SillyTavern export style). Legitimate Q&A uses 'Q:' / 'A:' without a name after the colon.",
+      "enabled": true
+    },
+    {
+      "name": "character_ai_example_block",
+      "regex": "\\[\\s*(?:Start a new chat|End of examples\\.\\s*Begin real interaction\\.?)\\s*\\]",
+      "flags": "IGNORECASE",
+      "description": "Character.ai-style example-conversation block markers: '[Start a new chat]', '[End of examples. Begin real interaction.]'.",
+      "enabled": true
+    },
+    {
+      "name": "example_conversations_between",
+      "regex": "Example conversations? between \\S+ and \\S+\\s*:",
+      "flags": "IGNORECASE",
+      "description": "Header used to inject pre-written example dialogues: 'Example conversations between X and Y:'. Signature of pasted roleplay jailbreak templates.",
+      "enabled": true
+    },
+    {
+      "name": "mystery_response_start_token",
+      "regex": "冥_RESPONSE_START_",
+      "flags": "",
+      "description": "Literal jailbreak control token '冥_RESPONSE_START_' observed in roleplay injection payloads.",
       "enabled": true
     }
   ]

--- a/backend/arena/spam_patterns.json
+++ b/backend/arena/spam_patterns.json
@@ -95,7 +95,7 @@
     },
     {
       "name": "trivial_short_prompt",
-      "regex": "^\\s*(?:hi|hello|hey|ok|okay|test|ping|say\\s+ok|say\\s+hi|say\\s+hello|hi\\s+or\\s+say\\s+ok)[\\s.!?]*$",
+      "regex": "^\\s*(?:hi|hello|hey|ok|okay|test|ping|say[\\s\\W]+ok|say[\\s\\W]+hi|say[\\s\\W]+hello|hi[\\s\\W]+or[\\s\\W]+say[\\s\\W]+ok)[\\s.!?]*$",
       "flags": "IGNORECASE",
       "description": "Whole-prompt trivial greetings/test pings ('hi', 'say OK', 'hello', 'test') used by bots to probe free-tier endpoints. Anchored to full string to avoid catching real prompts that contain these words.",
       "enabled": true


### PR DESCRIPTION
Deux types de spam récents :

## 1. Jailbreak roleplay character.ai (conv 1948794)

Template pasté ciblant la génération de contenu sexuel impliquant un personnage mineur + instructions de fabrication de drogues. Un modèle (gpt-oss-20b) a refusé, l'autre (llama-maverick) a complété.

4 patterns regex ciblant la **structure** du template (faible risque de faux-positifs) :
- `qa_named_chat_replay` — alternance `Q: <nom>:` / `A: <nom>:` (export character.ai)
- `character_ai_example_block` — `[Start a new chat]`, `[End of examples. Begin real interaction.]`
- `example_conversations_between` — header `Example conversations between X and Y:`
- `mystery_response_start_token` — token littéral `冥_RESPONSE_START_`

## 2. Évasion par caractères zero-width (conv 1948891)

Prompt `s‍ay - OK` avec un U+200D inséré entre `s` et `ay` pour bypass `say\s+ok`. Le séparateur `-` casse aussi le pattern existant.

- `spam_detection.py` : strip des caractères invisibles/bidi-control (U+200B–U+200F, U+202A–U+202E, U+2060–U+206F, U+FEFF) avant le match. Protège **tous** les patterns existants contre ce bypass.
- `trivial_short_prompt` : accepte n'importe quel séparateur non-mot entre `say` et la cible.

## Test plan

- [x] 5 snippets du jailbreak character.ai → tous détectés
- [x] 7 variants du `say ok` (ZWJ, BOM, ZWSP entre lettres, tirets) → tous détectés
- [x] 12 prompts légitimes (questions FR/EN, Q&A pédagogique, traduction, "say cheese", "Norway", etc.) → aucun faux-positif
- [ ] Vérifier en staging