### PR TITLE
fix(arena): unstick multi-turn after voting

### DIFF
--- a/backend/arena/services.py
+++ b/backend/arena/services.py
@@ -129,12 +129,13 @@ async def add_comparison_turn(
                 comparison_id=comparison_id, user_msg=UserMessage(content=prompt)
             )
         )
+        new_turn_id = db_turn.id
         session.add(db_turn)
         await session.commit()
 
     comparison = await read_comparison(comparison_id)
 
-    return (comparison, comparison.turns[-1])
+    return (comparison, next(t for t in comparison.turns if t.id == new_turn_id))
 
 
 async def update_turn(

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -269,8 +269,10 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
       comparison.error = undefined
     }
 
+    let receivedEvent = false
     try {
       for await (const event of api.stream(url, body)) {
+        receivedEvent = true
         if (event.type === 'init') {
           const id = event.comparison.id.toString()
           comparisons[id] = parseAPIComparison(event.comparison)
@@ -304,15 +306,20 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
             }
           }
         }
-        loading = false
+      }
+      if (!receivedEvent && comparison) {
+        // SSE opened with no events — backend crashed before its first yield.
+        comparison.error = 'empty_stream'
+        if (turn) turn.status = 'error'
       }
     } catch (err) {
-      loading = false
       if (err instanceof ValidationError) {
         promptError = err.message in ERROR_MESSAGES ? m[ERROR_MESSAGES[err.message]]() : err.message
       } else {
         throw err
       }
+    } finally {
+      loading = false
     }
   }
 

--- a/utils/database/models/comparison.py
+++ b/utils/database/models/comparison.py
@@ -106,7 +106,8 @@ class Comparison(ComparisonWithAnalyzeData, table=True):
     )
 
     turns: list[Turn] = Relationship(
-        back_populates="comparison", sa_relationship_kwargs={"lazy": "selectin"}
+        back_populates="comparison",
+        sa_relationship_kwargs={"lazy": "selectin", "order_by": "Turn.created_at"},
     )
 
 

--- a/utils/database/models/messages/llm.py
+++ b/utils/database/models/messages/llm.py
@@ -41,7 +41,9 @@ class LLMMessage(LLMMessageFinal, table=True):
 
 class LLMMessageCreate(LLMMessageBase):
     content: str = ""
-    reasoning_content: str = ""
+    # Nullable: StripAndEmptyAsNone persists empty reasoning_content as NULL,
+    # so DB-loaded rows must validate back through LLMMessageCreate.
+    reasoning_content: str | None = ""
 
 
 class LLMMessageRead(LLMMessageFinal):


### PR DESCRIPTION
Found three small bugs while testing the new vote feature on staging. Each one is independent; together they cause the symptom below.

## Symptom

After voting on the first turn and submitting a follow-up message, the page freezes on the loading spinner forever. The follow-up never appears as a user bubble, no model response streams in, and the "Terminer la discussion" button stays disabled. Refresh is the only way out.

Sentry: `LANGUIA-3XS` — `ValidationError: 1 validation error for TurnPublic, llm_msg_b.reasoning_content, Input should be a valid string, input_value=None`.

## Three bugs stacked

**1. `LLMMessageCreate.reasoning_content` declared as a required string**

In `utils/database/models/messages/llm.py`, the field was `str = ""`. But `StripAndEmptyAsNone` collapses an empty `reasoning_content` to `NULL` on persistence (this is intentional for the storage shape). So any DB-loaded `LLMMessage` from a non-reasoning model has `reasoning_content = None`, which then fails to revalidate through `LLMMessageCreate`. That's the actual exception Sentry captured.

Fix: `reasoning_content: str | None = ""`. Default stays `""` so streaming `msg.reasoning_content += chunk` still works.

**2. `comparison.turns[-1]` is not guaranteed to be the new turn**

`add_comparison_turn` writes the new turn, re-reads the comparison, and returns `comparison.turns[-1]`. But `Comparison.turns` was declared without `order_by`, so the order is whatever Postgres happens to give back — and after `update_turn` and the vote both update turn 1, the physical row order can put the old turn last. `comparison.turns[-1]` then returns the previous turn (which has populated `llm_msg_a/b`), which is what gets fed to `TurnPublic.model_validate` and triggers bug 1.

Fixes:
- Add `order_by="Turn.created_at"` to the `turns` relationship.
- Make `add_comparison_turn` look up the just-inserted turn by id rather than by position.

**3. The frontend has no escape hatch when the SSE stream is empty**

When the backend route opens the SSE response but raises before its first `yield`, the client sees `200 OK` with a 0-byte body. In `chatService.ask()`, `loading = false` was set inside the `for await` loop, so a zero-event stream left `loading = true` forever and no error was surfaced — the UI just spins.

Fixes:
- Move `loading = false` to a `finally`.
- If the stream closes with zero events, set `comparison.error = 'empty_stream'` and mark the turn as errored, so the user sees an error state instead of an eternal spinner.

## How I verified

- A pure-Pydantic repro inserting a row with `reasoning_content = NULL` and validating it through `TurnPublic` reproduces the Sentry error exactly. After the schema fix, it passes.
- An end-to-end repro through `httpx.ASGITransport` against `backend.main:app` with real OpenRouter responses: `add_first_text` returns ~200 KB SSE, vote returns 200, `add_text` returns ~125 KB SSE. Before the fix, `add_text` on staging returned 200 with a 0-byte body.

## Why this PR targets `refactor-db-tables`

All three bugs are scoped to code introduced in #447 — happy to squash into that PR rather than land separately.