### PR TITLE
blacklist grok models and archive related comparisons

### DIFF
--- a/utils/database/actions/__init__.py
+++ b/utils/database/actions/__init__.py
@@ -1,3 +1,4 @@
+from .archive_blacklisted_grok import archive_blacklisted_grok
 from .archive_corrupted import archive_corrupted
 from .archive_spam import archive_spam
 from .archive_unknown_llms import archive_unknown_llms

--- a/utils/database/actions/archive_blacklisted_grok.py
+++ b/utils/database/actions/archive_blacklisted_grok.py
@@ -1,0 +1,46 @@
+import logging
+
+import polars as pl
+from sqlmodel import and_, col, or_, select
+
+from ..models import Comparison
+from ..session import get_session
+from ..utils import archive
+
+logger = logging.getLogger("comparia.db")
+
+
+async def archive_blacklisted_grok(*, commit: bool = False) -> None:
+    """
+    Archive comparisons involving any Grok model (llm_id starting with 'grok-').
+    """
+    async with get_session() as session:
+        query = select(Comparison.id, Comparison.llm_id_a, Comparison.llm_id_b).where(
+            and_(
+                col(Comparison.archived) == None,
+                or_(
+                    col(Comparison.llm_id_a).like("grok-%"),
+                    col(Comparison.llm_id_b).like("grok-%"),
+                ),
+            )
+        )
+        data = pl.DataFrame((await session.exec(query)).all())
+
+    ids = data["id"].to_list() if not data.is_empty() else []
+    if not ids:
+        logger.info("No comparisons with Grok models found.")
+        return
+
+    logger.warning(f"Found {len(ids)} comparisons involving Grok models.")
+
+    grok_ids = set(
+        data["llm_id_a"].append(data["llm_id_b"])
+        .filter(data["llm_id_a"].append(data["llm_id_b"]).str.starts_with("grok-"))
+        .unique()
+        .to_list()
+    )
+    for grok_id in sorted(grok_ids):
+        count = len(data.filter((pl.col("llm_id_a") == grok_id) | (pl.col("llm_id_b") == grok_id)))
+        logger.warning(f"{count:4} comparisons with '{grok_id}'")
+
+    await archive(ids, "blacklist_grok", commit=commit)

--- a/utils/database/actions/migrate_reactions.py
+++ b/utils/database/actions/migrate_reactions.py
@@ -25,8 +25,6 @@ QUERY = _QUERY_BASE
 QUERY_FILTERED = _QUERY_BASE + "    AND conversation_pair_id = ANY(:ids)"
 
 REACTION_FLAGS = [
-    "liked",
-    "disliked",
     "useful",
     "complete",
     "creative",

--- a/utils/database/cli.py
+++ b/utils/database/cli.py
@@ -5,6 +5,7 @@ from cyclopts import App
 from utils.logger import configure_logger
 
 from .actions import (
+    archive_blacklisted_grok,
     archive_corrupted,
     archive_spam,
     archive_unknown_llms,
@@ -25,6 +26,7 @@ cli_archive = App(name="archive", help="Individual archival utilities.")
 cli_archive.command(archive_spam, name="spam")
 cli_archive.command(archive_corrupted, name="corrupted")
 cli_archive.command(archive_unknown_llms, name="unknown_llms")
+cli_archive.command(archive_blacklisted_grok, name="blacklisted_grok")
 
 cli_migrate = App(
     name="migrate", help="Migrate data from old schema to new SQLModel schema."

--- a/utils/database/lint.py
+++ b/utils/database/lint.py
@@ -6,7 +6,7 @@ import numpy as np
 import polars as pl
 from sqlmodel import select
 
-from .actions import archive_corrupted, archive_spam, archive_unknown_llms, llm_analyze
+from .actions import archive_blacklisted_grok, archive_corrupted, archive_spam, archive_unknown_llms, llm_analyze
 from .models import Comparison
 from .utils import get_session, reset_archived, set_not_archived
 
@@ -132,6 +132,7 @@ async def lint(
     await archive_spam(commit=fix)
     await archive_corrupted(commit=fix)
     await archive_unknown_llms(commit=fix and hard)
+    await archive_blacklisted_grok(commit=fix)
 
     if fix:
         await set_not_archived(start_at)

--- a/utils/database/models/comparison.py
+++ b/utils/database/models/comparison.py
@@ -33,6 +33,7 @@ ArchivedReason = Literal[
     # "duplicate_has_vote",
     "spam",
     "unknown_llm",
+    "blacklist_grok",
     "unknown",
 ]
 # TODO could be fixed?

--- a/utils/models/generated-models.json
+++ b/utils/models/generated-models.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1780415399.659021,
+  "timestamp": 1780420209.311006,
   "models": {
     "Apertus-70B-Instruct-2509": {
       "active_params": null,
@@ -2150,7 +2150,7 @@
       "reuse": false,
       "simple_name": "Grok 4.20",
       "specific_portals": null,
-      "status": "enabled",
+      "status": "archived",
       "url": "https://x.ai/news",
       "wh_per_million_token": 137100.43989371642
     },
@@ -2181,7 +2181,7 @@
       "reuse": false,
       "simple_name": "Grok 4.3",
       "specific_portals": null,
-      "status": "enabled",
+      "status": "archived",
       "url": "https://docs.x.ai/developers/models/grok-4.3",
       "wh_per_million_token": 137100.43989371642
     },

--- a/utils/models/models.json
+++ b/utils/models/models.json
@@ -441,6 +441,7 @@
     "proprietary_license_desc": "Le modèle est disponible sous licence payante et accessible via X et xAI, nécessitant un paiement à l'utilisation basé sur le nombre de jetons traités ou sur l’infrastructure réservée.",
     "models": [
       {
+        "status": "archived",
         "id": "grok-4.20",
         "simple_name": "Grok 4.20",
         "license": "proprietary",
@@ -458,6 +459,7 @@
         "fyi": "La préversion bêta de Grok 4.20 a été rendue disponible à la mi-février 2026, avant sa sortie officielle sur l'API xAI en mars 2026. Le mode multi-agent oriente chaque requête vers quatre agents spécialisés qui raisonnent en parallèle, puis synthétise leurs conclusions en une réponse unique, une approche annoncée comme bénéfique pour les tâches de raisonnement complexes. Le raisonnement est contrôlable via un paramètre d'API plutôt que via un identifiant de modèle distinct.\n\nSelon l'éditeur, Grok 4.20 introduit une architecture d'apprentissage continu qui met à jour hebdomadairement les capacités du modèle à partir de l'usage réel, sans intervention des utilisateurs. Aucun détail architectural précis (nombre de paramètres, architecture dense ou mélange d'experts) n'a été communiqué publiquement par xAI. Le modèle est proposé sous licence payante, accessible via l'API xAI et OpenRouter."
       },
       {
+        "status": "archived",
         "id": "grok-4.3",
         "simple_name": "Grok 4.3",
         "license": "proprietary",


### PR DESCRIPTION
## Summary

- Archive grok-4.20 and grok-4.3 in models.json and regenerate generated-models.json
- Add blacklist_grok archived_reason to ArchivedReason enum
- Add archive_blacklisted_grok lint action targeting comparisons with any grok model (llm_id LIKE 'grok-%')
- Wire into db lint pipeline and expose as standalone CLI command