### PR TITLE
fix(frontend): add missing SeoHead to homepage

### DIFF
--- a/frontend/src/routes/(pages)/+page.svelte
+++ b/frontend/src/routes/(pages)/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Accordion, AccordionGroup, Button, Checkbox, Icon, Link } from '$components/dsfr'
+  import SeoHead from '$components/SEOHead.svelte'
   import HowItWorks from '$components/HowItWorks.svelte'
   import Newsletter from '$components/Newsletter.svelte'
   import * as env from '$env/static/public'
@@ -144,6 +145,8 @@
     desc: m[`faq.${id}.questions.${index}.desc`]()
   }))
 </script>
+
+<SeoHead />
 
 <main id="content" class="">
   <section class="fr-container--fluid bg-light-grey pb-13 lg:pt-18 pt-10 lg:pb-28">


### PR DESCRIPTION
## Summary

- The homepage (`(pages)/+page.svelte`) had no `<SeoHead>` component, so no `<title>` tag was emitted
- Browsers fell back to displaying the domain name as the tab title
- On the Danish instance (`ai-arenaen.dk`) the title showed `comparia.beta.gouv.fr` instead of the site name

## Test plan

- [ ] Visit the homepage on the FR instance, check the tab title shows "compar:IA, le comparateur d'IA conversationnelles"
- [ ] Visit the homepage on the DA instance, check the tab title shows "compar:IA, arenaen for AI-chatbots"