### PR TITLE
fix(spam): strip zero-width chars and broaden 'say ok' pattern

### DIFF
--- a/backend/arena/spam_detection.py
+++ b/backend/arena/spam_detection.py
@@ -15,6 +15,10 @@ logger = logging.getLogger("languia")
 
 _compiled_patterns: Optional[list[re.Pattern]] = None
 
+# Zero-width and invisible characters used by bots to evade regex matching
+# (e.g. inserting U+200D between letters of 'say' so 'say ok' patterns miss).
+_INVISIBLE_CHARS = re.compile("[​-‏‪-‮⁠-⁯﻿]")
+
 
 def _load_spam_patterns() -> list[re.Pattern]:
     """Load and compile spam patterns from JSON file."""
@@ -77,4 +81,5 @@ def is_spam(prompt: str) -> bool:
     if _compiled_patterns is None:
         _compiled_patterns = _load_spam_patterns()
 
-    return any(pattern.search(prompt) for pattern in _compiled_patterns)
+    normalized = _INVISIBLE_CHARS.sub("", prompt)
+    return any(pattern.search(normalized) for pattern in _compiled_patterns)

--- a/backend/arena/spam_patterns.json
+++ b/backend/arena/spam_patterns.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.5",
   "description": "Regex patterns to detect prompt injection spam. Blocks structured prompt template formats that no legitimate user would type.",
   "patterns": [
     {
@@ -95,7 +95,7 @@
     },
     {
       "name": "trivial_short_prompt",
-      "regex": "^\\s*(?:hi|hello|hey|ok|okay|test|ping|say\\s+ok|say\\s+hi|say\\s+hello|hi\\s+or\\s+say\\s+ok)[\\s.!?]*$",
+      "regex": "^\\s*(?:hi|hello|hey|ok|okay|test|ping|say[\\s\\W]+ok|say[\\s\\W]+hi|say[\\s\\W]+hello|hi[\\s\\W]+or[\\s\\W]+say[\\s\\W]+ok)[\\s.!?]*$",
       "flags": "IGNORECASE",
       "description": "Whole-prompt trivial greetings/test pings ('hi', 'say OK', 'hello', 'test') used by bots to probe free-tier endpoints. Anchored to full string to avoid catching real prompts that contain these words.",
       "enabled": true


### PR DESCRIPTION
## Contexte

Nouvelle vague de spam (conversation 1948891 et autres) avec le prompt \`s‍ay - OK\` :
- **Caractère zero-width joiner** (U+200D) inséré entre \`s\` et \`ay\` → casse le pattern \`say\\s+ok\` existant
- Séparateur \`-\` au lieu d'espace → \`say\\s+ok\` ne matche pas \`say - OK\` non plus

## Fix

1. **\`spam_detection.py\`** : normalisation pré-match qui supprime les caractères invisibles/bidi-control (U+200B–U+200F, U+202A–U+202E, U+2060–U+206F, U+FEFF). Protège **tous** les patterns existants contre ce bypass, pas juste celui-ci.
2. **\`spam_patterns.json\`** : \`trivial_short_prompt\` accepte n'importe quel séparateur non-mot entre \`say\` et la cible (\`say - ok\`, \`say-ok\`).

## Test plan

- [x] \`s‍ay - OK\`, \`say - OK\`, \`say-OK\`, \`say  ok\`, \`s‍ay‍ ok\`, \`﻿hi\`, \`h​e​l​l​o\` → tous détectés
- [x] \`Pourquoi dit-on say cheese?\`, \`How do I say hello in French?\`, \`Comment dire OK en japonais\`, \`Saynete française\`, \`Tell me about Norway\` → tous passent
- [ ] Vérifier en staging qu'aucun trafic légitime ne déclenche le pattern élargi