### PR TITLE
fix(dataset): filter out comparisons with contains_pii or contains_spam

### DIFF
--- a/tests/dataset/test_comparison_to_turns.py
+++ b/tests/dataset/test_comparison_to_turns.py
@@ -264,6 +264,28 @@ def equivalent_cases():
         llm_analyzed=False,
         archived=False,
     )
+    yield "excluded: contains_pii True", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+        contains_pii=True,
+    )
+    yield "excluded: contains_spam True", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+        contains_spam=True,
+    )
+    yield "kept: contains_pii False, contains_spam False", comparison(
+        [turn(user_msg(), llm_msg("a", 10), llm_msg("b", 10))],
+        cohorts="c",
+        llm_analyzed=True,
+        archived=False,
+        contains_pii=False,
+        contains_spam=False,
+    )
 
     yield "multi-turn, b missing in one turn -> totals None", comparison(
         [

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -70,6 +70,8 @@ async def count_dataset_rows(datasets: list[Datasets]):
                 "normal": and_(
                     col(Comparison.archived) == False,
                     col(Comparison.llm_analyzed) == True,
+                    col(Comparison.contains_pii) != True,
+                    col(Comparison.contains_spam) != True,
                     col(Comparison.error) == JSONB.NULL,
                     col(Comparison.cohorts).in_((None, "")),
                 ),
@@ -210,6 +212,8 @@ def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
     excluded = bool(
         extra_meta["cohorts"]
         or extra_meta["archived"] is not False
+        or extra_meta["contains_pii"]
+        or extra_meta["contains_spam"]
         or extra_meta["error"] is not None
         or extra_meta["llm_analyzed"] is not True
     )

--- a/utils/dataset/models.py
+++ b/utils/dataset/models.py
@@ -185,6 +185,8 @@ class DatasetComparison(SQLModel):
             [
                 bool(self.extra_metadata_.cohorts),
                 self.extra_metadata_.archived is not False,
+                bool(self.extra_metadata_.contains_pii),
+                bool(self.extra_metadata_.contains_spam),
                 self.extra_metadata_.error is not None,
                 self.extra_metadata_.llm_analyzed is not True,
             ]


### PR DESCRIPTION
The export exclusion logic only checked `archived`, missing cases where
legacy `contains_pii` or `contains_spam` were set to TRUE without `archived`
being set to TRUE.

Added explicit checks on both fields in `comparison_to_turns` and in the
`count_dataset_rows` SQL query. Updated the oracle model and added test cases.