### PR TITLE
fix: corrections to data migration and backfills

### DIFF
--- a/utils/database/actions/migrate_reactions.py
+++ b/utils/database/actions/migrate_reactions.py
@@ -25,7 +25,7 @@ QUERY = _QUERY_BASE
 QUERY_FILTERED = _QUERY_BASE + "    AND conversation_pair_id = ANY(:ids)"
 
 REACTION_FLAGS = [
-    "liked", "disliked", "useful", "complete", "creative", "clear_formatting",
+    "useful", "complete", "creative", "clear_formatting",
     "incorrect", "superficial", "instructions_not_followed",
 ]
 


### PR DESCRIPTION
## Summary

- Fix reactions migration to exclude liked/dislike from keyword annotations
- Add backfill migrations to derive turn.choice from votes (all turns) and reactions (per turn)
- Fix archived_reason enum to include previously commented-out legacy values
- Fix dataset export to tolerate missing llm_id and nullable llm messages

## Work in progress

More commits to follow on this branch.