### PR TITLE
Stream the dataset export so memory stays bounded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-backend install-frontend dev dev-redis dev-backend dev-frontend dev-controller build-frontend db-generate-init-old db db-prd-local docker-app-up docker-app-down docker-app-logs clean redis models-doc up-fr down-fr logs-fr display-env-fr up-da down-da logs-da display-env-da dataset-export-fr
+.PHONY: help install install-backend install-frontend test test-backend test-dataset dev dev-redis dev-backend dev-frontend dev-controller build-frontend db-generate-init-old db db-prd-local docker-app-up docker-app-down docker-app-logs clean redis models-doc up-fr down-fr logs-fr display-env-fr up-da down-da logs-da display-env-da dataset-export-fr
 
 # Variables
 PYTHON := python3
@@ -112,6 +112,15 @@ display-env-da: ## Display env vars loaded from KeePass for DA instance
 ###################################
 # Development with local code
 ###################################
+
+test: test-backend test-dataset ## Run all tests
+
+test-backend: ## Run backend unit tests
+	$(UV) run pytest backend/
+
+test-dataset: ## Run dataset export tests (no DB required)
+	$(UV) run --group data python tests/dataset/test_comparison_to_turns.py
+	$(UV) run --group data python tests/dataset/test_streaming_export.py
 
 install: install-backend install-frontend ## Install all dependencies (backend + frontend)
 

--- a/tests/dataset/test_comparison_to_turns.py
+++ b/tests/dataset/test_comparison_to_turns.py
@@ -1,0 +1,358 @@
+"""
+Equivalence test pinning the fast `comparison_to_turns` against the original
+Pydantic pipeline (kept verbatim below as the oracle).
+
+The export builder was rewritten to read ORM attributes directly instead of
+re-validating and re-dumping the whole nested object graph. This test builds
+synthetic Comparison fixtures covering the tricky cases (legacy empty llm_id,
+a side that didn't answer, whitespace/empty content, missing system prompts,
+the metadata/excluded permutations, and the comparisons the old pipeline
+silently skipped) and asserts the new output is identical row-for-row,
+key-order included.
+
+No DB and no pytest required:
+    uv run --group data python tests/dataset/test_comparison_to_turns.py
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from utils.database.models import Comparison, Turn
+from utils.database.models.messages import LLMMessage, SystemMessage, UserMessage
+from utils.dataset import compute
+from utils.dataset.models import (
+    DatasetComparison,
+    DatasetComparisonBaseMetadata,
+    DatasetComparisonExtraMetadata,
+)
+
+# --- llms fixture (only `.wh_per_million_token` is read) -------------------
+
+LLMS = {
+    "model-a": SimpleNamespace(wh_per_million_token=1000.0),
+    "model-b": SimpleNamespace(wh_per_million_token=500.0),
+}
+compute.get_raw_llms_data = lambda: LLMS  # patch for both oracle and new code
+
+
+# --- oracle: the original implementation, unchanged ------------------------
+
+
+def oracle_comparison_to_turns(db_comparison: Comparison) -> list[dict]:
+    llms = compute.get_raw_llms_data()
+    ctx = {
+        "llm_a": llms.get(db_comparison.llm_id_a),
+        "llm_b": llms.get(db_comparison.llm_id_b),
+        "metadata": DatasetComparisonBaseMetadata.model_validate(
+            db_comparison
+        ).model_dump(),
+        "extra_metadata": DatasetComparisonExtraMetadata.model_validate(
+            db_comparison
+        ).model_dump(),
+    }
+    comparison = DatasetComparison.model_validate(db_comparison, context=ctx)
+    comp_data = comparison.model_dump()
+    comp_meta = comp_data.pop("metadata_")
+    comp_extra_meta = comp_data.pop("extra_metadata_")
+    comp_turns = comp_data.pop("turns_")
+
+    turns = []
+    for idx, turn_data in enumerate(comp_turns):
+        turn_meta = turn_data.pop("metadata_")
+        turns.append(
+            {
+                **turn_data,
+                "turn": idx,
+                **comp_data,
+                "metadata": {**turn_meta, **comp_meta},
+                "extra_metadata": comp_extra_meta,
+            }
+        )
+    return turns
+
+
+# --- fixture builders ------------------------------------------------------
+
+T0 = datetime(2024, 1, 1, 12, 0, 0)
+
+
+def user_msg(content="hi", **kw):
+    return UserMessage(content=content, created_at=T0, **kw)
+
+
+def system_msg(content="be nice"):
+    return SystemMessage(content=content, created_at=T0)
+
+
+def llm_msg(
+    content="answer",
+    tokens=120,
+    reasoning=None,
+    generation_id="gen-1",
+    created_at=T0,
+    responded_at=datetime(2024, 1, 1, 12, 0, 1),
+    updated_at=datetime(2024, 1, 1, 12, 0, 3),
+    **kw,
+):
+    return LLMMessage(
+        content=content,
+        reasoning_content=reasoning,
+        tokens=tokens,
+        generation_id=generation_id,
+        is_cached=False,
+        created_at=created_at,
+        responded_at=responded_at,
+        updated_at=updated_at,
+        **kw,
+    )
+
+
+def turn(user, a, b, choice=None):
+    t = Turn(created_at=T0)
+    t.user_msg = user
+    t.llm_msg_a = a
+    t.llm_msg_b = b
+    t.choice = choice
+    return t
+
+
+def comparison(
+    turns,
+    *,
+    sys_a=None,
+    sys_b=None,
+    llm_id_a="model-a",
+    llm_id_b="model-b",
+    mode="random",
+    custom_models_selection=None,
+    categories=None,
+    languages=None,
+    short_summary=None,
+    cohorts=None,
+    error=None,
+    llm_analyzed=None,
+    contains_pii=None,
+    contains_spam=None,
+    archived=None,
+    archived_reason=None,
+    archived_at=None,
+):
+    c = Comparison(ip="0.0.0.0", mode=mode, llm_id_a=llm_id_a, llm_id_b=llm_id_b)
+    c.custom_models_selection = custom_models_selection
+    c.categories = categories
+    c.languages = languages
+    c.short_summary = short_summary
+    c.cohorts = cohorts
+    c.error = error
+    c.llm_analyzed = llm_analyzed
+    c.contains_pii = contains_pii
+    c.contains_spam = contains_spam
+    c.archived = archived
+    c.archived_reason = archived_reason
+    c.archived_at = archived_at
+    c.system_msg_a = sys_a
+    c.system_msg_b = sys_b
+    c.turns = turns
+    return c
+
+
+# --- cases that must produce identical output ------------------------------
+
+
+def equivalent_cases():
+    yield "happy 2-turn, both answer, systems, analyzed/kept", comparison(
+        [
+            turn(user_msg("q1"), llm_msg("a1", 100), llm_msg("b1", 200), "a_better"),
+            turn(
+                user_msg("q2"),
+                llm_msg("a2", 50, reasoning="because"),
+                llm_msg("b2", 80),
+            ),
+        ],
+        sys_a=system_msg("sys a"),
+        sys_b=system_msg("sys b"),
+        cohorts="some-cohort",
+        llm_analyzed=True,
+        archived=False,
+    )
+
+    yield "legacy empty llm_id_a -> llm None -> conso None", comparison(
+        [turn(user_msg(), llm_msg("a", 100), llm_msg("b", 100))],
+        llm_id_a="",
+    )
+
+    yield "side b did not answer (llm_msg_b None)", comparison(
+        [turn(user_msg(), llm_msg("a", 70), None, "a_better")],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+
+    yield "no system messages", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 20))],
+    )
+
+    # The old pipeline left LLM content/reasoning RAW (the ORM object is already
+    # an LLMMessageFinal instance, so revalidate_instances="never" skipped the
+    # StripAndEmptyAsNone validators). We must preserve that, not strip.
+    yield "llm content/reasoning passed through raw (no strip)", comparison(
+        [
+            turn(
+                user_msg("  spaced  "),
+                llm_msg("  trimmed me  ", 10, reasoning="   "),
+                llm_msg("ok", 10, reasoning="  real  "),
+            )
+        ],
+    )
+
+    # generation_id is never read downstream, so a None one is not a skip.
+    yield "llm generation_id None is not a skip", comparison(
+        [turn(user_msg(), llm_msg("a", 10, generation_id=None), llm_msg("b", 10))],
+    )
+
+    # tokens None only blows up conso when the llm IS known; with a legacy empty
+    # llm_id the conso is None and the row is produced with tokens_a=None.
+    yield "legacy llm + tokens None -> kept, conso None", comparison(
+        [turn(user_msg(), llm_msg("a", tokens=None), None)],
+        llm_id_a="",
+    )
+
+    yield "error present -> normalized + excluded", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        error={"message": "boom"},
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+
+    yield "custom_models_selection list serialization", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        mode="custom",
+        custom_models_selection=["model-a", "model-b"],
+        categories=["code"],
+        languages=["fr", "en"],
+        short_summary="a summary",
+    )
+
+    # excluded permutations
+    yield "kept: cohort set, analyzed, archived False", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+    yield "excluded: no cohort", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts=None,
+        llm_analyzed=True,
+        archived=False,
+    )
+    yield "excluded: archived True", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=True,
+        archived_reason="spam",
+    )
+    yield "excluded: not analyzed", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts="c",
+        llm_analyzed=False,
+        archived=False,
+    )
+
+    yield "multi-turn, b missing in one turn -> totals None", comparison(
+        [
+            turn(user_msg(), llm_msg("a1", 100), llm_msg("b1", 100)),
+            turn(user_msg(), llm_msg("a2", 100), None),
+        ],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+
+
+# --- cases the old pipeline skipped (both must raise) ----------------------
+
+
+def skip_cases():
+    # Known llm + tokens None -> conso math raises TypeError -> comparison
+    # dropped. This is the actual (incidental) skip behaviour of the old code.
+    yield "known llm + tokens None", comparison(
+        [turn(user_msg(), llm_msg("a", tokens=None), llm_msg("b", 10))],
+    )
+    # Present message with a missing timestamp -> latency math raises.
+    yield "llm missing responded_at", comparison(
+        [turn(user_msg(), llm_msg("a", 10, responded_at=None), llm_msg("b", 10))],
+    )
+    # User message with no content -> UserMessageRead validation fails.
+    yield "user message content None", comparison(
+        [turn(user_msg(content=None), llm_msg("a", 10), llm_msg("b", 10))],
+    )
+
+
+# --- runner ----------------------------------------------------------------
+
+
+def _raises(fn, comp):
+    try:
+        fn(comp)
+        return False
+    except Exception:
+        return True
+
+
+def run():
+    failures = []
+
+    for name, comp in equivalent_cases():
+        expected = oracle_comparison_to_turns(comp)
+        actual = compute.comparison_to_turns(comp)
+        if actual != expected:
+            failures.append(f"[VALUE] {name}")
+            for i, (a, e) in enumerate(zip(actual, expected)):
+                for k in set(a) | set(e):
+                    if a.get(k) != e.get(k):
+                        print(f"    DIFF row{i}.{k}: new={a.get(k)!r} old={e.get(k)!r}")
+        elif [list(r) for r in actual] != [list(r) for r in expected]:
+            failures.append(f"[KEY-ORDER] {name}")
+        else:
+            print(f"  ok  {name}  ({len(actual)} rows)")
+
+    for name, comp in skip_cases():
+        o, n = _raises(oracle_comparison_to_turns, comp), _raises(
+            compute.comparison_to_turns, comp
+        )
+        if not (o and n):
+            failures.append(f"[SKIP oracle={o} new={n}] {name}")
+        else:
+            print(f"  ok  skip: {name}")
+
+    print()
+    if failures:
+        print(f"FAILED ({len(failures)}):")
+        for f in failures:
+            print("   -", f)
+        sys.exit(1)
+    print("All equivalence cases passed.")
+
+
+# pytest entry points (if pytest is ever added)
+def test_equivalence():
+    for name, comp in equivalent_cases():
+        assert compute.comparison_to_turns(comp) == oracle_comparison_to_turns(
+            comp
+        ), name
+
+
+def test_skips():
+    for name, comp in skip_cases():
+        assert _raises(compute.comparison_to_turns, comp), name
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/dataset/test_streaming_export.py
+++ b/tests/dataset/test_streaming_export.py
@@ -1,0 +1,313 @@
+"""
+Equivalence test for the streaming exporter.
+
+Asserts that `StreamingDatasetExporter` (batched parquet row-groups,
+memory-bounded) produces the same `.parquet` as the old "accumulate everything
+into one DataFrame, then to_parquet" path, for both the `raw` dataset and the
+column-dropped/filtered `normal` dataset. Also checks the full `.jsonl` is no
+longer emitted (we dropped it) while the small sample previews still are.
+
+Forces several batches so cross-row-group schema coercion is exercised, and
+includes null-heavy nested columns (the case most likely to trip up a schema
+captured from the first batch).
+
+    uv run --group data python tests/dataset/test_streaming_export.py
+"""
+
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from utils.dataset.export import StreamingDatasetExporter
+
+
+def make_rows(n: int) -> list[dict]:
+    rows = []
+    for i in range(n):
+        excluded = i % 3 == 0
+        rows.append(
+            {
+                "response_id": f"r{i}",
+                "choice": "a_better" if i % 2 else None,
+                "response_a": [
+                    {"role": "user", "content": f"q{i}"},
+                    {
+                        "role": "assistant",
+                        "content": f"a{i}",
+                        "reasoning_content": None if i % 4 else f"think{i}",
+                    },
+                ],
+                "response_b": [{"role": "user", "content": f"q{i}"}],
+                "turn": i % 3,
+                "comparison_id": f"c{i}",
+                "model_a": "model-a",
+                "model_b": "model-b" if i % 5 else "",
+                "full_conversation_a": [{"role": "user", "content": f"q{i}"}],
+                "full_conversation_b": [{"role": "user", "content": f"q{i}"}],
+                "excluded": excluded,
+                "metadata": {
+                    "tokens_a": i,
+                    "tokens_b": None if i % 7 else i + 1,
+                    "conso_a": float(i) / 3,
+                    "total_conso_a": float(i),
+                    "mode": "random",
+                    "categories": ["code"] if i % 2 else None,
+                },
+                "extra_metadata": {
+                    "cohorts": None if excluded else "c",
+                    "archived": False,
+                    "llm_analyzed": True,
+                    "archived_reason": None,
+                },
+            }
+        )
+    return rows
+
+
+def old_export(rows, name, export_dir, *, keep, drop_columns):
+    """The previous single-shot parquet write, for comparison."""
+    df = pd.DataFrame([r for r in rows if keep(r)])
+    if drop_columns:
+        df = df.drop(columns=list(drop_columns))
+    df.to_parquet(export_dir / f"{name}.parquet")
+    return df
+
+
+def normalize(df: pd.DataFrame) -> pd.DataFrame:
+    # Streaming rows arrive in the same order as the old path (input order),
+    # so a plain reset_index comparison is valid.
+    return df.reset_index(drop=True)
+
+
+def check(name, keep, drop_columns, failures):
+    rows = make_rows(120)  # > 2 batches at batch_rows=50
+    with tempfile.TemporaryDirectory() as d_old, tempfile.TemporaryDirectory() as d_new:
+        d_old, d_new = Path(d_old), Path(d_new)
+
+        old_df = old_export(rows, name, d_old, keep=keep, drop_columns=drop_columns)
+
+        exp = StreamingDatasetExporter(
+            name, d_new, keep=keep, drop_columns=drop_columns, batch_rows=50
+        )
+        # Feed in several chunks to mimic the per-comparison streaming.
+        for i in range(0, len(rows), 7):
+            exp.add_rows(rows[i : i + 7])
+        exp.close()
+
+        old_pq = normalize(pd.read_parquet(d_old / f"{name}.parquet"))
+        new_pq = normalize(pd.read_parquet(d_new / f"{name}.parquet"))
+
+        # same columns, same order
+        if list(old_pq.columns) != list(new_pq.columns):
+            failures.append(
+                f"{name}: parquet columns differ "
+                f"{list(new_pq.columns)} != {list(old_pq.columns)}"
+            )
+            return
+        # same parquet schema (types matter for the published dataset)
+        old_schema = pd.read_parquet(d_old / f"{name}.parquet").dtypes.to_dict()
+        # compare via pyarrow schema for fidelity
+        import pyarrow.parquet as pq
+
+        s_old = pq.read_schema(d_old / f"{name}.parquet")
+        s_new = pq.read_schema(d_new / f"{name}.parquet")
+        if s_old.remove_metadata() != s_new.remove_metadata():
+            failures.append(
+                f"{name}: parquet SCHEMA differs:\n OLD {s_old}\n NEW {s_new}"
+            )
+            return
+        # same data
+        if not old_pq.equals(new_pq):
+            failures.append(f"{name}: parquet DATA differs")
+            return
+
+        # the full jsonl must NOT be produced anymore...
+        if (d_new / f"{name}.jsonl").exists():
+            failures.append(f"{name}: full {name}.jsonl should no longer be written")
+            return
+        # ...but the small sample previews must still be there.
+        for suffix in ("_samples.tsv", "_samples.jsonl"):
+            if not (d_new / f"{name}{suffix}").exists():
+                failures.append(f"{name}: missing sample file {name}{suffix}")
+                return
+
+        print(f"  ok  {name}  ({len(new_pq)} rows, parquet identical, no full jsonl)")
+
+
+def check_reference_schema(failures):
+    """
+    The streaming export fixes its parquet schema from `_reference_rows()`. That
+    reference MUST yield the exact same schema as real `comparison_to_turns`
+    output, otherwise the published schema would silently change. Build a
+    fully-populated comparison, compare its inferred schema to the reference's.
+    """
+    import pyarrow as pa
+
+    import tests.dataset.test_comparison_to_turns as fix
+    from utils.dataset import compute
+
+    full = fix.comparison(
+        [
+            fix.turn(
+                fix.user_msg("q"),
+                fix.llm_msg("a", 100, reasoning="r"),
+                fix.llm_msg("b", 90, reasoning="r"),
+                "a_better",
+            )
+        ],
+        sys_a=fix.system_msg("s"),
+        sys_b=fix.system_msg("s"),
+        mode="custom",
+        custom_models_selection=["model-a", "model-b"],
+        categories=["c"],
+        languages=["fr"],
+        short_summary="s",
+        cohorts="c",
+        error={"message": "e", "pos": "a", "is_timeout": False},
+        llm_analyzed=True,
+        contains_pii=False,
+        contains_spam=False,
+        archived=False,
+        archived_reason="spam",
+        archived_at=datetime(2024, 1, 1),
+    )
+    real = pa.Table.from_pandas(
+        pd.DataFrame(compute.comparison_to_turns(full)), preserve_index=False
+    ).schema
+    ref = pa.Table.from_pandas(
+        pd.DataFrame(compute._reference_rows()), preserve_index=False
+    ).schema
+    if not real.remove_metadata().equals(ref.remove_metadata()):
+        failures.append(
+            f"_reference_rows schema != real output:\n REAL {real}\n REF {ref}"
+        )
+    else:
+        print("  ok  reference schema matches real comparison_to_turns output")
+
+
+def check_temporal_nulls(failures):
+    """
+    Regression: columns that are null for the oldest rows (analysis fields,
+    custom_models_selection, …) and populated later must not break the stream.
+    With a reference schema the sparse-then-populated sequence must write fine;
+    without one it raises ArrowInvalid.
+    """
+    from utils.dataset import compute
+
+    def row(i, populated):
+        return {
+            "response_id": f"r{i}",
+            "choice": None,
+            "response_a": [{"role": "user", "content": "q"}],
+            "response_b": [{"role": "user", "content": "q"}],
+            "turn": 0,
+            "comparison_id": f"c{i}",
+            "model_a": "a",
+            "model_b": "b",
+            "full_conversation_a": [{"role": "user", "content": "q"}],
+            "full_conversation_b": [{"role": "user", "content": "q"}],
+            "excluded": False,
+            "metadata": {
+                "tokens_a": 1,
+                "tokens_b": None,
+                "conso_a": 1.0,
+                "conso_b": None,
+                "duration_a": 1.0,
+                "duration_b": None,
+                "latency_a": 1.0,
+                "latency_b": None,
+                "mode": "random",
+                "custom_models_selection": (["m"] if populated else None),
+                "categories": (["c"] if populated else None),
+                "languages": (["fr"] if populated else None),
+                "short_summary": ("s" if populated else None),
+                "total_tokens_a": 1,
+                "total_tokens_b": None,
+                "total_conso_a": 1.0,
+                "total_conso_b": None,
+            },
+            "extra_metadata": {
+                "cohorts": "c",
+                "error": None,
+                "llm_analyzed": (True if populated else None),
+                "contains_pii": (False if populated else None),
+                "contains_spam": (False if populated else None),
+                "archived": False,
+                "archived_reason": None,
+                "archived_at": None,
+            },
+        }
+
+    with tempfile.TemporaryDirectory() as d:
+        exp = StreamingDatasetExporter(
+            "t", Path(d), batch_rows=5, schema_rows=compute._reference_rows()
+        )
+        try:
+            exp.add_rows([row(i, populated=False) for i in range(5)])  # sparse first
+            exp.add_rows(
+                [row(i, populated=True) for i in range(5, 10)]
+            )  # populated later
+            exp.close()
+        except Exception as e:  # noqa: BLE001
+            failures.append(f"temporal-null stream raised {type(e).__name__}: {e}")
+            return
+        import pyarrow.parquet as pq
+
+        n = pq.ParquetFile(Path(d) / "t.parquet").metadata.num_rows
+        if n != 10:
+            failures.append(f"temporal-null stream wrote {n} rows, expected 10")
+        else:
+            print("  ok  temporal-null (sparse-then-populated) streams cleanly")
+
+
+def run():
+    failures = []
+    check("comparisons-raw", lambda r: True, (), failures)
+    check(
+        "comparisons",
+        lambda r: not r["excluded"],
+        ("excluded", "extra_metadata"),
+        failures,
+    )
+    check_reference_schema(failures)
+    check_temporal_nulls(failures)
+    print()
+    if failures:
+        print(f"FAILED ({len(failures)}):")
+        for f in failures:
+            print("  -", f)
+        sys.exit(1)
+    print("Streaming exporter matches the single-shot output.")
+
+
+def test_streaming_matches_single_shot():
+    failures = []
+    check("comparisons-raw", lambda r: True, (), failures)
+    check(
+        "comparisons",
+        lambda r: not r["excluded"],
+        ("excluded", "extra_metadata"),
+        failures,
+    )
+    assert not failures, failures
+
+
+def test_reference_schema_matches_real_output():
+    failures = []
+    check_reference_schema(failures)
+    assert not failures, failures
+
+
+def test_temporal_nulls_stream_cleanly():
+    failures = []
+    check_temporal_nulls(failures)
+    assert not failures, failures
+
+
+if __name__ == "__main__":
+    run()

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -121,13 +121,13 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
 
 async def build_dataframe() -> pd.DataFrame:
     llms = get_raw_llms_data()
-    dataset = pd.DataFrame()
+    all_turns: list[dict] = []
     failed_comparison_ids: list[str] = []
 
     async for db_comp in get_db_comparisons_stream():
         try:
             turns = comparison_to_turns(db_comp)
-            dataset = pd.concat([dataset, pd.DataFrame(turns)])
+            all_turns.extend(turns)
         except Exception as exc:
             logger.exception(f"Failed to parse Comparison '{db_comp.id}', skipping...")
             failed_comparison_ids.append(str(db_comp.id))
@@ -139,7 +139,7 @@ async def build_dataframe() -> pd.DataFrame:
             f"{len(failed_comparison_ids)} comparisons could not be properly parsed: \n{"\n".join([f"- '{id_}'" for id_ in failed_comparison_ids])}"
         )
 
-    return dataset
+    return pd.DataFrame(all_turns)
 
 
 def get_repo_infos() -> tuple[str, str]:

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -119,7 +119,11 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
     return turns
 
 
-async def build_dataframe() -> pd.DataFrame:
+async def build_dataframe(cache_path: Path | None = None) -> pd.DataFrame:
+    if cache_path and cache_path.exists():
+        logger.info(f"Loading dataframe from cache: {cache_path}")
+        return pd.read_pickle(cache_path)
+
     llms = get_raw_llms_data()
     all_turns: list[dict] = []
     failed_comparison_ids: list[str] = []
@@ -145,7 +149,13 @@ async def build_dataframe() -> pd.DataFrame:
             f"{len(failed_comparison_ids)} comparisons could not be properly parsed: \n{"\n".join([f"- '{id_}'" for id_ in failed_comparison_ids])}"
         )
 
-    return pd.DataFrame(all_turns)
+    df = pd.DataFrame(all_turns)
+
+    if cache_path:
+        logger.info(f"Saving dataframe cache to: {cache_path}")
+        df.to_pickle(cache_path)
+
+    return df
 
 
 def get_repo_infos() -> tuple[str, str]:
@@ -167,6 +177,7 @@ async def process_datasets(
     datasets: list[Datasets],
     export_base_path: Path,
     dry_run: bool = False,
+    cache_path: Path | None = None,
 ):
     """
     Process a single dataset: fetch from DB, transform (anonymize, add metadata),
@@ -184,7 +195,7 @@ async def process_datasets(
     logger.info(f"Folder defined for dataset: {export_base_path}")
     logger.info(f"Generating dataset dataframe…")
 
-    df = await build_dataframe()
+    df = await build_dataframe(cache_path=cache_path)
 
     # Check if data fetching failed
     if df.empty:

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -124,6 +124,7 @@ async def build_dataframe() -> pd.DataFrame:
     all_turns: list[dict] = []
     failed_comparison_ids: list[str] = []
 
+    n_comparisons = 0
     async for db_comp in get_db_comparisons_stream():
         try:
             turns = comparison_to_turns(db_comp)
@@ -131,8 +132,11 @@ async def build_dataframe() -> pd.DataFrame:
         except Exception as exc:
             logger.exception(f"Failed to parse Comparison '{db_comp.id}', skipping...")
             failed_comparison_ids.append(str(db_comp.id))
+        n_comparisons += 1
+        if n_comparisons % 10_000 == 0:
+            logger.info(f"Progress: {n_comparisons:,} comparisons processed, {len(all_turns):,} turns accumulated.")
 
-    logger.info("Finished generating dataframe.")
+    logger.info(f"Finished: {n_comparisons:,} comparisons, {len(all_turns):,} turns.")
 
     if failed_comparison_ids:
         logger.error(

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -136,7 +136,9 @@ async def build_dataframe() -> pd.DataFrame:
         if n_comparisons % 10_000 == 0:
             logger.info(f"Progress: {n_comparisons:,} comparisons processed, {len(all_turns):,} turns accumulated.")
 
-    logger.info(f"Finished: {n_comparisons:,} comparisons, {len(all_turns):,} turns.")
+    logger.info(
+        f"Finished: {n_comparisons:,} comparisons processed, {len(all_turns):,} turns accumulated, {len(failed_comparison_ids):,} skipped (validation error)."
+    )
 
     if failed_comparison_ids:
         logger.error(

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -190,6 +190,17 @@ async def process_datasets(
     if df.empty:
         raise Exception(f"Dataframe is empty, aborting export")
 
+    # Log exclusion breakdown before export
+    n_total = len(df)
+    n_excluded = int(df["excluded"].sum())
+    logger.info(f"Dataset breakdown: {n_total:,} total turns, {n_total - n_excluded:,} included (normal), {n_excluded:,} excluded.")
+
+    extra = pd.DataFrame(df["extra_metadata"].tolist())
+    for field in ("archived", "llm_analyzed", "cohorts"):
+        counts = extra[field].value_counts(dropna=False).to_dict()
+        logger.info(f"  [{field}] {counts}")
+    logger.info(f"  [error] has_error={extra['error'].notna().sum():,}")
+
     for dataset in datasets:
         repo_name = repo_prefix + ("-raw" if dataset == "raw" else "")
         logger.info(f"Generating '{repo_name}'…")

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -208,7 +208,7 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
     extra_meta = DatasetComparisonExtraMetadata.model_validate(comp).model_dump()
 
     excluded = bool(
-        not extra_meta["cohorts"]
+        extra_meta["cohorts"]
         or extra_meta["archived"] is not False
         or extra_meta["error"] is not None
         or extra_meta["llm_analyzed"] is not True

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -374,10 +374,73 @@ def get_repo_infos() -> tuple[str, str]:
         )
 
 
+def _write_normal_from_raw_parquet(
+    raw_parquet_path: Path,
+    repo_name: str,
+    export_dir: Path,
+) -> int:
+    """
+    Regenerate the normal dataset from the raw parquet without hitting the DB.
+    Stays in Arrow throughout (filter + drop + write) to avoid OOM from
+    converting large nested columns to Python objects.
+    Sample files are written from the first 1000 filtered rows (not random,
+    but fast and memory-bounded).
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+
+    DROP_COLS = ["excluded", "extra_metadata"]
+    SAMPLE_SIZE = 1000
+
+    export_dir.mkdir(exist_ok=True)
+    parquet_path = export_dir / f"{repo_name}.parquet"
+
+    reader = pq.ParquetFile(raw_parquet_path)
+    writer: pq.ParquetWriter | None = None
+    sample_batches: list[pa.Table] = []
+    n_rows = 0
+
+    for batch in reader.iter_batches(batch_size=10_000):
+        table = pa.Table.from_batches([batch])
+        table = table.filter(pc.equal(table.column("excluded"), False))
+        table = table.drop(DROP_COLS)
+
+        if len(table) == 0:
+            continue
+
+        if writer is None:
+            writer = pq.ParquetWriter(parquet_path, table.schema)
+        writer.write_table(table)
+
+        if n_rows < SAMPLE_SIZE:
+            needed = SAMPLE_SIZE - n_rows
+            sample_batches.append(table.slice(0, min(needed, len(table))))
+
+        n_rows += len(table)
+        logger.debug(f"Cache: {n_rows:,} rows written to normal parquet")
+
+    if writer:
+        writer.close()
+
+    if sample_batches:
+        import pandas as pd
+        sample_df = pa.concat_tables(sample_batches).to_pandas()
+        sample_df.to_csv(export_dir / f"{repo_name}_samples.tsv", sep="\t", index=False)
+        sample_df.to_json(
+            export_dir / f"{repo_name}_samples.jsonl",
+            orient="records", lines=True, date_format="iso",
+        )
+
+    logger.info(f"Cache mode: {n_rows:,} rows written ({len(sample_df) if sample_batches else 0:,} sampled).")
+    return n_rows
+
+
 async def process_datasets(
     datasets: list[Datasets],
     export_base_path: Path,
     dry_run: bool = False,
+    use_cache: bool = False,
 ):
     """
     Process a single dataset: fetch from DB, transform (anonymize, add metadata),
@@ -387,21 +450,37 @@ async def process_datasets(
         dataset_names: Names of the datasets to process
         export_base_path: Local directory for export
         dry_run: If True, skip HuggingFace upload
+        use_cache: If True and raw parquet exists, regenerate normal from it (skips DB)
     """
     logger.info(f"Starting processing datasets…")
 
     repo_org, repo_prefix = get_repo_infos()
+    raw_parquet_path = (
+        export_base_path / (repo_prefix + "-raw") / (repo_prefix + "-raw.parquet")
+    )
 
     logger.info(f"Folder defined for dataset: {export_base_path}")
-    logger.info(f"Streaming datasets to local files: {', '.join(datasets)}…")
 
-    exporters = _build_exporters(datasets, repo_prefix, export_base_path)
-    await stream_to_exporters(exporters)
-
-    for dataset, exporter in exporters.items():
-        repo_name = exporter.dataset_name
-        repo_path = export_base_path / repo_name
+    if use_cache and "normal" in datasets and raw_parquet_path.exists():
+        logger.info(f"Cache mode: reading from {raw_parquet_path}")
+        normal_repo_name = repo_prefix
+        normal_export_dir = export_base_path / normal_repo_name
+        _write_normal_from_raw_parquet(raw_parquet_path, normal_repo_name, normal_export_dir)
         if dry_run:
-            logger.info(f"[DRY RUN] Skipping HuggingFace upload for '{repo_name}'")
+            logger.info(f"[DRY RUN] Skipping HuggingFace upload for '{normal_repo_name}'")
         else:
-            commit_and_push(repo_org, repo_name, repo_path)
+            commit_and_push(repo_org, normal_repo_name, normal_export_dir)
+    else:
+        if use_cache:
+            logger.warning(f"Cache requested but raw parquet not found at {raw_parquet_path}, running full export")
+        logger.info(f"Streaming datasets to local files: {', '.join(datasets)}…")
+        exporters = _build_exporters(datasets, repo_prefix, export_base_path)
+        await stream_to_exporters(exporters)
+
+        for dataset, exporter in exporters.items():
+            repo_name = exporter.dataset_name
+            repo_path = export_base_path / repo_name
+            if dry_run:
+                logger.info(f"[DRY RUN] Skipping HuggingFace upload for '{repo_name}'")
+            else:
+                commit_and_push(repo_org, repo_name, repo_path)

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -196,7 +196,7 @@ async def process_datasets(
         data = df[~df["excluded"]] if dataset == "normal" else df
 
         if dataset == "normal":
-            data = df.drop(columns=["excluded", "extra_metadata"])
+            data = data.drop(columns=["excluded", "extra_metadata"])
 
         repo_path = export_base_path / repo_name
         # Export data to local files

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -5,7 +5,7 @@ This script:
 1. Fetches Comparisons from the database
 2. Validate data with Dataset* models
 3. Filters out archived, errored, not analyzed and specific cohorts (Pix, do-not-track) for the public dataset
-4. Exports to multiple formats (parquet, jsonl, tsv samples)
+4. Exports to parquet (+ a small sample tsv/jsonl preview)
 5. Uploads to HuggingFace Hub repositories
 
 Usage:
@@ -16,22 +16,22 @@ Required env vars: COMPARIA_DB_URI, HF_PUSH_DATASET_KEY (if not --dry-run)
 
 import json
 import logging
+from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
 
-import pandas as pd
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import and_, col
 
 from backend.config import settings
 from backend.llms.models import LLMData
 from utils.database.models import Comparison
+from utils.database.models.messages import LLMMessage
 from utils.database.utils import get_db_comparisons_counts, get_db_comparisons_stream
 from utils.utils import LLMS_GENERATED_DATA_FILE, read_json
 
-from .export import commit_and_push, export_data
+from .export import StreamingDatasetExporter, commit_and_push
 from .models import (
-    DatasetComparison,
     DatasetComparisonBaseMetadata,
     DatasetComparisonExtraMetadata,
     Datasets,
@@ -84,78 +84,279 @@ async def count_dataset_rows(datasets: list[Datasets]):
         raise
 
 
-def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
-    llms = get_raw_llms_data()
-    ctx = {
-        # .get() tolerates empty/unknown llm_id (legacy comparisons)
-        "llm_a": llms.get(db_comparison.llm_id_a),
-        "llm_b": llms.get(db_comparison.llm_id_b),
-        "metadata": DatasetComparisonBaseMetadata.model_validate(
-            db_comparison
-        ).model_dump(),
-        "extra_metadata": DatasetComparisonExtraMetadata.model_validate(
-            db_comparison
-        ).model_dump(),
-    }
-    comparison = DatasetComparison.model_validate(db_comparison, context=ctx)
-    comp_data = comparison.model_dump()
-    comp_meta = comp_data.pop("metadata_")
-    comp_extra_meta = comp_data.pop("extra_metadata_")
-    comp_turns = comp_data.pop("turns_")
+def _conso(llm: LLMData | None, msg: LLMMessage | None) -> float | None:
+    # None for legacy comparisons with empty/unknown llm_id, or no answer.
+    if llm is None or msg is None:
+        return None
+    return (llm.wh_per_million_token / 1_000_000) * msg.tokens / 1_000
 
-    turns = []
-    for idx, turn_data in enumerate(comp_turns):
-        turn_meta = turn_data.pop("metadata_")
-        turns.append(
+
+def _latency(msg: LLMMessage | None) -> float | None:
+    return (msg.responded_at - msg.created_at).total_seconds() if msg else None
+
+
+def _duration(msg: LLMMessage | None) -> float | None:
+    return (msg.updated_at - msg.responded_at).total_seconds() if msg else None
+
+
+def _total(turns_metadata: list[dict], key: str) -> float | int | None:
+    # Sum across turns, but only when every turn has the value.
+    values = [meta[key] for meta in turns_metadata]
+    return sum(values) if all(v is not None for v in values) else None
+
+
+def _llm_response_entry(msg: LLMMessage) -> dict:
+    # Raw values on purpose: the ORM LLMMessage is already an LLMMessageFinal
+    # instance, so the old pipeline's nested validation never re-ran (Pydantic
+    # revalidate_instances="never"): no stripping, no constraint checks. The
+    # only comparisons it dropped were those that hit a TypeError in the
+    # tokens/latency/duration math below, which we reproduce by construction.
+    return {
+        "role": msg.role,
+        "content": msg.content,
+        "reasoning_content": msg.reasoning_content,
+    }
+
+
+def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
+    """
+    Flatten a Comparison into one row per turn.
+
+    Reads ORM attributes directly instead of routing the whole nested object
+    graph (turns, user/assistant/system messages, full conversations) through
+    Pydantic validate+dump, which was the dominant cost on large exports. The
+    flat metadata blocks still go through their Pydantic models so their
+    serialization stays byte-for-byte identical. The equivalence with the old
+    pipeline is pinned by tests/dataset/test_comparison_to_turns.py.
+    """
+    comp = db_comparison
+    llms = get_raw_llms_data()
+    llm_a = llms.get(comp.llm_id_a)  # .get() tolerates empty/unknown llm_id
+    llm_b = llms.get(comp.llm_id_b)
+
+    # A side's full conversation opens with its system prompt (when present),
+    # then alternates user / assistant for every turn.
+    if comp.system_msg_a and comp.system_msg_a.content is None:
+        raise ValueError("System message A has no content")
+    if comp.system_msg_b and comp.system_msg_b.content is None:
+        raise ValueError("System message B has no content")
+
+    full_conversation_a: list[dict] = (
+        [{"role": comp.system_msg_a.role, "content": comp.system_msg_a.content}]
+        if comp.system_msg_a
+        else []
+    )
+    full_conversation_b: list[dict] = (
+        [{"role": comp.system_msg_b.role, "content": comp.system_msg_b.content}]
+        if comp.system_msg_b
+        else []
+    )
+
+    partial_rows: list[dict] = []
+    turns_metadata: list[dict] = []
+
+    for turn in comp.turns:
+        if turn.user_msg is None or turn.user_msg.content is None:
+            raise ValueError("Turn has no user message")
+
+        msg_a, msg_b = turn.llm_msg_a, turn.llm_msg_b
+
+        user_entry = {"role": turn.user_msg.role, "content": turn.user_msg.content}
+        response_a = [user_entry] + ([_llm_response_entry(msg_a)] if msg_a else [])
+        response_b = [user_entry] + ([_llm_response_entry(msg_b)] if msg_b else [])
+        full_conversation_a.extend(response_a)
+        full_conversation_b.extend(response_b)
+
+        # Keys are emitted in DatasetTurnMetadata field order so the output
+        # matches the old model_dump (the equivalence test pins this).
+        turns_metadata.append(
             {
-                **turn_data,
-                "turn": idx,
-                **comp_data,
-                "metadata": {**turn_meta, **comp_meta},
-                "extra_metadata": comp_extra_meta,
+                "tokens_a": msg_a.tokens if msg_a else None,
+                "tokens_b": msg_b.tokens if msg_b else None,
+                "conso_a": _conso(llm_a, msg_a),
+                "conso_b": _conso(llm_b, msg_b),
+                "duration_a": _duration(msg_a),
+                "duration_b": _duration(msg_b),
+                "latency_a": _latency(msg_a),
+                "latency_b": _latency(msg_b),
+            }
+        )
+        partial_rows.append(
+            {
+                "response_id": str(turn.id),
+                "choice": turn.choice,
+                "response_a": response_a,
+                "response_b": response_b,
             }
         )
 
-    return turns
+    if not partial_rows:
+        return []
+
+    # base_meta and extra_meta still go through their models: they read raw ORM
+    # columns that need coercion (e.g. custom_models_selection tuple, error ->
+    # ErrorDetails). The totals are appended in DatasetComparisonMetadata field
+    # order so the merged dict matches the old model_dump output exactly.
+    base_meta = DatasetComparisonBaseMetadata.model_validate(comp).model_dump()
+    comp_meta = {
+        **base_meta,
+        "total_tokens_a": _total(turns_metadata, "tokens_a"),
+        "total_tokens_b": _total(turns_metadata, "tokens_b"),
+        "total_conso_a": _total(turns_metadata, "conso_a"),
+        "total_conso_b": _total(turns_metadata, "conso_b"),
+    }
+    extra_meta = DatasetComparisonExtraMetadata.model_validate(comp).model_dump()
+
+    excluded = bool(
+        not extra_meta["cohorts"]
+        or extra_meta["archived"] is not False
+        or extra_meta["error"] is not None
+        or extra_meta["llm_analyzed"] is not True
+    )
+    comparison_id = str(comp.id)
+
+    return [
+        {
+            **row,
+            "turn": idx,
+            "comparison_id": comparison_id,
+            "model_a": comp.llm_id_a,
+            "model_b": comp.llm_id_b,
+            "full_conversation_a": full_conversation_a,
+            "full_conversation_b": full_conversation_b,
+            "excluded": excluded,
+            "metadata": {**turn_meta, **comp_meta},
+            "extra_metadata": extra_meta,
+        }
+        for idx, (row, turn_meta) in enumerate(zip(partial_rows, turns_metadata))
+    ]
 
 
-async def build_dataframe(cache_path: Path | None = None) -> pd.DataFrame:
-    if cache_path and cache_path.exists():
-        logger.info(f"Loading dataframe from cache: {cache_path}")
-        return pd.read_pickle(cache_path)
+def _reference_rows() -> list[dict]:
+    """
+    One fully-populated row, mirroring `comparison_to_turns` output exactly, used
+    to fix the parquet schema before streaming (see StreamingDatasetExporter).
+    Every nullable field carries a value here so the column types are known up
+    front instead of inferred from a first batch where they may be all-null.
+    The equivalence test pins that this matches real `comparison_to_turns` output.
+    """
+    user = {"role": "user", "content": "x"}
+    assistant = {"role": "assistant", "content": "x", "reasoning_content": "x"}
+    system = {"role": "system", "content": "x"}
+    return [
+        {
+            "response_id": "ref",
+            "choice": "a_better",
+            "response_a": [user, assistant],
+            "response_b": [user, assistant],
+            "turn": 0,
+            "comparison_id": "ref",
+            "model_a": "x",
+            "model_b": "x",
+            "full_conversation_a": [system, user, assistant],
+            "full_conversation_b": [system, user, assistant],
+            "excluded": False,
+            "metadata": {
+                "tokens_a": 1,
+                "tokens_b": 1,
+                "conso_a": 1.0,
+                "conso_b": 1.0,
+                "duration_a": 1.0,
+                "duration_b": 1.0,
+                "latency_a": 1.0,
+                "latency_b": 1.0,
+                "mode": "random",
+                "custom_models_selection": ["x"],
+                "categories": ["x"],
+                "languages": ["x"],
+                "short_summary": "x",
+                "total_tokens_a": 1,
+                "total_tokens_b": 1,
+                "total_conso_a": 1.0,
+                "total_conso_b": 1.0,
+            },
+            "extra_metadata": {
+                "cohorts": "x",
+                "error": {"message": "x", "pos": "a", "is_timeout": False},
+                "llm_analyzed": True,
+                "contains_pii": False,
+                "contains_spam": False,
+                "archived": False,
+                "archived_reason": "spam",
+                "archived_at": datetime(2024, 1, 1),
+            },
+        }
+    ]
 
-    llms = get_raw_llms_data()
-    all_turns: list[dict] = []
+
+def _build_exporters(
+    datasets: list[Datasets], repo_prefix: str, export_base_path: Path
+) -> dict[Datasets, StreamingDatasetExporter]:
+    schema_rows = _reference_rows()
+    exporters: dict[Datasets, StreamingDatasetExporter] = {}
+    for dataset in datasets:
+        repo_name = repo_prefix + ("-raw" if dataset == "raw" else "")
+        if dataset == "normal":
+            exporters[dataset] = StreamingDatasetExporter(
+                repo_name,
+                export_base_path / repo_name,
+                keep=lambda row: not row["excluded"],
+                drop_columns=("excluded", "extra_metadata"),
+                schema_rows=schema_rows,
+            )
+        else:
+            exporters[dataset] = StreamingDatasetExporter(
+                repo_name, export_base_path / repo_name, schema_rows=schema_rows
+            )
+    return exporters
+
+
+async def stream_to_exporters(
+    exporters: dict[Datasets, StreamingDatasetExporter],
+) -> None:
+    """
+    Single pass over the DB: turn each Comparison into rows and feed every
+    exporter (each keeps/drops what it needs). Nothing is accumulated in memory
+    beyond the exporters' batch buffers.
+    """
     failed_comparison_ids: list[str] = []
-
     n_comparisons = 0
+
     async for db_comp in get_db_comparisons_stream():
         try:
             turns = comparison_to_turns(db_comp)
-            all_turns.extend(turns)
-        except Exception as exc:
+        except Exception:
             logger.exception(f"Failed to parse Comparison '{db_comp.id}', skipping...")
             failed_comparison_ids.append(str(db_comp.id))
+            continue
+
+        for exporter in exporters.values():
+            exporter.add_rows(turns)
+
         n_comparisons += 1
         if n_comparisons % 10_000 == 0:
-            logger.info(f"Progress: {n_comparisons:,} comparisons processed, {len(all_turns):,} turns accumulated.")
+            written = ", ".join(
+                f"{name}={exp.total_rows:,}" for name, exp in exporters.items()
+            )
+            logger.info(
+                f"Progress: {n_comparisons:,} comparisons processed ({written})."
+            )
 
+    for exporter in exporters.values():
+        exporter.close()
+
+    total_rows = sum(exp.total_rows for exp in exporters.values())
     logger.info(
-        f"Finished: {n_comparisons:,} comparisons processed, {len(all_turns):,} turns accumulated, {len(failed_comparison_ids):,} skipped (validation error)."
+        f"Finished: {n_comparisons:,} comparisons processed, "
+        f"{len(failed_comparison_ids):,} skipped (validation error)."
     )
-
     if failed_comparison_ids:
         logger.error(
-            f"{len(failed_comparison_ids)} comparisons could not be properly parsed: \n{"\n".join([f"- '{id_}'" for id_ in failed_comparison_ids])}"
+            f"{len(failed_comparison_ids)} comparisons could not be properly parsed: \n"
+            + "\n".join(f"- '{id_}'" for id_ in failed_comparison_ids)
         )
-
-    df = pd.DataFrame(all_turns)
-
-    if cache_path:
-        logger.info(f"Saving dataframe cache to: {cache_path}")
-        df.to_pickle(cache_path)
-
-    return df
+    if total_rows == 0:
+        raise Exception("No rows produced, aborting export")
 
 
 def get_repo_infos() -> tuple[str, str]:
@@ -177,11 +378,10 @@ async def process_datasets(
     datasets: list[Datasets],
     export_base_path: Path,
     dry_run: bool = False,
-    cache_path: Path | None = None,
 ):
     """
     Process a single dataset: fetch from DB, transform (anonymize, add metadata),
-    Export to multiple formats (parquet, jsonl, samples), and push to HF Hub.
+    Export to parquet (+ sample tsv/jsonl preview), and push to HF Hub.
 
     Args:
         dataset_names: Names of the datasets to process
@@ -193,38 +393,14 @@ async def process_datasets(
     repo_org, repo_prefix = get_repo_infos()
 
     logger.info(f"Folder defined for dataset: {export_base_path}")
-    logger.info(f"Generating dataset dataframe…")
+    logger.info(f"Streaming datasets to local files: {', '.join(datasets)}…")
 
-    df = await build_dataframe(cache_path=cache_path)
+    exporters = _build_exporters(datasets, repo_prefix, export_base_path)
+    await stream_to_exporters(exporters)
 
-    # Check if data fetching failed
-    if df.empty:
-        raise Exception(f"Dataframe is empty, aborting export")
-
-    # Log exclusion breakdown before export
-    n_total = len(df)
-    n_excluded = int(df["excluded"].sum())
-    logger.info(f"Dataset breakdown: {n_total:,} total turns, {n_total - n_excluded:,} included (normal), {n_excluded:,} excluded.")
-
-    extra = pd.DataFrame(df["extra_metadata"].tolist())
-    for field in ("archived", "llm_analyzed", "cohorts"):
-        counts = extra[field].value_counts(dropna=False).to_dict()
-        logger.info(f"  [{field}] {counts}")
-    logger.info(f"  [error] has_error={extra['error'].notna().sum():,}")
-
-    for dataset in datasets:
-        repo_name = repo_prefix + ("-raw" if dataset == "raw" else "")
-        logger.info(f"Generating '{repo_name}'…")
-        data = df[~df["excluded"]] if dataset == "normal" else df
-
-        if dataset == "normal":
-            data = data.drop(columns=["excluded", "extra_metadata"])
-
+    for dataset, exporter in exporters.items():
+        repo_name = exporter.dataset_name
         repo_path = export_base_path / repo_name
-        # Export data to local files
-        export_data(data, repo_name, repo_path)
-
-        # Upload to HuggingFace Hub (skip if dry_run)
         if dry_run:
             logger.info(f"[DRY RUN] Skipping HuggingFace upload for '{repo_name}'")
         else:

--- a/utils/dataset/export.py
+++ b/utils/dataset/export.py
@@ -1,99 +1,160 @@
 import json
 import logging
+import random
 from datetime import datetime
 from pathlib import Path
+from typing import Callable, Iterable
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from huggingface_hub import HfApi
 
 logger = logging.getLogger("comparia.dataset")
 
-NESTED_COLUMNS = [
-    "response_a",
-    "response_b",
-    "full_conversation_a",
-    "full_conversation_b",
-    "metadata",
-    "extra_metadata",
-]
+# How many rows to buffer before flushing a parquet row group. Caps peak
+# memory: we never hold the whole dataset (or a full DataFrame copy) in RAM,
+# which is what made the old "accumulate everything then to_parquet" path swap
+# on large exports. This is also the parquet row-group size, so don't make it
+# tiny.
+BATCH_ROWS = 10_000
+SAMPLE_SIZE = 1000
+SAMPLE_SEED = 42
 
 
-def _serialize_nested(dataframe: pd.DataFrame) -> pd.DataFrame:
-    """Serialize nested columns (lists, dicts) to JSON strings for uniform parquet schema."""
-    df = dataframe.copy()
-    for col in NESTED_COLUMNS:
-        if col in df.columns:
-            df[col] = df[col].apply(lambda v: json.dumps(v, default=str) if v is not None else None)
-    return df
-
-
-def export_data(
-    dataframe: pd.DataFrame,
-    dataset_name: str,
-    export_dir: Path,
-) -> None:
+class StreamingDatasetExporter:
     """
-    Export DataFrame to multiple formats.
+    Write one dataset (parquet + a small sample tsv/jsonl) incrementally.
 
-    Generates:
-    - Full dataset: parquet, jsonl
-    - 1000-row sample: tsv, jsonl
+    Rows are pushed in as they are produced and flushed in batches, so memory
+    stays bounded regardless of dataset size. The parquet file is a single
+    file written as successive row groups.
+
+    Pass `schema_rows` (fully-populated example rows) to fix the parquet schema
+    up front. This matters because the export streams comparisons ordered by
+    `created_at`: columns added to the product later (analysis fields,
+    `custom_models_selection`, `error`, message `reasoning_content`, …) are all
+    null for long stretches of the oldest rows. Inferring the schema from the
+    first batch alone would type those columns as null and then fail when a
+    later batch populates them. With `schema_rows` the types are known before
+    any data is written. If omitted, the schema is inferred from the first batch
+    (fine for uniform inputs such as tests).
+
+    We do not emit the full multi-GB `{name}.jsonl`: nothing consumes it (the
+    parquet is the canonical format used by HuggingFace and our own tooling),
+    it would be ~70% of the published bytes, and serialising it was the export's
+    memory and time bottleneck. The tiny sample previews are still written.
     """
-    export_dir.mkdir(exist_ok=True)
 
-    logger.info(f"Exporting data for dataset: '{dataset_name}'")
-    try:
-        serialized = _serialize_nested(dataframe)
+    def __init__(
+        self,
+        dataset_name: str,
+        export_dir: Path,
+        *,
+        keep: Callable[[dict], bool] = lambda row: True,
+        drop_columns: tuple[str, ...] = (),
+        schema_rows: list[dict] | None = None,
+        batch_rows: int = BATCH_ROWS,
+    ):
+        self.dataset_name = dataset_name
+        self.export_dir = export_dir
+        self.keep = keep
+        self.drop_columns = drop_columns
+        self.batch_rows = batch_rows
 
-        # Full dataset exports
-        logger.debug(f"  Writing '{dataset_name}.parquet'...")
-        serialized.to_parquet(f"{export_dir}/{dataset_name}.parquet", index=False)
+        export_dir.mkdir(exist_ok=True)
+        self._parquet_path = export_dir / f"{dataset_name}.parquet"
 
-        logger.debug(
-            f"  Writing '{dataset_name}.jsonl' (this may take several minutes for large datasets)..."
+        self._buffer: list[dict] = []
+        self._parquet_writer: pq.ParquetWriter | None = None
+        self._schema: pa.Schema | None = (
+            pa.Table.from_pandas(self._frame(schema_rows), preserve_index=False).schema
+            if schema_rows
+            else None
         )
-        chunk_size = 10_000
-        with open(f"{export_dir}/{dataset_name}.jsonl", "w") as f:
-            for i in range(0, len(serialized), chunk_size):
-                chunk = serialized.iloc[i : i + chunk_size]
-                chunk_json = chunk.to_json(
-                    orient="records", lines=True, date_format="iso"
-                )
-                f.write(chunk_json)
-                if i + chunk_size < len(serialized):
-                    f.write("\n")
-                if (i // chunk_size) % 10 == 0:
-                    logger.debug(
-                        f"    Progress: {i+len(chunk):,}/{len(serialized):,} rows"
-                    )
 
-        # Sample dataset exports (max 1000 rows)
-        logger.debug(f"  Creating sample ({min(len(serialized), 1000)} rows)...")
-        sample_df = serialized.sample(n=min(len(serialized), 1000), random_state=42)
+        # Reservoir sample (deterministic given input order and seed).
+        self._reservoir: list[dict] = []
+        self._reservoir_seen = 0
+        self._rng = random.Random(SAMPLE_SEED)
 
-        logger.debug(f"  Writing '{dataset_name}_samples.tsv'...")
+        self.total_rows = 0
+
+    def add_rows(self, rows: Iterable[dict]) -> None:
+        for row in rows:
+            if not self.keep(row):
+                continue
+            self._buffer.append(row)
+            self._sample(row)
+            self.total_rows += 1
+        if len(self._buffer) >= self.batch_rows:
+            self._flush()
+
+    def _frame(self, rows: list[dict]) -> pd.DataFrame:
+        # Drop columns once per DataFrame rather than rebuilding every row dict.
+        df = pd.DataFrame(rows)
+        if self.drop_columns:
+            df = df.drop(columns=list(self.drop_columns), errors="ignore")
+        return df
+
+    def _sample(self, row: dict) -> None:
+        self._reservoir_seen += 1
+        if len(self._reservoir) < SAMPLE_SIZE:
+            self._reservoir.append(row)
+        else:
+            j = self._rng.randint(0, self._reservoir_seen - 1)
+            if j < SAMPLE_SIZE:
+                self._reservoir[j] = row
+
+    def _flush(self) -> None:
+        if not self._buffer:
+            return
+        df = self._frame(self._buffer)
+
+        if self._schema is None:
+            # No reference schema given: infer from the first batch and reuse it.
+            self._schema = pa.Table.from_pandas(df, preserve_index=False).schema
+        # Coerce every batch to the fixed schema. A batch that genuinely can't
+        # conform raises loudly rather than producing a silently corrupt file.
+        table = pa.Table.from_pandas(df, schema=self._schema, preserve_index=False)
+        if self._parquet_writer is None:
+            self._parquet_writer = pq.ParquetWriter(self._parquet_path, self._schema)
+        self._parquet_writer.write_table(table)
+
+        self._buffer.clear()
+        logger.debug(f"  '{self.dataset_name}': {self.total_rows:,} rows written")
+
+    def close(self) -> None:
+        self._flush()
+        if self._parquet_writer is not None:
+            self._parquet_writer.close()
+
+        sample_df = self._frame(self._reservoir)
         sample_df.to_csv(
-            f"{export_dir}/{dataset_name}_samples.tsv", sep="\t", index=False
+            self.export_dir / f"{self.dataset_name}_samples.tsv", sep="\t", index=False
         )
-
-        logger.debug(f"  Writing '{dataset_name}_samples.jsonl'...")
         sample_df.to_json(
-            f"{export_dir}/{dataset_name}_samples.jsonl",
+            self.export_dir / f"{self.dataset_name}_samples.jsonl",
             orient="records",
             lines=True,
             date_format="iso",
         )
-
-        logger.info(f"Export completed for dataset: '{dataset_name}'")
-    except Exception as exc:
-        logger.error(f"Failed to export data for dataset '{dataset_name}'.")
-        raise
+        logger.info(
+            f"Export completed for dataset '{self.dataset_name}' "
+            f"({self.total_rows:,} rows, {len(self._reservoir):,} sampled)."
+        )
 
 
 def commit_and_push(repo_org: str, repo_name: str, repo_path: Path):
     """
     Upload exported files to HuggingFace Hub repository.
     Uses HF upload_folder method with timestamped commit message.
+
+    `delete_patterns=["*.jsonl"]` makes each push self-healing: any full
+    `*.jsonl` already on the remote (we no longer produce one) is removed in the
+    same commit. The `_samples.jsonl` preview is re-uploaded in this same commit,
+    so it is kept (uploaded files take precedence over the delete pattern). On a
+    fresh repo this is simply a no-op.
     """
     commit_message = f"Update data files {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
     logger.info(
@@ -106,6 +167,7 @@ def commit_and_push(repo_org: str, repo_name: str, repo_path: Path):
             repo_id=f"{repo_org}/{repo_name}",
             repo_type="dataset",
             commit_message=commit_message,
+            delete_patterns=["*.jsonl"],
         )
         logger.info(
             f"Successfully pushed changes for '{repo_path}', commit: {commit_link}"

--- a/utils/dataset/export.py
+++ b/utils/dataset/export.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from huggingface_hub import HfApi
 
 logger = logging.getLogger("comparia.dataset")
@@ -26,7 +28,27 @@ def export_data(
     try:
         # Full dataset exports
         logger.debug(f"  Writing '{dataset_name}.parquet'...")
-        dataframe.to_parquet(f"{export_dir}/{dataset_name}.parquet")
+        parquet_path = f"{export_dir}/{dataset_name}.parquet"
+        chunk_size = 50_000
+
+        # Pass 1: unify schema across all chunks (handles null-typed columns in early chunks)
+        schema = None
+        for i in range(0, len(dataframe), chunk_size):
+            chunk_schema = pa.Table.from_pandas(dataframe.iloc[i : i + chunk_size]).schema
+            schema = pa.unify_schemas([schema, chunk_schema]) if schema else chunk_schema
+
+        # Pass 2: write with the unified schema
+        writer = None
+        try:
+            for i in range(0, len(dataframe), chunk_size):
+                chunk = dataframe.iloc[i : i + chunk_size]
+                table = pa.Table.from_pandas(chunk, schema=schema)
+                if writer is None:
+                    writer = pq.ParquetWriter(parquet_path, schema)
+                writer.write_table(table)
+        finally:
+            if writer:
+                writer.close()
 
         logger.debug(
             f"  Writing '{dataset_name}.jsonl' (this may take several minutes for large datasets)..."

--- a/utils/dataset/export.py
+++ b/utils/dataset/export.py
@@ -1,13 +1,30 @@
+import json
 import logging
 from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
-import pyarrow as pa
-import pyarrow.parquet as pq
 from huggingface_hub import HfApi
 
 logger = logging.getLogger("comparia.dataset")
+
+NESTED_COLUMNS = [
+    "response_a",
+    "response_b",
+    "full_conversation_a",
+    "full_conversation_b",
+    "metadata",
+    "extra_metadata",
+]
+
+
+def _serialize_nested(dataframe: pd.DataFrame) -> pd.DataFrame:
+    """Serialize nested columns (lists, dicts) to JSON strings for uniform parquet schema."""
+    df = dataframe.copy()
+    for col in NESTED_COLUMNS:
+        if col in df.columns:
+            df[col] = df[col].apply(lambda v: json.dumps(v, default=str) if v is not None else None)
+    return df
 
 
 def export_data(
@@ -26,52 +43,33 @@ def export_data(
 
     logger.info(f"Exporting data for dataset: '{dataset_name}'")
     try:
+        serialized = _serialize_nested(dataframe)
+
         # Full dataset exports
         logger.debug(f"  Writing '{dataset_name}.parquet'...")
-        parquet_path = f"{export_dir}/{dataset_name}.parquet"
-        chunk_size = 50_000
-
-        # Pass 1: unify schema across all chunks (handles null-typed columns in early chunks)
-        schema = None
-        for i in range(0, len(dataframe), chunk_size):
-            chunk_schema = pa.Table.from_pandas(dataframe.iloc[i : i + chunk_size]).schema
-            schema = pa.unify_schemas([schema, chunk_schema]) if schema else chunk_schema
-
-        # Pass 2: write with the unified schema
-        writer = None
-        try:
-            for i in range(0, len(dataframe), chunk_size):
-                chunk = dataframe.iloc[i : i + chunk_size]
-                table = pa.Table.from_pandas(chunk, schema=schema)
-                if writer is None:
-                    writer = pq.ParquetWriter(parquet_path, schema)
-                writer.write_table(table)
-        finally:
-            if writer:
-                writer.close()
+        serialized.to_parquet(f"{export_dir}/{dataset_name}.parquet", index=False)
 
         logger.debug(
             f"  Writing '{dataset_name}.jsonl' (this may take several minutes for large datasets)..."
         )
-        # Write in chunks to avoid OOM for large datasets
         chunk_size = 10_000
         with open(f"{export_dir}/{dataset_name}.jsonl", "w") as f:
-            for i in range(0, len(dataframe), chunk_size):
-                chunk = dataframe.iloc[i : i + chunk_size]
+            for i in range(0, len(serialized), chunk_size):
+                chunk = serialized.iloc[i : i + chunk_size]
                 chunk_json = chunk.to_json(
                     orient="records", lines=True, date_format="iso"
                 )
                 f.write(chunk_json)
-                if i + chunk_size < len(dataframe):
+                if i + chunk_size < len(serialized):
                     f.write("\n")
                 if (i // chunk_size) % 10 == 0:
                     logger.debug(
-                        f"    Progress: {i+len(chunk):,}/{len(dataframe):,} rows"
+                        f"    Progress: {i+len(chunk):,}/{len(serialized):,} rows"
                     )
 
         # Sample dataset exports (max 1000 rows)
-        logger.debug(f"  Creating sample ({min(len(dataframe), 1000)} rows)...")
-        sample_df = dataframe.sample(n=min(len(dataframe), 1000), random_state=42)
+        logger.debug(f"  Creating sample ({min(len(serialized), 1000)} rows)...")
+        sample_df = serialized.sample(n=min(len(serialized), 1000), random_state=42)
 
         logger.debug(f"  Writing '{dataset_name}_samples.tsv'...")
         sample_df.to_csv(

--- a/utils/dataset/models.py
+++ b/utils/dataset/models.py
@@ -178,7 +178,7 @@ class DatasetComparison(SQLModel):
     def excluded(self) -> bool:
         if any(
             [
-                not self.extra_metadata_.cohorts,
+                bool(self.extra_metadata_.cohorts),
                 self.extra_metadata_.archived is not False,
                 self.extra_metadata_.error is not None,
                 self.extra_metadata_.llm_analyzed is not True,

--- a/utils/dataset/run.py
+++ b/utils/dataset/run.py
@@ -21,6 +21,7 @@ async def main(
     dataset: Literal[Datasets, "all"] = "all",
     dry_run: bool = False,
     count: bool = False,
+    use_cache: bool = False,
 ):
     """
     Export ComparIA datasets from PostgreSQL to HuggingFace Hub.
@@ -50,7 +51,7 @@ async def main(
         logger.info("[DRY RUN] Skipping HuggingFace authentication")
 
     try:
-        await process_datasets(datasets, export_base_path, dry_run=dry_run)
+        await process_datasets(datasets, export_base_path, dry_run=dry_run, use_cache=use_cache)
 
         logger.info("Finished processing all datasets.")
     except KeyboardInterrupt:

--- a/utils/dataset/run.py
+++ b/utils/dataset/run.py
@@ -21,6 +21,7 @@ async def main(
     dataset: Literal[Datasets, "all"] = "all",
     dry_run: bool = False,
     count: bool = False,
+    cache_path: Path = Path("/tmp/comparia_dataset_cache.pkl"),
 ):
     """
     Export ComparIA datasets from PostgreSQL to HuggingFace Hub.
@@ -50,7 +51,7 @@ async def main(
         logger.info("[DRY RUN] Skipping HuggingFace authentication")
 
     try:
-        await process_datasets(datasets, export_base_path, dry_run=dry_run)
+        await process_datasets(datasets, export_base_path, dry_run=dry_run, cache_path=cache_path)
 
         logger.info("Finished processing all datasets.")
     except KeyboardInterrupt:

--- a/utils/dataset/run.py
+++ b/utils/dataset/run.py
@@ -21,7 +21,6 @@ async def main(
     dataset: Literal[Datasets, "all"] = "all",
     dry_run: bool = False,
     count: bool = False,
-    cache_path: Path = Path("/tmp/comparia_dataset_cache.pkl"),
 ):
     """
     Export ComparIA datasets from PostgreSQL to HuggingFace Hub.
@@ -51,7 +50,7 @@ async def main(
         logger.info("[DRY RUN] Skipping HuggingFace authentication")
 
     try:
-        await process_datasets(datasets, export_base_path, dry_run=dry_run, cache_path=cache_path)
+        await process_datasets(datasets, export_base_path, dry_run=dry_run)
 
         logger.info("Finished processing all datasets.")
     except KeyboardInterrupt:


### PR DESCRIPTION
The dataset export built the whole dataset in memory before writing anything, which is too slow and swaps on the full table (~500k comparisons). This reworks it to stream.

Each dataset now writes to parquet in row-group batches as rows come off the database, so peak memory stays flat instead of growing with the row count. The per-turn rows are built directly from the ORM objects instead of going back through Pydantic, which is most of the speedup. I also stopped writing the full conversations.jsonl: nothing reads it, the parquet is the canonical format, and it was the biggest file and the slowest step. The sample preview files stay.

Worth a close look in review: the parquet schema is now fixed from a reference row instead of inferred from the first batch. We stream oldest-first and the oldest comparisons predate the analysis fields, so inferring from the first batch types those columns as null and crashes once a later batch fills them. There are tests for that case and for the reference schema matching real output, so the published schema doesn't move.

I haven't run this against the production database yet. Before pointing the new repo at it I'd want a --dry-run on a real dump to check memory and diff the parquet against the current dataset.
