### PR TITLE
Add time-to-vote tracking and conversation timestamp to the dataset

### DIFF
--- a/backend/arena/services.py
+++ b/backend/arena/services.py
@@ -165,11 +165,12 @@ async def update_turn_vote(
 ) -> None:
     async with get_session() as session:
         db_turn = await _get_item(Turn, id, session)
-        data = (
-            {f"{k}_{vote.pos}": v for k, v in vote.model_dump().items()}
-            if isinstance(vote, TurnVoteAnnotate)
-            else vote.model_dump()
-        )
+        if isinstance(vote, TurnVoteAnnotate):
+            data = {f"{k}_{vote.pos}": v for k, v in vote.model_dump().items()}
+        else:
+            # A choice vote can only be cast once (enforced in the router), so
+            # this stamps the single moment the user decided.
+            data = {**vote.model_dump(), "voted_at": datetime.now()}
         db_turn.sqlmodel_update(data)
         session.add(db_turn)
         await session.commit()

--- a/tests/dataset/test_comparison_to_turns.py
+++ b/tests/dataset/test_comparison_to_turns.py
@@ -305,6 +305,23 @@ def equivalent_cases():
         archived=False,
     )
 
+    # voted_at set but one side never answered -> no "both finished" moment, so
+    # time_to_vote must be None (not computed off the single answer).
+    yield "voted but b missing -> time_to_vote None", comparison(
+        [
+            turn(
+                user_msg("q"),
+                llm_msg("a", 70),
+                None,
+                "a_better",
+                voted_at=datetime(2024, 1, 1, 12, 0, 10),
+            )
+        ],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+
     yield "multi-turn, b missing in one turn -> totals None", comparison(
         [
             turn(user_msg(), llm_msg("a1", 100), llm_msg("b1", 100)),
@@ -346,6 +363,49 @@ def _raises(fn, comp):
         return True
 
 
+def time_to_vote_value_cases():
+    # (name, comparison, expected time_to_vote). Pins the actual value, because
+    # equivalence alone can't catch a bug that lives in both code paths.
+    both = comparison(
+        [
+            turn(
+                user_msg("q"),
+                llm_msg("a", 70),  # updated_at 12:00:03
+                llm_msg("b", 80, updated_at=datetime(2024, 1, 1, 12, 0, 4)),
+                "a_better",
+                voted_at=datetime(2024, 1, 1, 12, 0, 10),
+            )
+        ],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+    one_sided = comparison(
+        [
+            turn(
+                user_msg("q"),
+                llm_msg("a", 70),
+                None,
+                "a_better",
+                voted_at=datetime(2024, 1, 1, 12, 0, 10),
+            )
+        ],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+    no_vote = comparison(
+        [turn(user_msg("q"), llm_msg("a", 70), llm_msg("b", 80))],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+    )
+    # both finished (later of 12:00:03 / 12:00:04) -> vote at 12:00:10 -> 6.0s
+    yield "both answered + voted", both, 6.0
+    yield "one side missing + voted", one_sided, None
+    yield "both answered, no vote", no_vote, None
+
+
 def run():
     failures = []
 
@@ -372,6 +432,13 @@ def run():
         else:
             print(f"  ok  skip: {name}")
 
+    for name, comp, expected in time_to_vote_value_cases():
+        got = compute.comparison_to_turns(comp)[0]["metadata"]["time_to_vote"]
+        if got != expected:
+            failures.append(f"[TIME_TO_VOTE {name}] got {got!r}, expected {expected!r}")
+        else:
+            print(f"  ok  time_to_vote: {name}  ({got!r})")
+
     print()
     if failures:
         print(f"FAILED ({len(failures)}):")
@@ -392,6 +459,12 @@ def test_equivalence():
 def test_skips():
     for name, comp in skip_cases():
         assert _raises(compute.comparison_to_turns, comp), name
+
+
+def test_time_to_vote_values():
+    for name, comp, expected in time_to_vote_value_cases():
+        got = compute.comparison_to_turns(comp)[0]["metadata"]["time_to_vote"]
+        assert got == expected, f"{name}: got {got!r}, expected {expected!r}"
 
 
 if __name__ == "__main__":

--- a/tests/dataset/test_comparison_to_turns.py
+++ b/tests/dataset/test_comparison_to_turns.py
@@ -111,12 +111,13 @@ def llm_msg(
     )
 
 
-def turn(user, a, b, choice=None):
+def turn(user, a, b, choice=None, voted_at=None):
     t = Turn(created_at=T0)
     t.user_msg = user
     t.llm_msg_a = a
     t.llm_msg_b = b
     t.choice = choice
+    t.voted_at = voted_at
     return t
 
 
@@ -285,6 +286,23 @@ def equivalent_cases():
         archived=False,
         contains_pii=False,
         contains_spam=False,
+    )
+
+    # voted_at set -> time_to_vote = voted_at - max(updated_at_a, updated_at_b).
+    # llm_msg updated_at defaults to 12:00:03; vote at 12:00:10 -> 7.0s.
+    yield "voted turn -> time_to_vote computed", comparison(
+        [
+            turn(
+                user_msg("q"),
+                llm_msg("a", 100),
+                llm_msg("b", 200),
+                "a_better",
+                voted_at=datetime(2024, 1, 1, 12, 0, 10),
+            )
+        ],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
     )
 
     yield "multi-turn, b missing in one turn -> totals None", comparison(

--- a/tests/dataset/test_streaming_export.py
+++ b/tests/dataset/test_streaming_export.py
@@ -158,6 +158,7 @@ def check_reference_schema(failures):
                 fix.llm_msg("a", 100, reasoning="r"),
                 fix.llm_msg("b", 90, reasoning="r"),
                 "a_better",
+                voted_at=datetime(2024, 1, 1, 12, 0, 5),
             )
         ],
         sys_a=fix.system_msg("s"),
@@ -209,6 +210,7 @@ def check_temporal_nulls(failures):
             "comparison_id": f"c{i}",
             "model_a": "a",
             "model_b": "b",
+            "timestamp": datetime(2024, 1, 1),
             "full_conversation_a": [{"role": "user", "content": "q"}],
             "full_conversation_b": [{"role": "user", "content": "q"}],
             "excluded": False,
@@ -221,6 +223,7 @@ def check_temporal_nulls(failures):
                 "duration_b": None,
                 "latency_a": 1.0,
                 "latency_b": None,
+                "time_to_vote": 1.0 if populated else None,
                 "mode": "random",
                 "custom_models_selection": (["m"] if populated else None),
                 "categories": (["c"] if populated else None),

--- a/utils/database/alembic/versions/89de92001a7e_merge_voted_at_and_web_search_results_.py
+++ b/utils/database/alembic/versions/89de92001a7e_merge_voted_at_and_web_search_results_.py
@@ -1,0 +1,29 @@
+"""merge voted_at and web_search_results heads
+
+Revision ID: 89de92001a7e
+Revises: a3f7c1e9b2d4, d9b83b7f2988
+Create Date: 2026-06-11 16:25:05.997998
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '89de92001a7e'
+down_revision: Union[str, Sequence[str], None] = ('a3f7c1e9b2d4', 'd9b83b7f2988')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/utils/database/alembic/versions/a3f7c1e9b2d4_add_turn_voted_at.py
+++ b/utils/database/alembic/versions/a3f7c1e9b2d4_add_turn_voted_at.py
@@ -1,0 +1,32 @@
+"""add Turn.voted_at
+
+Revision ID: a3f7c1e9b2d4
+Revises: 67e629fed515
+Create Date: 2026-06-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3f7c1e9b2d4'
+down_revision: Union[str, Sequence[str], None] = '67e629fed515'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'turn',
+        sa.Column('voted_at', postgresql.TIMESTAMP(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('turn', 'voted_at')

--- a/utils/database/models/comparison.py
+++ b/utils/database/models/comparison.py
@@ -32,6 +32,7 @@ ArchivedReason = Literal[
     # "duplicate",
     # "duplicate_has_vote",
     "spam",
+    "pii",
     "unknown_llm",
     "blacklist_grok",
     "unknown",

--- a/utils/database/models/turn.py
+++ b/utils/database/models/turn.py
@@ -14,7 +14,7 @@ from .messages import (
     UserMessage,
     UserMessageRead,
 )
-from .utils import AutoDatetime, ModelId
+from .utils import AutoDatetime, ModelId, OptionalDatetime
 
 if TYPE_CHECKING:
     from .comparison import Comparison
@@ -35,6 +35,9 @@ class TurnBase(SQLModel):
     created_at: AutoDatetime
     updated_at: AutoDatetime
     choice: Annotated[TurnChoice | None, Field(sa_type=String)] = None
+    # Set when the user submits their choice vote (once per turn). Used to
+    # measure how long they took to vote after both models finished.
+    voted_at: OptionalDatetime = None
 
     # a
     llm_msg_a_id: LLMMessageId = None

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -105,11 +105,12 @@ def _time_to_vote(
     voted_at: datetime | None, msg_a: LLMMessage | None, msg_b: LLMMessage | None
 ) -> float | None:
     # Seconds between both models finishing (the later of the two) and the vote.
-    # None when the turn was not voted on, or no answer carries a timestamp.
-    finished = [m.updated_at for m in (msg_a, msg_b) if m]
-    if voted_at is None or not finished:
+    # Requires both answers: a one-sided turn has no "both finished" moment, so
+    # we return None rather than a misleading value (legacy/corrupt rows can have
+    # voted_at set with a side missing, even though the live route forbids it).
+    if voted_at is None or msg_a is None or msg_b is None:
         return None
-    return (voted_at - max(finished)).total_seconds()
+    return (voted_at - max(msg_a.updated_at, msg_b.updated_at)).total_seconds()
 
 
 def _total(turns_metadata: list[dict], key: str) -> float | int | None:

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import and_, col
 
+from backend.arena.web_search import merge_web_search_with_content
 from backend.config import settings
 from backend.llms.models import LLMData
 from utils.database.models import Comparison
@@ -126,9 +127,9 @@ def _llm_response_entry(msg: LLMMessage) -> dict:
     # only comparisons it dropped were those that hit a TypeError in the
     # tokens/latency/duration math below, which we reproduce by construction.
     return {
-        "role": msg.role,
         "content": msg.content,
         "reasoning_content": msg.reasoning_content,
+        "role": msg.role,
     }
 
 
@@ -175,7 +176,13 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
 
         msg_a, msg_b = turn.llm_msg_a, turn.llm_msg_b
 
-        user_entry = {"role": turn.user_msg.role, "content": turn.user_msg.content}
+        raw_content = turn.user_msg.content
+        content = (
+            merge_web_search_with_content(raw_content, turn.user_msg.web_search_results)
+            if turn.user_msg.web_search_results
+            else raw_content
+        )
+        user_entry = {"role": turn.user_msg.role, "content": content, "user_content": raw_content}
         response_a = [user_entry] + ([_llm_response_entry(msg_a)] if msg_a else [])
         response_b = [user_entry] + ([_llm_response_entry(msg_b)] if msg_b else [])
         full_conversation_a.extend(response_a)
@@ -258,8 +265,8 @@ def _reference_rows() -> list[dict]:
     front instead of inferred from a first batch where they may be all-null.
     The equivalence test pins that this matches real `comparison_to_turns` output.
     """
-    user = {"role": "user", "content": "x"}
-    assistant = {"role": "assistant", "content": "x", "reasoning_content": "x"}
+    user = {"role": "user", "content": "x", "user_content": "x"}
+    assistant = {"content": "x", "reasoning_content": "x", "role": "assistant"}
     system = {"role": "system", "content": "x"}
     return [
         {

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -101,6 +101,17 @@ def _duration(msg: LLMMessage | None) -> float | None:
     return (msg.updated_at - msg.responded_at).total_seconds() if msg else None
 
 
+def _time_to_vote(
+    voted_at: datetime | None, msg_a: LLMMessage | None, msg_b: LLMMessage | None
+) -> float | None:
+    # Seconds between both models finishing (the later of the two) and the vote.
+    # None when the turn was not voted on, or no answer carries a timestamp.
+    finished = [m.updated_at for m in (msg_a, msg_b) if m]
+    if voted_at is None or not finished:
+        return None
+    return (voted_at - max(finished)).total_seconds()
+
+
 def _total(turns_metadata: list[dict], key: str) -> float | int | None:
     # Sum across turns, but only when every turn has the value.
     values = [meta[key] for meta in turns_metadata]
@@ -181,6 +192,7 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
                 "duration_b": _duration(msg_b),
                 "latency_a": _latency(msg_a),
                 "latency_b": _latency(msg_b),
+                "time_to_vote": _time_to_vote(turn.voted_at, msg_a, msg_b),
             }
         )
         partial_rows.append(
@@ -226,6 +238,7 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
             "comparison_id": comparison_id,
             "model_a": comp.llm_id_a,
             "model_b": comp.llm_id_b,
+            "timestamp": comp.created_at,
             "full_conversation_a": full_conversation_a,
             "full_conversation_b": full_conversation_b,
             "excluded": excluded,
@@ -257,6 +270,7 @@ def _reference_rows() -> list[dict]:
             "comparison_id": "ref",
             "model_a": "x",
             "model_b": "x",
+            "timestamp": datetime(2024, 1, 1),
             "full_conversation_a": [system, user, assistant],
             "full_conversation_b": [system, user, assistant],
             "excluded": False,
@@ -269,6 +283,7 @@ def _reference_rows() -> list[dict]:
                 "duration_b": 1.0,
                 "latency_a": 1.0,
                 "latency_b": 1.0,
+                "time_to_vote": 1.0,
                 "mode": "random",
                 "custom_models_selection": ["x"],
                 "categories": ["x"],

--- a/utils/dataset/models.py
+++ b/utils/dataset/models.py
@@ -32,6 +32,9 @@ class DatasetTurnMetadata(SQLModel):
     duration_b: float | None
     latency_a: float | None
     latency_b: float | None
+    # Seconds between both models finishing and the user casting their vote.
+    # None when the turn was not voted on (or timestamps are missing).
+    time_to_vote: float | None
 
 
 class DatasetComparisonBaseMetadata(SQLModel):
@@ -74,6 +77,9 @@ class DatasetTurn(SQLModel):
     llm_msg_a: Annotated[LLMMessageFinal | None, Field(exclude=True)]
     llm_msg_b: Annotated[LLMMessageFinal | None, Field(exclude=True)]
 
+    # Excluded, used to compute time_to_vote
+    voted_at: Annotated[datetime | None, Field(exclude=True)] = None
+
     # Extracted then merged with DatasetComparisonMetadata
     metadata_: Annotated[
         DatasetTurnMetadata, Field(default=None, validate_default=True)
@@ -97,6 +103,9 @@ class DatasetTurn(SQLModel):
         msg_a = info.data.get("llm_msg_a")
         llm_b = info.context["llm_b"]
         msg_b = info.data.get("llm_msg_b")
+
+        voted_at = info.data.get("voted_at")
+        finished = [m.updated_at for m in (msg_a, msg_b) if m]
 
         return {
             "tokens_a": msg_a.tokens if msg_a else None,
@@ -131,6 +140,11 @@ class DatasetTurn(SQLModel):
                 if msg_b
                 else None
             ),
+            "time_to_vote": (
+                (voted_at - max(finished)).total_seconds()
+                if (voted_at and finished)
+                else None
+            ),
         }
 
     # HELPERS
@@ -158,6 +172,7 @@ class DatasetComparison(SQLModel):
     comparison_id: Annotated[str, BeforeValidator(str), Field(validation_alias="id")]
     model_a: Annotated[str, Field(validation_alias="llm_id_a")]
     model_b: Annotated[str, Field(validation_alias="llm_id_b")]
+    timestamp: Annotated[datetime, Field(validation_alias="created_at")]
 
     # Extracted to build rows
     turns_: Annotated[list[DatasetTurn], Field(validation_alias="turns")]

--- a/utils/dataset/models.py
+++ b/utils/dataset/models.py
@@ -105,7 +105,6 @@ class DatasetTurn(SQLModel):
         msg_b = info.data.get("llm_msg_b")
 
         voted_at = info.data.get("voted_at")
-        finished = [m.updated_at for m in (msg_a, msg_b) if m]
 
         return {
             "tokens_a": msg_a.tokens if msg_a else None,
@@ -141,8 +140,8 @@ class DatasetTurn(SQLModel):
                 else None
             ),
             "time_to_vote": (
-                (voted_at - max(finished)).total_seconds()
-                if (voted_at and finished)
+                (voted_at - max(msg_a.updated_at, msg_b.updated_at)).total_seconds()
+                if (voted_at and msg_a and msg_b)
                 else None
             ),
         }

--- a/uv.lock
+++ b/uv.lock
@@ -487,16 +487,16 @@ wheels = [
 
 [[package]]
 name = "ecologits"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/39/22ae958fff6a877ac32449642dc56d055bc7054c9688a53613840d3afc53/ecologits-0.10.1.tar.gz", hash = "sha256:e4b4013e7132713e2b392559d3766f24df1ec4661580ca12f87f48adbb0263c7", size = 1011502, upload-time = "2026-04-09T12:17:50.668Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/7b/a8af782f0305bd08f6c61614680f9c4a70e4c30831bba435d5bab603bac4/ecologits-0.10.2.tar.gz", hash = "sha256:cdbd1f67a82d4008c6bb2d3373912f5f58fba4eedb25531972544b950bab5332", size = 1020789, upload-time = "2026-06-04T17:31:08.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/3c/cb9cf568b2fb0cc34be2230a780a301bdcde4299008efdc064ee11fef358/ecologits-0.10.1-py3-none-any.whl", hash = "sha256:5dc95f379e87f60025f6bcd28d50c84cbc8024fea3ada909480e74a2c7dd1d4b", size = 47075, upload-time = "2026-04-09T12:17:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6b/a6d8354a9816401f52f5a8a08b038cf525b40f2b4efddda41d72eb392eb4/ecologits-0.10.2-py3-none-any.whl", hash = "sha256:d98973a196566f640c8b213f371b44b6d0b11a4b49a9551d3771fee77ac798d7", size = 50769, upload-time = "2026-06-04T17:31:09.999Z" },
 ]
 
 [[package]]
@@ -1306,12 +1306,12 @@ devops = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "altcha", specifier = ">=1.0.0" },
-    { name = "ecologits", specifier = "==0.10.1" },
+    { name = "ecologits", specifier = "==0.10.2" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "google-auth", specifier = ">=2.38.0" },
     { name = "json5", specifier = ">=0.13.0" },
     { name = "linkup-sdk", specifier = ">=0.13.0" },
-    { name = "litellm", specifier = "==1.86.0" },
+    { name = "litellm", specifier = "==1.88.0" },
     { name = "markdown", specifier = ">=3.10.1" },
     { name = "numpy", specifier = ">=2.4.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
@@ -1418,7 +1418,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.86.0"
+version = "1.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1434,9 +1434,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/a7/26b8b04e4fcff26b60200ffe7458a255552ae51014468188f5db45674eb2/litellm-1.86.0.tar.gz", hash = "sha256:eccab86e0820b60b3f9484b233fb8d818b97afb19d5b4fa08d0d045621350ba4", size = 15379195, upload-time = "2026-05-24T02:42:10.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/8c/6cfce5d15554e076b8438a955436e9e6e2a2bd39c76539656c1c3861c369/litellm-1.88.0.tar.gz", hash = "sha256:4ff794493e40bd86c6f13e91dcb3e1aad697403fd46a96902196d93356ba48f4", size = 13886026, upload-time = "2026-06-06T23:25:17.93Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/0b/9a044c061a69e801de042e962c34f5bc2e094810e28b49ce0b3bedee9327/litellm-1.86.0-py3-none-any.whl", hash = "sha256:9d8171ca1a17705b7c7a6fdce8cfc07bbf641284b46c1b6047f83a779159990c", size = 17011225, upload-time = "2026-05-24T02:42:00.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/71/deb6637475253b83eb4577c058863eec4b4ddaef2d08dcd93981b1aa4209/litellm-1.88.0-py3-none-any.whl", hash = "sha256:abd3037e0bf5703f833f5565c87bdfd93578d3de46cbcb36dfa108c3ef58021c", size = 15276203, upload-time = "2026-06-06T23:25:07.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Two small additions to the exported dataset.

### Time to vote

We don't currently capture how long someone takes to decide once both models have answered. This adds it:

- New nullable `voted_at` column on `Turn`, stamped in `update_turn_vote` when a choice vote is recorded. Annotations (keyword tags, which happen after the vote) don't touch it, and the router already guarantees a single choice per turn, so it's an unambiguous timestamp.
- The export gains a per-turn `time_to_vote` in the turn metadata: seconds between the later of the two models finishing and the vote. It's `null` for turns that weren't voted on.

Heads up: there was no vote timestamp before, so `voted_at` can't be backfilled. It'll only have values for votes cast after this is deployed and the migration is applied; existing rows stay `null`.

### Conversation timestamp

Adds the conversation `created_at` to the exported rows as `timestamp`, so reusers have a date to filter and split on (the previous dataset had one and people relied on it).

## Notes

- `voted_at` is a nullable column, so the migration is forward-compatible.
- The fast export path (`compute.py`) and the Pydantic oracle (`models.py`) are kept identical, and the equivalence tests in `tests/dataset/` cover both new fields.
- Marked as draft for review of the field names (`time_to_vote`, `timestamp`) and whether we want both changes in one PR or split.