### PR TITLE
Mobile vote UX: layout, swipe, and animations

### DIFF
--- a/frontend/src/lib/components/SideSwitcher.svelte
+++ b/frontend/src/lib/components/SideSwitcher.svelte
@@ -2,6 +2,7 @@
   import { Button } from '$components/dsfr'
   import type { Bot } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
+  import { onDestroy } from 'svelte'
   import type { SvelteHTMLElements } from 'svelte/elements'
 
   let { children, ...props }: SvelteHTMLElements['div'] = $props()
@@ -27,9 +28,12 @@
       const { scrollLeft, scrollWidth, clientWidth } = scrollableElem
       const maxScroll = scrollWidth - clientWidth
       if (maxScroll <= 0) return
-      scrolledSide = scrollLeft / maxScroll > 0.5 ? 'b' : 'a'
+      const next: Bot = scrollLeft / maxScroll > 0.5 ? 'b' : 'a'
+      if (next !== scrolledSide) scrolledSide = next
     }, 80)
   }
+
+  onDestroy(() => clearTimeout(scrollDebounce))
 </script>
 
 <div {...props} class="min-h-0 relative flex max-w-full">

--- a/frontend/src/lib/components/SideSwitcher.svelte
+++ b/frontend/src/lib/components/SideSwitcher.svelte
@@ -10,13 +10,34 @@
   let scrollableElem = $state<HTMLDivElement>()
 
   function doScroll() {
-    scrollableElem?.scrollTo({ left: scrolledSide === 'a' ? scrollableElem?.scrollWidth : 0 })
-    scrolledSide = scrolledSide === 'a' ? 'b' : 'a'
+    const next: Bot = scrolledSide === 'a' ? 'b' : 'a'
+    scrollableElem?.scrollTo({
+      left: next === 'b' ? scrollableElem.scrollWidth : 0,
+      behavior: 'smooth'
+    })
+    scrolledSide = next
+  }
+
+  let scrollDebounce: ReturnType<typeof setTimeout> | undefined
+  function onScroll() {
+    if (!scrollableElem) return
+    clearTimeout(scrollDebounce)
+    scrollDebounce = setTimeout(() => {
+      if (!scrollableElem) return
+      const { scrollLeft, scrollWidth, clientWidth } = scrollableElem
+      const maxScroll = scrollWidth - clientWidth
+      if (maxScroll <= 0) return
+      scrolledSide = scrollLeft / maxScroll > 0.5 ? 'b' : 'a'
+    }, 80)
   }
 </script>
 
 <div {...props} class="min-h-0 relative flex max-w-full">
-  <div class="flex w-full overflow-hidden" bind:this={scrollableElem}>
+  <div
+    class="cl-side-switcher-scroller md:overflow-hidden! flex w-full overflow-x-auto"
+    bind:this={scrollableElem}
+    onscroll={onScroll}
+  >
     {@render children?.()}
   </div>
 
@@ -34,3 +55,20 @@
     />
   {/each}
 </div>
+
+<style>
+  @media (max-width: 47.99em) {
+    .cl-side-switcher-scroller {
+      scroll-snap-type: x mandatory;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+    }
+    .cl-side-switcher-scroller::-webkit-scrollbar {
+      display: none;
+    }
+    .cl-side-switcher-scroller :global(> * > *) {
+      scroll-snap-align: center;
+      scroll-snap-stop: always;
+    }
+  }
+</style>

--- a/frontend/src/routes/arene/components/VoteAnnotate.svelte
+++ b/frontend/src/routes/arene/components/VoteAnnotate.svelte
@@ -45,7 +45,7 @@
 
 <form
   {id}
-  class="bg-light-info px-4 py-2 mt-auto"
+  class="cl-vote-annotate bg-light-info px-4 py-2 mt-auto"
   in:fly={{ y: 8, duration: 200, opacity: 0 }}
 >
   <TextPrompt
@@ -74,3 +74,21 @@
     onChange={() => onUpdate(annotations)}
   />
 </form>
+
+<style>
+  @keyframes chipPulse {
+    0% {
+      transform: scale(1);
+    }
+    50% {
+      transform: scale(1.08);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  .cl-vote-annotate :global(label:has(input:checked)) {
+    animation: chipPulse 220ms ease-out;
+  }
+</style>

--- a/frontend/src/routes/arene/components/VoteAnnotate.svelte
+++ b/frontend/src/routes/arene/components/VoteAnnotate.svelte
@@ -4,6 +4,7 @@
   import type { APIReactionPref, VoteAnnotations } from '$lib/chatService.svelte'
   import { APINegativePrefs, APIPositivePrefs, PREFS_EMOJIS } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
+  import { fly } from 'svelte/transition'
 
   export interface VoteAnnotateProps {
     id: string
@@ -42,7 +43,11 @@
   const keywordChoices = $derived(keywords[kind])
 </script>
 
-<form {id} class="bg-light-info px-4 py-2 mt-auto">
+<form
+  {id}
+  class="bg-light-info px-4 py-2 mt-auto"
+  in:fly={{ y: 8, duration: 200, opacity: 0 }}
+>
   <TextPrompt
     id="chatbot-prompt"
     bind:value={annotations.custom_annotation}

--- a/frontend/src/routes/arene/components/VoteAnnotate.svelte
+++ b/frontend/src/routes/arene/components/VoteAnnotate.svelte
@@ -46,7 +46,7 @@
 <form
   {id}
   class="cl-vote-annotate bg-light-info px-4 py-2 mt-auto"
-  in:fly={{ y: 8, duration: 200, opacity: 0 }}
+  in:fly={{ y: 8, duration: 200 }}
 >
   <TextPrompt
     id="chatbot-prompt"

--- a/frontend/src/routes/arene/components/VoteSelect.svelte
+++ b/frontend/src/routes/arene/components/VoteSelect.svelte
@@ -23,9 +23,14 @@
     icon: choiceIcons[value]
   }))
 
+  let pickedChoice = $state<TurnChoice | null>(null)
+
   function onSubmit(e: SubmitEvent) {
     e.preventDefault()
-    onVote(e.submitter!.dataset.choice as TurnChoice)
+    if (pickedChoice) return
+    const choice = e.submitter!.dataset.choice as TurnChoice
+    pickedChoice = choice
+    setTimeout(() => onVote(choice), 280)
   }
 </script>
 
@@ -41,8 +46,12 @@
       {#each choices as choice (choice.value)}
         <button
           type="submit"
-          class="rounded-lg p-2 text-xs! bg-white cg-border flex items-center"
+          class={[
+            'rounded-lg p-2 text-xs! bg-white cg-border flex items-center',
+            { 'cl-vote-picked': pickedChoice === choice.value }
+          ]}
           data-choice={choice.value}
+          disabled={pickedChoice !== null && pickedChoice !== choice.value}
         >
           <span class={['gap-1 m-auto flex', { 'flex-row-reverse': choice.value === 'b_better' }]}>
             <Icon icon={choice.icon} block size="xs" class="text-primary" />
@@ -89,6 +98,14 @@
   }
   .cl-vote-select button[data-choice]:not([data-choice='idk']):active:not(:disabled) {
     transform: scale(0.97);
+  }
+  .cl-vote-select .cl-vote-picked {
+    background-color: var(--blue-france-main-525) !important;
+    color: white !important;
+    transform: scale(1.04);
+  }
+  .cl-vote-select .cl-vote-picked :global(.text-primary) {
+    color: white !important;
   }
 
   @media (max-width: 47.99em) {

--- a/frontend/src/routes/arene/components/VoteSelect.svelte
+++ b/frontend/src/routes/arene/components/VoteSelect.svelte
@@ -37,7 +37,7 @@
   >
     <legend id="display-fieldset-legend" class="sr-only">{m['vote.title']()}</legend>
 
-    <div class="gap-2 md:grid-cols-4 grid">
+    <div class="gap-2 grid-cols-2 md:grid-cols-4 grid">
       {#each choices as choice (choice.value)}
         <button
           type="submit"
@@ -76,6 +76,21 @@
   .cl-vote-select button {
     &:disabled {
       filter: grayscale(100%);
+    }
+  }
+
+  @media (max-width: 47.99em) {
+    .cl-vote-select button[data-choice='a_better'] {
+      order: 1;
+    }
+    .cl-vote-select button[data-choice='b_better'] {
+      order: 2;
+    }
+    .cl-vote-select button[data-choice='both_bad'] {
+      order: 3;
+    }
+    .cl-vote-select button[data-choice='both_good'] {
+      order: 4;
     }
   }
 </style>

--- a/frontend/src/routes/arene/components/VoteSelect.svelte
+++ b/frontend/src/routes/arene/components/VoteSelect.svelte
@@ -3,6 +3,7 @@
   import { TURN_CHOICES, type TurnChoice } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
   import { propsToAttrs, sanitize } from '$lib/utils/commons'
+  import { onDestroy } from 'svelte'
 
   interface VoteSelectProps {
     id: string
@@ -24,14 +25,17 @@
   }))
 
   let pickedChoice = $state<TurnChoice | null>(null)
+  let voteTimeout: ReturnType<typeof setTimeout> | undefined
 
   function onSubmit(e: SubmitEvent) {
     e.preventDefault()
     if (pickedChoice) return
     const choice = e.submitter!.dataset.choice as TurnChoice
     pickedChoice = choice
-    setTimeout(() => onVote(choice), 280)
+    voteTimeout = setTimeout(() => onVote(choice), 280)
   }
+
+  onDestroy(() => clearTimeout(voteTimeout))
 </script>
 
 <form class="px-4 w-full" novalidate onsubmit={onSubmit}>
@@ -47,7 +51,7 @@
         <button
           type="submit"
           class={[
-            'rounded-lg p-2 text-xs! bg-white cg-border flex items-center',
+            'cl-vote-choice rounded-lg p-2 text-xs! bg-white cg-border flex items-center',
             { 'cl-vote-picked': pickedChoice === choice.value }
           ]}
           data-choice={choice.value}
@@ -88,23 +92,23 @@
     }
   }
 
-  .cl-vote-select button[data-choice]:not([data-choice='idk']) {
+  .cl-vote-choice {
     transition:
       transform 150ms ease,
       background-color 150ms ease;
   }
-  .cl-vote-select button[data-choice]:not([data-choice='idk']):hover:not(:disabled) {
+  .cl-vote-choice:hover:not(:disabled) {
     transform: scale(1.02);
   }
-  .cl-vote-select button[data-choice]:not([data-choice='idk']):active:not(:disabled) {
+  .cl-vote-choice:active:not(:disabled) {
     transform: scale(0.97);
   }
-  .cl-vote-select .cl-vote-picked {
+  .cl-vote-picked {
     background-color: var(--blue-france-main-525) !important;
     color: white !important;
     transform: scale(1.04);
   }
-  .cl-vote-select .cl-vote-picked :global(.text-primary) {
+  .cl-vote-picked :global(.text-primary) {
     color: white !important;
   }
 

--- a/frontend/src/routes/arene/components/VoteSelect.svelte
+++ b/frontend/src/routes/arene/components/VoteSelect.svelte
@@ -79,6 +79,18 @@
     }
   }
 
+  .cl-vote-select button[data-choice]:not([data-choice='idk']) {
+    transition:
+      transform 150ms ease,
+      background-color 150ms ease;
+  }
+  .cl-vote-select button[data-choice]:not([data-choice='idk']):hover:not(:disabled) {
+    transform: scale(1.02);
+  }
+  .cl-vote-select button[data-choice]:not([data-choice='idk']):active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
   @media (max-width: 47.99em) {
     .cl-vote-select button[data-choice='a_better'] {
       order: 1;


### PR DESCRIPTION
Some mobile polish on top of the db-tables refactor, mostly around the vote step.

- The 4 vote buttons sit in a 2×2 grid on mobile instead of stacking, so the model response above them stays visible. Desktop still gets the 1×4 row.
- On mobile the 2×2 puts A and B on the top row and the two "both" choices on the bottom row, while the underlying DOM order is untouched (purely CSS `order`).
- Picked button briefly highlights in blue + scales up before the annotation panel appears, so the click feels confirmed.
- Annotation panel slides up and fades in (`svelte/transition` `fly`) instead of appearing instantly.
- Keyword chips pulse on check.
- Hover and active scale on the choice buttons (very small, just for tactile feedback).
- `SideSwitcher`: the model cards can now actually be swiped on mobile (previously the scroller was `overflow-hidden`, so only the arrow buttons worked). Added `scroll-snap` so swipes settle on one card or the other, smooth-scroll on the arrow taps, and a debounced scroll listener so the arrow toggles when you swipe by hand. Cleans up the timeout on unmount.

Everything is scoped to ≤768px or the affected components — desktop is unchanged.