### PR TITLE
feat(db): backfill pii and spam as archived

### DIFF
--- a/utils/database/actions/__init__.py
+++ b/utils/database/actions/__init__.py
@@ -1,4 +1,5 @@
 from .archive_blacklisted_grok import archive_blacklisted_grok
+from .backfill_pii_spam import backfill_pii_spam
 from .archive_corrupted import archive_corrupted
 from .archive_spam import archive_spam
 from .archive_unknown_llms import archive_unknown_llms

--- a/utils/database/actions/backfill_pii_spam.py
+++ b/utils/database/actions/backfill_pii_spam.py
@@ -1,0 +1,53 @@
+import logging
+from datetime import datetime
+
+from sqlmodel import and_, col, update
+
+from utils.database.models.comparison import Comparison
+from utils.database.session import get_session
+
+logger = logging.getLogger("comparia.db")
+
+
+async def backfill_pii_spam(*, commit: bool = False) -> None:
+    """
+    Backfill archived fields for comparisons with contains_pii=TRUE or contains_spam=TRUE.
+    Sets archived=TRUE, archived_reason='pii'|'spam', archived_at=now().
+    Only affects comparisons where archived IS NOT TRUE.
+    """
+    now = datetime.now()
+
+    async with get_session() as session:
+        pii_query = (
+            update(Comparison)
+            .where(
+                and_(
+                    col(Comparison.contains_pii) == True,
+                    col(Comparison.archived) != True,
+                )
+            )
+            .values(archived=True, archived_reason="pii", archived_at=now)
+        )
+        pii_result = await session.execute(pii_query)
+
+        spam_query = (
+            update(Comparison)
+            .where(
+                and_(
+                    col(Comparison.contains_spam) == True,
+                    col(Comparison.archived) != True,
+                )
+            )
+            .values(archived=True, archived_reason="spam", archived_at=now)
+        )
+        spam_result = await session.execute(spam_query)
+
+        if commit:
+            await session.commit()
+            logger.info(
+                f"Backfilled {pii_result.rowcount} pii and {spam_result.rowcount} spam comparisons."
+            )
+        else:
+            logger.error(
+                f"{pii_result.rowcount} pii and {spam_result.rowcount} spam comparisons should be archived (dry-run)."
+            )

--- a/utils/database/cli.py
+++ b/utils/database/cli.py
@@ -9,6 +9,7 @@ from .actions import (
     archive_corrupted,
     archive_spam,
     archive_unknown_llms,
+    backfill_pii_spam,
     llm_analyze,
     migrate_comparisons,
     migrate_llm_messages,
@@ -45,6 +46,7 @@ cli_db.command(lint)
 cli_db.command(log_archived)
 cli_db.command(rename_llm)
 cli_db.command(llm_analyze)
+cli_db.command(backfill_pii_spam)
 cli_db.command(cli_archive)
 cli_db.command(cli_migrate)
 


### PR DESCRIPTION
Adds `./comparia-cli db backfill-pii-spam` to archive comparisons where
`contains_pii` or `contains_spam` is TRUE but `archived` is not yet TRUE.

Sets `archived=TRUE`, `archived_reason='pii'|'spam'`, `archived_at=now()`.
Dry-run by default, `--commit` to apply.

Companion to the dataset export fix that added explicit `contains_pii`/`contains_spam`
checks to the exclusion logic.