### PR TITLE
feat(models): replace Trinity Large Preview with Trinity Large Thinking

### DIFF
--- a/utils/models/models.json
+++ b/utils/models/models.json
@@ -402,6 +402,7 @@
       {
         "id": "trinity-large-preview",
         "simple_name": "Trinity Large",
+        "status": "archived",
         "license": "Apache 2.0",
         "release_date": "01/2026",
         "arch": "moe",
@@ -415,6 +416,25 @@
         "desc": "Modèle semi-ouvert américain créé par Arcee AI, une startup de 30 personnes.",
         "size_desc": "Avec 398 milliards de paramètres, Trinity Large est un modèle de très grande taille. Néanmoins, grâce à son architecture de mélange d'experts (MoE, Mixture of Experts) hautement optimisée, il n'active que 13 milliards de paramètres par jeton généré, ce qui réduit significativement l'empreinte énergétique et les coûts d'inférence comparé à un modèle dense équivalent. Sa fenêtre de contexte atteint 512 000 jetons, ce qui le rend particulièrement adapté à l'analyse de très longs documents ou de bases de code massives.",
         "fyi": "Trinity Large a été conçu et entraîné entièrement aux États-Unis par Arcee AI, une startup de 30 personnes. Il a été entraîné sur 17 billions de jetons.\n\nL'entraînement complet s'est déroulé en 33 jours sur 2 048 GPUs Nvidia B300, pour un coût total d'environ 20 millions de dollars. L'architecture intègre des avancées comme l'attention \"gated\" et Muon."
+      },
+      {
+        "id": "trinity-large-thinking",
+        "simple_name": "Trinity Large Thinking",
+        "license": "Apache 2.0",
+        "release_date": "04/2026",
+        "arch": "moe",
+        "params": 398,
+        "active_params": 13,
+        "reasoning": true,
+        "new": true,
+        "url": "https://huggingface.co/arcee-ai/Trinity-Large-Thinking",
+        "endpoint": {
+          "api_type": "openrouter",
+          "api_model_id": "arcee-ai/trinity-large-thinking"
+        },
+        "desc": "Très grand modèle semi-ouvert américain créé par Arcee AI, une startup d'une trentaine de personnes. Il intègre une capacité de raisonnement avancée et a été spécifiquement post-entraîné pour les usages agentiques et l'utilisation d'outils externes.",
+        "size_desc": "Avec 398 milliards de paramètres, ce modèle se place dans la catégorie des très grands modèles. Grâce à une architecture de mélange d'experts (MoE, Mixture of Experts), il n'active que 13 milliards de paramètres par jeton généré (4 experts actifs sur 256), ce qui réduit son empreinte énergétique et ses coûts d'inférence comparé à un modèle dense équivalent. Sa fenêtre de contexte va jusqu'à 512 000 jetons, ce qui permet de traiter de très longs documents.\n\nLes modèles de raisonnement de ce type fonctionnent plus longtemps pour produire une réponse, ce qui augmente la consommation énergétique.",
+        "fyi": "Trinity Large Thinking a été conçu et entraîné entièrement aux États-Unis par Arcee AI. Il s'agit de la variante optimisée pour le raisonnement et les usages agentiques de la famille Trinity Large, qui partage la même architecture de mélange d'experts à 398 milliards de paramètres avec 256 experts dont 4 activés par jeton.\n\nL'entraînement de base a porté sur 17 billions de jetons, en partenariat avec Datology pour les données et Prime Intellect pour le calcul. L'infrastructure d'entraînement reposait sur 2 048 cartes graphiques Nvidia B300. Le post-entraînement repose sur un affinage supervisé (SFT, supervised fine-tuning) avec des chaînes de raisonnement étendues, suivi d'apprentissage par renforcement orienté agentique, intégrant des trajectoires d'appels d'outils multi-étapes.\n\nSelon l'éditeur, le modèle se classe deuxième au benchmark PinchBench, juste derrière Opus 4.6. Il obtient 94,7 % sur τ²-Telecom (tâches agentiques), 98,2 % sur LiveCodeBench, 96,3 % sur AIME25 et 83,4 % sur MMLU-Pro."
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Archive `trinity-large-preview`: the model is no longer routable through OpenRouter (`No endpoints found for arcee-ai/trinity-large-preview`, ~850 events in the last week on prd), so it stays in the catalog as `"status": "archived"` for historical lookups but is no longer offered to users.
- Add `trinity-large-thinking` (Arcee's reasoning variant of the same 398B MoE family, released 04/2026): Apache 2.0, 512k context, agentic post-training, routed via OpenRouter as `arcee-ai/trinity-large-thinking`.

## Test plan

- [ ] Verify the new entry shows up in the arena and that `arena/add_first_text` succeeds against `arcee-ai/trinity-large-thinking` on dev
- [ ] Confirm `trinity-large-preview` no longer appears in the user-facing selector
- [ ] Check that LANGUIA-3XD stops growing once dev/stg/prd are deployed