### PR TITLE
Add style control to the ranking

### DIFF
--- a/backend/llms/models.py
+++ b/backend/llms/models.py
@@ -58,12 +58,14 @@ RoundInt = Annotated[int | float, AfterValidator(lambda n: round(n))]
 
 
 # TODO could be moved to 'utils/ranking'
-class DatasetData(BaseModel):
+class RankingVariant(BaseModel):
     """
-    Ranking/evaluation data from benchmark datasets.
+    A single Bradley-Terry ranking view (one set of Elo scores and ranks).
 
-    Contains Elo ratings and confidence intervals from model comparison datasets
-    (e.g., LMSYS arena, ComparIA own data).
+    The leaderboard ships two of these per model: the style-controlled view
+    (shown by default) and the plain view used when the user turns Style Control
+    off. They share the raw vote count but differ in Elo, ranks and win
+    probabilities once presentation features are regressed out.
 
     Attributes:
         elo: Estimated Elo rating (median/central estimate)
@@ -93,6 +95,21 @@ class DatasetData(BaseModel):
             self.rank - self.rank_p2_5,
             self.rank_p97_5 - self.rank,
         ]
+
+
+# TODO could be moved to 'utils/ranking'
+class DatasetData(RankingVariant):
+    """
+    Ranking/evaluation data exposed for a model.
+
+    The top-level fields are the style-controlled ranking (Style Control on,
+    the default). ``uncontrolled`` carries the plain Bradley-Terry ranking the
+    frontend swaps in when Style Control is toggled off, so the leaderboard can
+    switch views without a recompute. It is ``None`` for models that are
+    degenerate (never won or never lost) in the plain fit.
+    """
+
+    uncontrolled: RankingVariant | None = None
 
 
 # TODO could be moved to 'utils/ranking'

--- a/backend/llms/router.py
+++ b/backend/llms/router.py
@@ -36,4 +36,7 @@ async def get_available_models():
     return {
         "data_timestamp": data.timestamp,
         "models": models_list,
+        # Global style-control coefficients (one per presentation feature), for
+        # the transparency panel on the ranking page's methodology tab.
+        "style_coefficients": data.style_coefficients,
     }

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -2053,6 +2053,24 @@
                     "title": "Classement par taux de victoire"
                 }
             },
+            "style": {
+                "coef": {
+                    "footnote": "La longueur et les marqueurs markdown sont corrélés : ces coefficients se lisent conjointement, et non comme des effets indépendants pris isolément.",
+                    "hint": "Coefficients de la régression estimés sur l’ensemble des votes. Une valeur positive indique que cet axe de présentation est associé à une probabilité de victoire plus élevée une fois la force du modèle prise en compte. C’est précisément la part que le contrôle du style retire du classement.",
+                    "title": "Effet mesuré de la présentation"
+                },
+                "desc": {
+                    "1": "Un modèle peut grimper dans le classement simplement en répondant plus longuement ou avec une mise en forme plus riche (titres, gras, listes), sans être plus pertinent sur le fond. Le contrôle du style, inspiré du « Style Control » de LMArena, retire cet effet : une régression logistique sépare, dans chaque vote, ce qui revient à la force du modèle de ce qui revient à la présentation.",
+                    "2": "Le score affiché devient alors un Elo « débiaisé du style » : le classement que l’on obtiendrait si les deux réponses comparées étaient mises en forme de la même manière. Le contrôle du style est activé par défaut ; le bouton « Contrôle du style » en haut du tableau permet de revenir au classement Bradley-Terry brut pour comparer."
+                },
+                "features": {
+                    "length": "Longueur de la réponse",
+                    "md_bold": "Texte en gras",
+                    "md_headers": "Titres",
+                    "md_lists": "Listes à puces"
+                },
+                "title": "Contrôle du style : neutraliser l’effet de la présentation"
+            },
             "tabLabel": "Méthodologie",
             "title": "Comment choisir la méthode de classement des modèles ?"
         },
@@ -2089,6 +2107,10 @@
         "ranking": {
             "desc": "Merci pour vos contributions !<br> Le classement <strong>compar:IA</strong> repose sur l’ensemble des votes et réactions issus de la <strong>comparaison à l'aveugle </strong> des modèles et collectés depuis l’ouverture du service au public en octobre 2024.<br> Construit en partenariat avec le Pôle d'Expertise de la Régulation Numérique (<a {linkProps}>PEReN</a>), le classement des modèles est établi en fonction du <strong>score de satisfaction</strong> calculé à partir du modèle statistique <strong>Bradley Terry</strong>, méthode largement répandue pour convertir des votes binaires en classement probabiliste.<br> Le classement compar:IA n’a pas vocation à constituer une recommandation officielle ni à évaluer la performance technique des modèles. Il reflète les <strong>préférences subjectives</strong> des utilisateurs de la plateforme et non la factualité ou la véracité des réponses.",
             "tabLabel": "Classement"
+        },
+        "styleControl": {
+            "help": "Retire l’effet de la mise en forme (longueur de la réponse, titres, gras, listes) du classement, pour que le score reflète le fond plutôt que la présentation. Activé par défaut. Détails dans l’onglet Méthodologie.",
+            "label": "Contrôle du style"
         },
         "table": {
             "data": {

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -1,6 +1,7 @@
 import { ARCHS, LICENSES, MAYBE_ARCHS, MODELS, ORGANISATIONS } from '$lib/generated/models'
 import { getContext, setContext } from 'svelte'
 import { m } from './i18n/messages'
+import { styleControl } from './styleControl.svelte'
 
 export const SIZES = ['XS', 'S', 'M', 'L', 'XL'] as const
 export const CONSO_SIZES = ['S', 'M', 'L'] as const
@@ -14,7 +15,7 @@ export type License = (typeof LICENSES)[number]
 export type Organisation = (typeof ORGANISATIONS)[number]
 export type Model = (typeof MODELS)[number]
 
-interface DatasetData {
+interface RankingVariant {
   elo: number
   score_p2_5: number
   score_p97_5: number
@@ -25,6 +26,12 @@ interface DatasetData {
   mean_win_prob: number
   win_rate: number
   trust_range: [number, number]
+}
+
+interface DatasetData extends RankingVariant {
+  // Plain Bradley-Terry view, shown when Style Control is toggled off. Null for
+  // models that are degenerate (never won/lost) in the plain fit.
+  uncontrolled: RankingVariant | null
 }
 
 interface PreferencesData {
@@ -66,8 +73,16 @@ export interface APIBotModel {
   data: DatasetData | null
   prefs: PreferencesData | null
 }
-export type APIData = { data_timestamp: number; models: APIBotModel[] }
-export type Data = { lastUpdateDate: string | null; models: BotModel[] }
+export type APIData = {
+  data_timestamp: number
+  models: APIBotModel[]
+  style_coefficients?: Record<string, number>
+}
+export type Data = {
+  lastUpdateDate: string | null
+  models: BotModel[]
+  styleCoefficients: Record<string, number>
+}
 export type BotModel = ReturnType<typeof parseModel>
 export type BotModelWithData = BotModel & { data: DatasetData; prefs: PreferencesData }
 
@@ -157,12 +172,17 @@ export function setModelsContext(data: APIData) {
     lastUpdateDate: data.data_timestamp
       ? new Date(data.data_timestamp * 1000).toLocaleDateString()
       : null,
+    styleCoefficients: data.style_coefficients ?? {},
     models: data.models.map((model) => parseModel(model))
   })
 }
 
 export function getModelsContext() {
   return getContext<Data>('data')
+}
+
+export function getStyleCoefficients(): Record<string, number> {
+  return getContext<Data>('data').styleCoefficients ?? {}
 }
 
 export function getModelsWithDataContext() {
@@ -186,4 +206,23 @@ export function getModelsWithDataContext() {
         }
       }))
   }
+}
+
+/**
+ * Pick the ranking view that matches the current Style Control toggle and
+ * re-rank accordingly. Reads `styleControl.enabled` so callers that wrap it in a
+ * `$derived` update live when the toggle flips. With the toggle on (default) the
+ * style-controlled scores are kept; off swaps in each model's `uncontrolled`
+ * (plain Bradley-Terry) view. Either way models are re-sorted by the active Elo
+ * and ranks renumbered 1..N over the displayed set.
+ */
+export function applyStyleControl(models: BotModelWithData[]): BotModelWithData[] {
+  const enabled = styleControl.enabled
+  return models
+    .map((m) => {
+      const active = enabled || !m.data.uncontrolled ? m.data : m.data.uncontrolled
+      return { ...m, data: { ...active, uncontrolled: m.data.uncontrolled } }
+    })
+    .sort((a, b) => a.data.rank - b.data.rank)
+    .map((m, i) => ({ ...m, data: { ...m.data, rank: i + 1 } }))
 }

--- a/frontend/src/lib/styleControl.svelte.ts
+++ b/frontend/src/lib/styleControl.svelte.ts
@@ -1,0 +1,14 @@
+/**
+ * Global "Contrôle du style" (Style Control) toggle.
+ *
+ * On by default: the leaderboard shows the style-controlled Bradley-Terry
+ * ranking, where answer length and markdown formatting are regressed out so the
+ * score reflects substance over presentation. Turning it off swaps in the plain
+ * ranking (see `DatasetData.uncontrolled`). A module-level singleton so the
+ * choice is shared across every ranking view and survives tab switches.
+ */
+class StyleControl {
+  enabled = $state(true)
+}
+
+export const styleControl = new StyleControl()

--- a/frontend/src/routes/(pages)/ranking/+page.svelte
+++ b/frontend/src/routes/(pages)/ranking/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { Tabs } from '$components/dsfr'
+  import { Tabs, Toggle, Tooltip } from '$components/dsfr'
   import SeoHead from '$components/SEOHead.svelte'
   import { m } from '$lib/i18n/messages'
-  import { getModelsWithDataContext } from '$lib/models'
+  import { applyStyleControl, getModelsWithDataContext } from '$lib/models'
+  import { styleControl } from '$lib/styleControl.svelte'
   import { externalLinkProps, sanitize } from '$lib/utils/commons'
   import { downloadTextFile, sortIfDefined } from '$lib/utils/data'
   import { Energy, Methodology, RankingTable } from './components'
@@ -21,8 +22,18 @@
 
   const { lastUpdateDate, models: modelsData } = getModelsWithDataContext()
 
+  // Local mirror the DSFR Toggle binds to, pushed to the shared singleton that
+  // every ranking view reads (RankingTable, EnergyGraph, the CSV export).
+  let styleEnabled = $state(styleControl.enabled)
+  $effect(() => {
+    styleControl.enabled = styleEnabled
+  })
+
   function onDownloadData(kind: 'ranking' | 'energy') {
     if (modelsData.length === 0) return
+
+    // Export the view currently on screen (style-controlled or plain).
+    const viewData = applyStyleControl(modelsData)
 
     const csvCols = [
       { key: 'rank' as const, label: 'Rank' },
@@ -45,7 +56,7 @@
     const cols = kind === 'ranking' ? csvCols : csvCols.filter((col) => col.energy)
     const data = [
       cols.map((col) => col.label).join(','),
-      ...modelsData
+      ...viewData
         .sort((a, b) => sortIfDefined(a.data, b.data, 'elo'))
         .map((m) => {
           return cols
@@ -120,8 +131,9 @@
     <h1 class="fr-h3 mb-8!">{m['ranking.title']()}</h1>
 
     {#if lastUpdateDate}
-      <Tabs {tabs} noBorders kind="nav">
-        {#snippet tab({ id })}
+      <div class="relative">
+        <Tabs {tabs} noBorders kind="nav">
+          {#snippet tab({ id })}
           {#if id === 'ranking'}
             <p class="mb-12! text-dark-grey text-[14px]!">
               {@html sanitize(
@@ -136,11 +148,29 @@
             <Energy onDownloadData={() => onDownloadData('energy')} />
             <!-- {:else if id === 'preferences'}
           <Preferences onDownloadData={() => onDownloadPrefsData()} /> -->
-          {:else if id === 'methodo'}
-            <Methodology />
-          {/if}
-        {/snippet}
-      </Tabs>
+            {:else if id === 'methodo'}
+              <Methodology />
+            {/if}
+          {/snippet}
+        </Tabs>
+
+        <!-- Placed after the tabs in the DOM so it paints above the tab list and
+             stays clickable; absolutely positioned over the tab row on md+. -->
+        <div
+          class="z-10 mb-4 flex items-center gap-2 md:absolute md:top-0 md:right-0 md:mb-0"
+        >
+          <Toggle
+            id="style-control"
+            bind:value={styleEnabled}
+            label={m['ranking.styleControl.label']()}
+            hideCheckLabel
+            class="mb-0! whitespace-nowrap pr-13! font-medium text-[14px]!"
+          />
+          <Tooltip id="style-control-help" size="sm">
+            {@html sanitize(m['ranking.styleControl.help']())}
+          </Tooltip>
+        </div>
+      </div>
     {:else}
       <p>{m['ranking.no_data']()}</p>
     {/if}

--- a/frontend/src/routes/(pages)/ranking/components/EnergyGraph.svelte
+++ b/frontend/src/routes/(pages)/ranking/components/EnergyGraph.svelte
@@ -4,7 +4,7 @@
   import { ARCHS } from '$lib/generated/models'
   import { m } from '$lib/i18n/messages'
   import type { Archs, ConsoSizes, Sizes } from '$lib/models'
-  import { CONSO_SIZES, getModelsWithDataContext, SIZES } from '$lib/models'
+  import { applyStyleControl, CONSO_SIZES, getModelsWithDataContext, SIZES } from '$lib/models'
   import { sortIfDefined } from '$lib/utils/data'
   import { extent, ticks } from 'd3-array'
   import { scaleLinear } from 'd3-scale'
@@ -12,7 +12,8 @@
 
   type ModelGraphData = (typeof models)[number]
 
-  const { models: data } = getModelsWithDataContext()
+  const { models: baseModels } = getModelsWithDataContext()
+  const data = $derived(applyStyleControl(baseModels))
 
   const dotSizes = { XS: 5, S: 7, M: 9, L: 11, XL: 13 } as const
 

--- a/frontend/src/routes/(pages)/ranking/components/Methodology.svelte
+++ b/frontend/src/routes/(pages)/ranking/components/Methodology.svelte
@@ -1,13 +1,29 @@
 <script lang="ts">
   import { Icon, Link } from '$components/dsfr'
   import { m } from '$lib/i18n/messages'
-  import { getModelsWithDataContext, type BotModelWithData } from '$lib/models'
+  import {
+    getModelsWithDataContext,
+    getStyleCoefficients,
+    type BotModelWithData
+  } from '$lib/models'
   import { externalLinkProps, sanitize } from '$lib/utils/commons'
   import { downloadTextFile, sortIfDefined } from '$lib/utils/data'
   import { extent } from 'd3'
   import { WinHistogram } from '.'
 
   const { lastUpdateDate, models: data } = getModelsWithDataContext()
+
+  // Live style-control coefficients, in the documented feature order. A positive
+  // value means that presentation axis is associated with a higher win
+  // probability once model strength is accounted for, i.e. how much raw votes
+  // reward it; Style Control removes exactly this from the ranking.
+  const STYLE_FEATURE_KEYS = ['length', 'md_headers', 'md_bold', 'md_lists'] as const
+  const styleCoefficients = getStyleCoefficients()
+  const styleRows = STYLE_FEATURE_KEYS.filter((key) => key in styleCoefficients).map((key) => ({
+    key,
+    label: m[`ranking.methodo.style.features.${key}`](),
+    value: styleCoefficients[key]
+  }))
 
   type WinKey = 'mean_win_prob' | 'win_rate'
 
@@ -105,6 +121,47 @@
         </div>
       {/each}
     </div>
+  </section>
+
+  <section class="mt-16">
+    <h3 class="fr-h6 mb-4!">{m['ranking.methodo.style.title']()}</h3>
+    <p class="mb-4! text-dark-grey text-[14px]!">
+      {@html sanitize(m['ranking.methodo.style.desc.1']())}
+    </p>
+    <p class="mb-6! text-dark-grey text-[14px]!">
+      {@html sanitize(m['ranking.methodo.style.desc.2']())}
+    </p>
+
+    {#if styleRows.length > 0}
+      <div class="cg-border rounded-sm! max-w-[640px] bg-white p-6">
+        <h4 class="mb-1! text-lg!">{m['ranking.methodo.style.coef.title']()}</h4>
+        <p class="mb-5! text-dark-grey text-[13px]!">
+          {@html sanitize(m['ranking.methodo.style.coef.hint']())}
+        </p>
+
+        <ul class="m-0! p-0! list-none!">
+          {#each styleRows as row (row.key)}
+            <li
+              class="not-last:mb-3 not-last:border-b not-last:border-[--border-default-grey] flex items-center justify-between gap-4 pb-3"
+            >
+              <span class="text-[14px]">{row.label}</span>
+              <span
+                class={[
+                  'font-mono text-[14px] font-bold',
+                  row.value >= 0 ? 'text-info' : 'text-[--text-default-success]'
+                ]}
+              >
+                {row.value >= 0 ? '+' : ''}{row.value.toFixed(3)}
+              </span>
+            </li>
+          {/each}
+        </ul>
+
+        <p class="mt-5! mb-0! text-dark-grey text-[12px]!">
+          {@html sanitize(m['ranking.methodo.style.coef.footnote']())}
+        </p>
+      </div>
+    {/if}
   </section>
 
   <section class="mt-16">

--- a/frontend/src/routes/(pages)/ranking/components/RankingTable.svelte
+++ b/frontend/src/routes/(pages)/ranking/components/RankingTable.svelte
@@ -5,7 +5,7 @@
   import { getVotesContext } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale } from '$lib/i18n/runtime'
-  import { getModelsWithDataContext, type Archs } from '$lib/models'
+  import { applyStyleControl, getModelsWithDataContext, type Archs } from '$lib/models'
   import { sortIfDefined } from '$lib/utils/data'
 
   type ColKind =
@@ -45,7 +45,8 @@
 
   const votesData = getVotesContext()
   const totalVotes = $derived(NumberFormater.format(votesData.count))
-  const { lastUpdateDate, models: data } = getModelsWithDataContext()
+  const { lastUpdateDate, models: baseModels } = getModelsWithDataContext()
+  const data = $derived(applyStyleControl(baseModels))
   let selectedModel = $state<string>()
   const selectedModelData = $derived(data.find((m) => m.id === selectedModel))
 

--- a/tests/ranking/test_style_control.py
+++ b/tests/ranking/test_style_control.py
@@ -1,0 +1,122 @@
+"""
+Tests for the style-controlled Bradley-Terry solver (utils/ranking/style_control).
+
+Deterministic and DB-free. Runnable either way:
+    uv run python tests/ranking/test_style_control.py
+    pytest tests/ranking/test_style_control.py
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from utils.ranking.style_control import (  # noqa: E402
+    STYLE_FEATURES,
+    fit_style_controlled,
+    markdown_counts,
+    style_vector,
+)
+
+RICH = (
+    "## Heading\nIntro with **bold** and **strong** text.\n- a\n- b\n1. c\n" + "x" * 400
+)
+PLAIN = "Oui, c'est une bonne reponse."
+
+
+def test_markdown_counts():
+    headers, bold, lists = markdown_counts(RICH)
+    assert headers == 1
+    assert bold == 2  # two "**...**" spans; "__"-style is deliberately ignored
+    assert lists == 3  # two "-" items + one "1." item
+    # "__"-style bold is not counted, to avoid false positives on code like __init__
+    assert markdown_counts("call __init__ and __main__")[1] == 0
+    assert markdown_counts(None) == (0, 0, 0)
+    assert markdown_counts("") == (0, 0, 0)
+
+
+def test_style_vector_length_from_tokens():
+    v = style_vector(PLAIN, tokens=42)
+    assert v[0] == 42.0
+    assert style_vector(PLAIN, tokens=None)[0] == 0.0
+    assert style_vector(PLAIN, tokens=0)[0] == 0.0
+
+
+def _synthetic_battles(n=6000, seed=0):
+    """
+    Four equally-strong models. ``show_off`` formats richly 90% of the time, the
+    others 50%. The richer-formatted answer wins with probability 0.7,
+    independent of model identity -> a pure style effect that plain Bradley-Terry
+    would misattribute to ``show_off`` being a better model.
+    """
+    rng = np.random.default_rng(seed)
+    models = {"show_off": 0.9, "m1": 0.5, "m2": 0.5, "m3": 0.5}
+    names = list(models)
+    battles, style_a, style_b = [], [], []
+    for _ in range(n):
+        a, b = rng.choice(names, size=2, replace=False)
+        rich_a = rng.random() < models[a]
+        rich_b = rng.random() < models[b]
+        if rich_a == rich_b:
+            a_wins = rng.random() < 0.5
+        else:
+            richer_is_a = rich_a and not rich_b
+            a_wins = richer_is_a == (rng.random() < 0.7)
+        battles.append((a, b, a if a_wins else b))
+        style_a.append(style_vector(RICH if rich_a else PLAIN, 600 if rich_a else 15))
+        style_b.append(style_vector(RICH if rich_b else PLAIN, 600 if rich_b else 15))
+    return battles, np.array(style_a), np.array(style_b)
+
+
+def test_style_coefficients_positive():
+    battles, sa, sb = _synthetic_battles()
+    _, coeffs = fit_style_controlled(battles, sa, sb)
+    assert set(coeffs) == set(STYLE_FEATURES)
+    # richer formatting was constructed to help win -> positive style pressure
+    assert sum(coeffs.values()) > 0
+    assert all(np.isfinite(v) for v in coeffs.values())
+
+
+def test_style_control_deflates_inflated_model():
+    from utils.ranking.bradley_terry import fit_bradley_terry
+
+    battles, sa, sb = _synthetic_battles()
+    plain = fit_bradley_terry(battles)
+    controlled, _ = fit_style_controlled(battles, sa, sb)
+
+    # Plain BT over-credits the heavy formatter; style control moves it back
+    # toward the (equally strong) pack.
+    others = [m for m in controlled if m != "show_off"]
+    plain_gap = plain["show_off"] - np.mean([plain[m] for m in others])
+    ctrl_gap = controlled["show_off"] - np.mean([controlled[m] for m in others])
+    assert plain_gap > ctrl_gap
+    assert plain_gap > 15  # the bias is clearly visible without control
+
+
+def test_degenerate_models_return_nan():
+    # "always_wins" never loses -> Bradley-Terry MLE is degenerate -> NaN.
+    battles = [("always_wins", "loser", "always_wins")] * 50
+    battles += [("loser", "mid", "mid")] * 50
+    battles += [("mid", "other", "other")] * 50
+    battles += [("other", "loser", "other")] * 50
+    n = len(battles)
+    sa = np.ones((n, len(STYLE_FEATURES)))
+    sb = np.ones((n, len(STYLE_FEATURES)))
+    elo, _ = fit_style_controlled(battles, sa, sb)
+    assert np.isnan(elo["always_wins"])
+
+
+def test_empty_input():
+    elo, coeffs = fit_style_controlled([], np.empty((0, 4)), np.empty((0, 4)))
+    assert elo == {}
+    assert coeffs == {f: 0.0 for f in STYLE_FEATURES}
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\nAll {len(fns)} tests passed.")

--- a/tests/ranking/test_style_control.py
+++ b/tests/ranking/test_style_control.py
@@ -95,6 +95,36 @@ def test_style_control_deflates_inflated_model():
     assert plain_gap > 15  # the bias is clearly visible without control
 
 
+def test_matches_plain_bradley_terry_when_style_is_neutral():
+    from utils.ranking.bradley_terry import fit_bradley_terry
+
+    # Identical style on both sides of every battle -> the style regressors are
+    # all zero, so the style-controlled fit must reproduce the plain MM Bradley-
+    # Terry ranking. This guards the production swap of MM for this Newton solver:
+    # when presentation is neutral the leaderboard must not move.
+    battles, _, _ = _synthetic_battles()
+    n = len(battles)
+    flat = np.ones((n, len(STYLE_FEATURES)))
+
+    elo, coeffs = fit_style_controlled(battles, flat, flat)
+    plain = fit_bradley_terry(battles)
+
+    assert all(v == 0.0 for v in coeffs.values())  # no style signal to absorb
+    assert max(abs(elo[m] - plain[m]) for m in plain) < 0.01
+
+
+def test_style_regressor_is_antisymmetric():
+    from utils.ranking.style_control import _style_regressors
+
+    # Swapping the A and B answers must flip the regressor's sign exactly, the
+    # antisymmetry a Bradley-Terry style term requires (no mean-centering bias).
+    sa = np.array([[600.0, 2, 3, 4], [15.0, 0, 0, 0], [120.0, 1, 0, 2]])
+    sb = np.array([[15.0, 0, 0, 0], [300.0, 1, 1, 1], [120.0, 1, 0, 2]])
+    np.testing.assert_allclose(
+        _style_regressors(sa, sb), -_style_regressors(sb, sa), atol=1e-12
+    )
+
+
 def test_degenerate_models_return_nan():
     # "always_wins" never loses -> Bradley-Terry MLE is degenerate -> NaN.
     battles = [("always_wins", "loser", "always_wins")] * 50

--- a/utils/ranking/compute.py
+++ b/utils/ranking/compute.py
@@ -43,20 +43,34 @@ def _votes_to_battles(
     Convert vote records to decisive battle tuples plus aligned style vectors.
 
     Ties (both_good / both_bad) carry no winner and are dropped from the
-    Bradley-Terry fit. Returns ``(battles, style_a, style_b)`` where the two
-    arrays are (n_battles, n_features) raw style measurements row-aligned with
-    ``battles`` for the style-controlled solver.
+    Bradley-Terry fit. Decisive votes whose answers have no token count are also
+    dropped: a zero-length style vector would read as an extreme "minimal style"
+    signal rather than as missing data. Returns ``(battles, style_a, style_b)``
+    where the two arrays are (n_battles, n_features) raw style measurements
+    row-aligned with ``battles`` for the style-controlled solver.
     """
     battles: list[tuple[str, str, str]] = []
     style_a: list[np.ndarray] = []
     style_b: list[np.ndarray] = []
+    dropped_no_length = 0
     for v in votes:
         if v["choice"] not in ("a_better", "b_better"):
             continue
+        tokens_a, tokens_b = v.get("tokens_a"), v.get("tokens_b")
+        if not tokens_a or not tokens_b:
+            dropped_no_length += 1
+            continue
         winner = v["llm_id_a"] if v["choice"] == "a_better" else v["llm_id_b"]
         battles.append((v["llm_id_a"], v["llm_id_b"], winner))
-        style_a.append(style_vector(v.get("content_a"), v.get("tokens_a")))
-        style_b.append(style_vector(v.get("content_b"), v.get("tokens_b")))
+        style_a.append(style_vector(v.get("content_a"), tokens_a))
+        style_b.append(style_vector(v.get("content_b"), tokens_b))
+
+    if dropped_no_length:
+        logger.warning(
+            "[Ranking] Dropped %d decisive vote(s) with no answer token count "
+            "from the style-controlled fit.",
+            dropped_no_length,
+        )
 
     n_feat = len(STYLE_FEATURES)
     return (

--- a/utils/ranking/compute.py
+++ b/utils/ranking/compute.py
@@ -14,7 +14,8 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from backend.config import ALL_PREFS, NEGATIVE_PREFS, POSITIVE_PREFS
-from backend.llms.models import DatasetData, PreferencesData
+from backend.llms.models import DatasetData, PreferencesData, RankingVariant
+from utils.ranking.bradley_terry import bootstrap_confidence_intervals
 from utils.ranking.queries import fetch_votes
 from utils.ranking.style_control import (
     STYLE_FEATURES,
@@ -116,38 +117,27 @@ def _aggregate_preferences(votes: list[dict]) -> dict[str, PreferencesData]:
     return result
 
 
-def _compute_ranking(votes: list[dict]) -> RankingResult:
-    """Compute ranking and preferences for a single group of votes/reactions."""
-    all_battles, style_a, style_b = _votes_to_battles(votes)
+def _variant_table(
+    ci: dict[str, tuple[float, float, float]],
+    match_counts: dict[str, int],
+    win_counts: dict[str, int],
+) -> dict[str, dict]:
+    """
+    Turn a ``{model: (elo, lower, upper)}`` CI map into per-model ranking fields.
 
-    if not all_battles:
-        return RankingResult(timestamp=time.time())
-
-    # Style-controlled Bradley-Terry: per-model strengths with answer length and
-    # markdown formatting regressed out, so the Elo reflects substance rather
-    # than presentation. (point_estimate, lower_2.5, upper_97.5) per model.
-    ci, style_coefficients = bootstrap_style_controlled(all_battles, style_a, style_b)
-    logger.info(
-        "[Ranking] Style coefficients: "
-        + ", ".join(f"{k}={v:+.3f}" for k, v in style_coefficients.items())
-    )
-
-    # Count matches and wins per model
-    match_counts: dict[str, int] = defaultdict(int)
-    win_counts: dict[str, int] = defaultdict(int)
-    for a, b, winner in all_battles:
-        match_counts[a] += 1
-        match_counts[b] += 1
-        win_counts[winner] += 1
-
-    # Drop degenerate models (never won or never lost in the full data)
+    Shared by the style-controlled and plain Bradley-Terry views so both are
+    built identically (rank, CI-overlap rank bounds, mean win probability, win
+    rate); only the input CI differs. Degenerate models (any NaN bound) are
+    dropped here. Returns a ``{model: fields}`` dict ready to splat into a
+    ``RankingVariant`` / ``DatasetData``.
+    """
     ci = {m: v for m, v in ci.items() if not any(math.isnan(x) for x in v)}
 
     # Sort by point-estimate Elo descending
     sorted_models = sorted(ci, key=lambda m: -ci[m][0])
     n_total = len(sorted_models)
 
-    rankings: dict[str, DatasetData] = {}
+    table: dict[str, dict] = {}
     for rank, model in enumerate(sorted_models, 1):
         elo_point, elo_lower, elo_upper = ci[model]
         n_match = match_counts.get(model, 0)
@@ -176,7 +166,7 @@ def _compute_ranking(votes: list[dict]) -> RankingResult:
             win_probs.append(strength_i / (strength_i + strength_j))
         mean_win_prob = sum(win_probs) / len(win_probs) if win_probs else 0.5
 
-        rankings[model] = DatasetData(
+        table[model] = dict(
             elo=round(elo_point),
             score_p2_5=round(elo_lower),
             score_p97_5=round(elo_upper),
@@ -186,6 +176,50 @@ def _compute_ranking(votes: list[dict]) -> RankingResult:
             n_match=n_match,
             mean_win_prob=round(mean_win_prob, 4),
             win_rate=round(wins / n_match, 4) if n_match > 0 else 0.0,
+        )
+
+    return table
+
+
+def _compute_ranking(votes: list[dict]) -> RankingResult:
+    """Compute ranking and preferences for a single group of votes/reactions."""
+    all_battles, style_a, style_b = _votes_to_battles(votes)
+
+    if not all_battles:
+        return RankingResult(timestamp=time.time())
+
+    # Two rankings from the same battles so the frontend "Contrôle du style"
+    # toggle can switch views without a recompute:
+    #   - style-controlled (default): answer length and markdown formatting
+    #     regressed out, so the Elo reflects substance over presentation;
+    #   - uncontrolled: the plain MM Bradley-Terry fit (presentation included).
+    # Both are (point_estimate, lower_2.5, upper_97.5) per model.
+    ci_controlled, style_coefficients = bootstrap_style_controlled(
+        all_battles, style_a, style_b
+    )
+    ci_plain = bootstrap_confidence_intervals(all_battles)
+    logger.info(
+        "[Ranking] Style coefficients: "
+        + ", ".join(f"{k}={v:+.3f}" for k, v in style_coefficients.items())
+    )
+
+    # Count matches and wins per model (shared by both views)
+    match_counts: dict[str, int] = defaultdict(int)
+    win_counts: dict[str, int] = defaultdict(int)
+    for a, b, winner in all_battles:
+        match_counts[a] += 1
+        match_counts[b] += 1
+        win_counts[winner] += 1
+
+    controlled = _variant_table(ci_controlled, match_counts, win_counts)
+    plain = _variant_table(ci_plain, match_counts, win_counts)
+
+    rankings: dict[str, DatasetData] = {}
+    for model, fields in controlled.items():
+        uncontrolled = plain.get(model)
+        rankings[model] = DatasetData(
+            **fields,
+            uncontrolled=RankingVariant(**uncontrolled) if uncontrolled else None,
         )
 
     preferences = _aggregate_preferences(votes)

--- a/utils/ranking/compute.py
+++ b/utils/ranking/compute.py
@@ -11,10 +11,16 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 
+import numpy as np
+
 from backend.config import ALL_PREFS, NEGATIVE_PREFS, POSITIVE_PREFS
 from backend.llms.models import DatasetData, PreferencesData
-from utils.ranking.bradley_terry import bootstrap_confidence_intervals
 from utils.ranking.queries import fetch_votes
+from utils.ranking.style_control import (
+    STYLE_FEATURES,
+    bootstrap_style_controlled,
+    style_vector,
+)
 from utils.utils import configure_logger
 
 logger = configure_logger(logging.getLogger("ranking.compute"))
@@ -25,17 +31,39 @@ class RankingResult:
     timestamp: float
     rankings: dict[str, DatasetData] = field(default_factory=dict)
     preferences: dict[str, PreferencesData] = field(default_factory=dict)
+    # Style coefficients from the style-controlled fit (one per STYLE_FEATURES
+    # entry); exposed for transparency about how much presentation drives votes.
+    style_coefficients: dict[str, float] = field(default_factory=dict)
 
 
-def _votes_to_battles(votes: list[dict]) -> list[tuple[str, str, str]]:
-    """Convert vote records to battle tuples, filtering ties."""
-    battles = []
+def _votes_to_battles(
+    votes: list[dict],
+) -> tuple[list[tuple[str, str, str]], np.ndarray, np.ndarray]:
+    """
+    Convert vote records to decisive battle tuples plus aligned style vectors.
+
+    Ties (both_good / both_bad) carry no winner and are dropped from the
+    Bradley-Terry fit. Returns ``(battles, style_a, style_b)`` where the two
+    arrays are (n_battles, n_features) raw style measurements row-aligned with
+    ``battles`` for the style-controlled solver.
+    """
+    battles: list[tuple[str, str, str]] = []
+    style_a: list[np.ndarray] = []
+    style_b: list[np.ndarray] = []
     for v in votes:
-        if v["choice"] in ("a_better", "b_better"):
-            winner = v["llm_id_a"] if v["choice"] == "a_better" else v["llm_id_b"]
-            battles.append((v["llm_id_a"], v["llm_id_b"], winner))
+        if v["choice"] not in ("a_better", "b_better"):
+            continue
+        winner = v["llm_id_a"] if v["choice"] == "a_better" else v["llm_id_b"]
+        battles.append((v["llm_id_a"], v["llm_id_b"], winner))
+        style_a.append(style_vector(v.get("content_a"), v.get("tokens_a")))
+        style_b.append(style_vector(v.get("content_b"), v.get("tokens_b")))
 
-    return battles
+    n_feat = len(STYLE_FEATURES)
+    return (
+        battles,
+        np.array(style_a) if style_a else np.empty((0, n_feat)),
+        np.array(style_b) if style_b else np.empty((0, n_feat)),
+    )
 
 
 def _aggregate_preferences(votes: list[dict]) -> dict[str, PreferencesData]:
@@ -76,13 +104,19 @@ def _aggregate_preferences(votes: list[dict]) -> dict[str, PreferencesData]:
 
 def _compute_ranking(votes: list[dict]) -> RankingResult:
     """Compute ranking and preferences for a single group of votes/reactions."""
-    all_battles = _votes_to_battles(votes)
+    all_battles, style_a, style_b = _votes_to_battles(votes)
 
     if not all_battles:
         return RankingResult(timestamp=time.time())
 
-    # (point_estimate, lower_2.5, upper_97.5) per model
-    ci = bootstrap_confidence_intervals(all_battles)
+    # Style-controlled Bradley-Terry: per-model strengths with answer length and
+    # markdown formatting regressed out, so the Elo reflects substance rather
+    # than presentation. (point_estimate, lower_2.5, upper_97.5) per model.
+    ci, style_coefficients = bootstrap_style_controlled(all_battles, style_a, style_b)
+    logger.info(
+        "[Ranking] Style coefficients: "
+        + ", ".join(f"{k}={v:+.3f}" for k, v in style_coefficients.items())
+    )
 
     # Count matches and wins per model
     match_counts: dict[str, int] = defaultdict(int)
@@ -146,6 +180,7 @@ def _compute_ranking(votes: list[dict]) -> RankingResult:
         timestamp=time.time(),
         rankings=rankings,
         preferences=preferences,
+        style_coefficients=style_coefficients,
     )
 
 

--- a/utils/ranking/queries.py
+++ b/utils/ranking/queries.py
@@ -4,9 +4,10 @@ Database queries for fetching turns vote data for ranking computation.
 
 import logging
 
+from sqlalchemy.orm import aliased
 from sqlmodel import col, select
 
-from utils.database.models import Comparison, Turn
+from utils.database.models import Comparison, LLMMessage, Turn
 from utils.database.session import get_session
 from utils.utils import configure_logger
 
@@ -17,10 +18,17 @@ async def fetch_votes() -> list[dict]:
     """
     Fetch all non-archived Turn's votes joined with Comparison data.
 
+    The two assistant answers (content + token count) are joined in as well so
+    the ranking can control for answer style (length, markdown formatting); see
+    ``utils.ranking.style_control``.
+
     Returns:
         List of dicts with keys: choice, keyword_annotations_a,
-        keyword_annotations_b, llm_id_a, llm_id_b.
+        keyword_annotations_b, llm_id_a, llm_id_b, content_a, content_b,
+        tokens_a, tokens_b.
     """
+    msg_a = aliased(LLMMessage)
+    msg_b = aliased(LLMMessage)
     async with get_session() as session:
         results = await session.exec(
             select(
@@ -29,8 +37,14 @@ async def fetch_votes() -> list[dict]:
                 Turn.keyword_annotations_b,
                 Comparison.llm_id_a,
                 Comparison.llm_id_b,
+                col(msg_a.content).label("content_a"),
+                col(msg_b.content).label("content_b"),
+                col(msg_a.tokens).label("tokens_a"),
+                col(msg_b.tokens).label("tokens_b"),
             )
             .join(Comparison, col(Turn.comparison_id) == col(Comparison.id))
+            .join(msg_a, col(Turn.llm_msg_a_id) == col(msg_a.id), isouter=True)
+            .join(msg_b, col(Turn.llm_msg_b_id) == col(msg_b.id), isouter=True)
             .where(col(Comparison.archived).is_not(True))
             .where(
                 col(Turn.choice).in_(["both_good", "both_bad", "a_better", "b_better"])

--- a/utils/ranking/style_control.py
+++ b/utils/ranking/style_control.py
@@ -1,0 +1,279 @@
+"""
+Style-controlled Bradley-Terry model.
+
+The plain Bradley-Terry fit in ``bradley_terry.py`` treats every win equally,
+so a model can climb the leaderboard purely by answering at greater length or
+with heavier markdown formatting (headers, bold, bullet lists) rather than by
+being more correct. This module removes that confound the same way the LMArena
+"Style Control" does: it fits a logistic regression whose design matrix is the
+usual per-model strength indicators *augmented* with a handful of presentation
+features (the normalized A-vs-B difference in length and markdown density).
+
+The presentation coefficients absorb the part of the vote explained by style,
+so the per-model strengths become a *style-debiased* Elo: what the ranking
+would look like if both answers were formatted identically.
+
+Pure numpy (Newton-Raphson / IRLS) to avoid a scipy/sklearn dependency, mirroring
+the MM solver next door. The public surface matches ``bradley_terry.py`` so the
+two are drop-in compatible for the ranking pipeline.
+"""
+
+import re
+
+import numpy as np
+
+# --------------------------------------------------------------------------- #
+# Style feature extraction
+# --------------------------------------------------------------------------- #
+
+# Markdown atx headers (## ...), up to three leading spaces per CommonMark.
+_HEADER_RE = re.compile(r"^ {0,3}#{1,6}\s", re.MULTILINE)
+# Ordered or unordered list items.
+_LIST_RE = re.compile(r"^ {0,3}([-*+]|\d+[.)])\s", re.MULTILINE)
+
+# Order matters: it is the column order of the style design matrix and of the
+# coefficients reported back to callers.
+STYLE_FEATURES: tuple[str, ...] = ("length", "md_headers", "md_bold", "md_lists")
+
+
+def markdown_counts(content: str | None) -> tuple[int, int, int]:
+    """Return (headers, bold_spans, list_items) for one assistant answer."""
+    if not content:
+        return 0, 0, 0
+    headers = len(_HEADER_RE.findall(content))
+    bold = content.count("**") // 2
+    lists = len(_LIST_RE.findall(content))
+    return headers, bold, lists
+
+
+def style_vector(content: str | None, tokens: int | None) -> np.ndarray:
+    """Raw style measurements for one answer, ordered like ``STYLE_FEATURES``."""
+    headers, bold, lists = markdown_counts(content)
+    length = float(tokens) if tokens and tokens > 0 else 0.0
+    return np.array([length, headers, bold, lists], dtype=float)
+
+
+def _normalized_standardized_diffs(
+    style_a: np.ndarray, style_b: np.ndarray
+) -> np.ndarray:
+    """
+    Turn raw per-answer style measurements into model-agnostic regressors.
+
+    For each feature we take the *normalized* difference (a - b) / (a + b) so a
+    long answer beating a short one looks the same whether both are 50 or 5000
+    tokens, then standardize each column to unit variance so the logistic
+    coefficients are directly comparable across features.
+
+    Args:
+        style_a, style_b: (n_battles, n_features) raw measurements for the A and
+            B answer of each battle.
+
+    Returns:
+        (n_battles, n_features) standardized difference matrix. All-zero columns
+        (a feature that never varies) are left at zero rather than divided by 0.
+    """
+    denom = style_a + style_b
+    diff = np.divide(
+        style_a - style_b, denom, out=np.zeros_like(denom), where=denom > 0
+    )
+    std = diff.std(axis=0)
+    std[std == 0] = 1.0
+    return (diff - diff.mean(axis=0)) / std
+
+
+# --------------------------------------------------------------------------- #
+# Logistic Bradley-Terry solver with style covariates
+# --------------------------------------------------------------------------- #
+
+
+def _fit_logistic(
+    ia: np.ndarray,
+    ib: np.ndarray,
+    winner_is_a: np.ndarray,
+    style: np.ndarray,
+    n: int,
+    ridge: float = 1e-3,
+    max_iter: int = 100,
+    tol: float = 1e-8,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Fit ``P(a beats b) = sigmoid(beta_a - beta_b + style . gamma)`` by Newton's
+    method and return ``(elo, gamma)``.
+
+    ``beta`` are per-model log-strengths, ``gamma`` the style coefficients. As in
+    the MM solver, models that never won or never lost are degenerate (their MLE
+    is ±inf) so they are dropped from the fit and returned as NaN; callers (the
+    bootstrap especially) can then ignore them instead of treating them as wild
+    outliers.
+
+    A small ridge penalty fixes the additive gauge freedom of the per-model
+    indicators (adding a constant to every ``beta`` leaves the likelihood
+    unchanged) and keeps the Hessian positive-definite for sparsely observed
+    models; it is negligible for well-observed ones.
+    """
+    k = style.shape[1]
+    elo = np.full(n, np.nan)
+
+    wins = np.bincount(ia, weights=winner_is_a, minlength=n) + np.bincount(
+        ib, weights=~winner_is_a, minlength=n
+    )
+    appearances = np.bincount(ia, minlength=n) + np.bincount(ib, minlength=n)
+    present = (appearances > 0) & (wins > 0) & (wins < appearances)
+    if not present.any():
+        return elo, np.zeros(k)
+
+    # Reindex battles onto the present-models-only sub-problem. A battle is kept
+    # only if both of its models are non-degenerate.
+    remap = np.full(n, -1)
+    remap[present] = np.arange(present.sum())
+    m = int(present.sum())
+    ja, jb = remap[ia], remap[ib]
+    keep = (ja >= 0) & (jb >= 0)
+    ja, jb, style = ja[keep], jb[keep], style[keep]
+    y = winner_is_a[keep].astype(float)
+    # Parameter vector theta = [beta (m) | gamma (k)].
+    theta = np.zeros(m + k)
+
+    for _ in range(max_iter):
+        beta, gamma = theta[:m], theta[m:]
+        logits = beta[ja] - beta[jb] + style @ gamma
+        p = 1.0 / (1.0 + np.exp(-logits))
+        w = p * (1.0 - p)
+        resid = y - p
+
+        # Gradient of the penalized log-likelihood.
+        g = np.empty(m + k)
+        g[:m] = (
+            np.bincount(ja, weights=resid, minlength=m)
+            - np.bincount(jb, weights=resid, minlength=m)
+            - ridge * beta
+        )
+        g[m:] = style.T @ resid - ridge * gamma
+
+        # Hessian (negative): H = X^T diag(w) X + ridge*I, built blockwise to
+        # exploit the +1/-1 sparsity of the per-model indicator block.
+        H = np.zeros((m + k, m + k))
+        diag = np.bincount(ja, weights=w, minlength=m) + np.bincount(
+            jb, weights=w, minlength=m
+        )
+        bb = H[:m, :m]
+        bb[np.arange(m), np.arange(m)] = diag
+        np.add.at(bb, (ja, jb), -w)
+        np.add.at(bb, (jb, ja), -w)
+
+        ws = w[:, None] * style
+        cross = np.zeros((m, k))  # beta-gamma block
+        for c in range(k):
+            cross[:, c] = np.bincount(ja, weights=ws[:, c], minlength=m) - np.bincount(
+                jb, weights=ws[:, c], minlength=m
+            )
+        H[:m, m:] = cross
+        H[m:, :m] = cross.T
+        H[m:, m:] = style.T @ ws
+        H[np.arange(m + k), np.arange(m + k)] += ridge
+
+        try:
+            step = np.linalg.solve(H, g)
+        except np.linalg.LinAlgError:
+            step = np.linalg.lstsq(H, g, rcond=None)[0]
+        theta += step
+        if np.max(np.abs(step)) < tol:
+            break
+
+    beta = theta[:m]
+    beta -= beta.mean()  # center, then map log-strength -> Elo points
+    elo[present] = 400.0 / np.log(10.0) * beta
+    elo[present] += 1000.0
+    return elo, theta[m:]
+
+
+def fit_style_controlled(
+    battles: list[tuple[str, str, str]],
+    style_a: np.ndarray,
+    style_b: np.ndarray,
+    ridge: float = 1e-3,
+) -> tuple[dict[str, float], dict[str, float]]:
+    """
+    Style-controlled Bradley-Terry point estimate.
+
+    Args:
+        battles: (model_a, model_b, winner) tuples; winner is model_a or model_b.
+        style_a, style_b: (n_battles, n_features) raw style measurements aligned
+            row-for-row with ``battles`` (see ``style_vector``).
+        ridge: L2 strength for gauge-fixing / regularization.
+
+    Returns:
+        (elo_by_model, style_coefficients) where style_coefficients maps each
+        name in ``STYLE_FEATURES`` to its logistic coefficient (positive = that
+        presentation axis independently raises an answer's win probability).
+    """
+    if not battles:
+        return {}, {f: 0.0 for f in STYLE_FEATURES}
+
+    models = sorted({m for b in battles for m in (b[0], b[1])})
+    idx = {m: i for i, m in enumerate(models)}
+    ia = np.fromiter((idx[b[0]] for b in battles), dtype=int, count=len(battles))
+    ib = np.fromiter((idx[b[1]] for b in battles), dtype=int, count=len(battles))
+    winner_is_a = np.fromiter(
+        (b[2] == b[0] for b in battles), dtype=bool, count=len(battles)
+    )
+
+    style = _normalized_standardized_diffs(style_a, style_b)
+    elo, gamma = _fit_logistic(ia, ib, winner_is_a, style, len(models), ridge=ridge)
+    return (
+        dict(zip(models, elo.tolist())),
+        dict(zip(STYLE_FEATURES, gamma.tolist())),
+    )
+
+
+def bootstrap_style_controlled(
+    battles: list[tuple[str, str, str]],
+    style_a: np.ndarray,
+    style_b: np.ndarray,
+    n_samples: int = 200,
+    ridge: float = 1e-3,
+) -> tuple[dict[str, tuple[float, float, float]], dict[str, float]]:
+    """
+    Style-controlled ratings with bootstrap confidence intervals.
+
+    Mirrors ``bradley_terry.bootstrap_confidence_intervals``: the displayed Elo
+    is the single full-data point estimate (not the bootstrap median), and the
+    bootstrap is used only for the 2.5/97.5 percentile bounds. Rounds where a
+    model is absent / undefeated / winless contribute NaN and are dropped from
+    that model's percentile.
+
+    Returns:
+        (ci_by_model, style_coefficients) where ci_by_model maps model -> (point,
+        lower_2.5, upper_97.5).
+    """
+    if not battles:
+        return {}, {f: 0.0 for f in STYLE_FEATURES}
+
+    models = sorted({m for b in battles for m in (b[0], b[1])})
+    idx = {m: i for i, m in enumerate(models)}
+    n_models = len(models)
+    n_battles = len(battles)
+    ia = np.fromiter((idx[b[0]] for b in battles), dtype=int, count=n_battles)
+    ib = np.fromiter((idx[b[1]] for b in battles), dtype=int, count=n_battles)
+    winner_is_a = np.fromiter(
+        (b[2] == b[0] for b in battles), dtype=bool, count=n_battles
+    )
+    style = _normalized_standardized_diffs(style_a, style_b)
+
+    point_elo, gamma = _fit_logistic(ia, ib, winner_is_a, style, n_models, ridge=ridge)
+
+    all_elos = np.empty((n_samples, n_models))
+    rng = np.random.default_rng()
+    for s in range(n_samples):
+        sel = rng.integers(0, n_battles, size=n_battles)
+        all_elos[s], _ = _fit_logistic(
+            ia[sel], ib[sel], winner_is_a[sel], style[sel], n_models, ridge=ridge
+        )
+
+    lowers = np.nanpercentile(all_elos, 2.5, axis=0)
+    uppers = np.nanpercentile(all_elos, 97.5, axis=0)
+    ci = {
+        models[i]: (float(point_elo[i]), float(lowers[i]), float(uppers[i]))
+        for i in range(n_models)
+    }
+    return ci, dict(zip(STYLE_FEATURES, gamma.tolist()))

--- a/utils/ranking/style_control.py
+++ b/utils/ranking/style_control.py
@@ -7,7 +7,7 @@ with heavier markdown formatting (headers, bold, bullet lists) rather than by
 being more correct. This module removes that confound the same way the LMArena
 "Style Control" does: it fits a logistic regression whose design matrix is the
 usual per-model strength indicators *augmented* with a handful of presentation
-features (the normalized A-vs-B difference in length and markdown density).
+features (the normalized A-vs-B difference in length and markdown formatting).
 
 The presentation coefficients absorb the part of the vote explained by style,
 so the per-model strengths become a *style-debiased* Elo: what the ranking
@@ -53,24 +53,28 @@ def style_vector(content: str | None, tokens: int | None) -> np.ndarray:
     return np.array([length, headers, bold, lists], dtype=float)
 
 
-def _normalized_standardized_diffs(
-    style_a: np.ndarray, style_b: np.ndarray
-) -> np.ndarray:
+def _style_regressors(style_a: np.ndarray, style_b: np.ndarray) -> np.ndarray:
     """
     Turn raw per-answer style measurements into model-agnostic regressors.
 
     For each feature we take the *normalized* difference (a - b) / (a + b) so a
     long answer beating a short one looks the same whether both are 50 or 5000
-    tokens, then standardize each column to unit variance so the logistic
-    coefficients are directly comparable across features.
+    tokens, then scale each column to unit variance so the logistic coefficients
+    are comparable across features.
+
+    The difference is deliberately left un-centered. Swapping the A and B answer
+    flips both the outcome label and this regressor's sign, which is exactly the
+    antisymmetry a Bradley-Terry model requires; subtracting a column mean would
+    fold a constant intercept into ``style . gamma`` and bias the style
+    coefficients whenever A/B ordering is not perfectly balanced.
 
     Args:
         style_a, style_b: (n_battles, n_features) raw measurements for the A and
             B answer of each battle.
 
     Returns:
-        (n_battles, n_features) standardized difference matrix. All-zero columns
-        (a feature that never varies) are left at zero rather than divided by 0.
+        (n_battles, n_features) scaled difference matrix. All-zero columns (a
+        feature that never varies) are left at zero rather than divided by 0.
     """
     denom = style_a + style_b
     diff = np.divide(
@@ -78,12 +82,22 @@ def _normalized_standardized_diffs(
     )
     std = diff.std(axis=0)
     std[std == 0] = 1.0
-    return (diff - diff.mean(axis=0)) / std
+    return diff / std
 
 
 # --------------------------------------------------------------------------- #
 # Logistic Bradley-Terry solver with style covariates
 # --------------------------------------------------------------------------- #
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    """Logistic sigmoid, evaluated branchwise so large |x| never overflows exp."""
+    out = np.empty_like(x, dtype=float)
+    pos = x >= 0
+    out[pos] = 1.0 / (1.0 + np.exp(-x[pos]))
+    ex = np.exp(x[~pos])
+    out[~pos] = ex / (1.0 + ex)
+    return out
 
 
 def _fit_logistic(
@@ -137,7 +151,7 @@ def _fit_logistic(
     for _ in range(max_iter):
         beta, gamma = theta[:m], theta[m:]
         logits = beta[ja] - beta[jb] + style @ gamma
-        p = 1.0 / (1.0 + np.exp(-logits))
+        p = _sigmoid(logits)
         w = p * (1.0 - p)
         resid = y - p
 
@@ -205,7 +219,10 @@ def fit_style_controlled(
     Returns:
         (elo_by_model, style_coefficients) where style_coefficients maps each
         name in ``STYLE_FEATURES`` to its logistic coefficient (positive = that
-        presentation axis independently raises an answer's win probability).
+        presentation axis is associated with a higher win probability after
+        model strength is controlled for). Length and the markdown counts are
+        correlated, so the coefficients should be read jointly rather than as
+        independent per-feature effects.
     """
     if not battles:
         return {}, {f: 0.0 for f in STYLE_FEATURES}
@@ -218,7 +235,7 @@ def fit_style_controlled(
         (b[2] == b[0] for b in battles), dtype=bool, count=len(battles)
     )
 
-    style = _normalized_standardized_diffs(style_a, style_b)
+    style = _style_regressors(style_a, style_b)
     elo, gamma = _fit_logistic(ia, ib, winner_is_a, style, len(models), ridge=ridge)
     return (
         dict(zip(models, elo.tolist())),
@@ -230,7 +247,7 @@ def bootstrap_style_controlled(
     battles: list[tuple[str, str, str]],
     style_a: np.ndarray,
     style_b: np.ndarray,
-    n_samples: int = 200,
+    n_samples: int = 500,
     ridge: float = 1e-3,
 ) -> tuple[dict[str, tuple[float, float, float]], dict[str, float]]:
     """
@@ -258,7 +275,7 @@ def bootstrap_style_controlled(
     winner_is_a = np.fromiter(
         (b[2] == b[0] for b in battles), dtype=bool, count=n_battles
     )
-    style = _normalized_standardized_diffs(style_a, style_b)
+    style = _style_regressors(style_a, style_b)
 
     point_elo, gamma = _fit_logistic(ia, ib, winner_is_a, style, n_models, ridge=ridge)
 


### PR DESCRIPTION
## What

The leaderboard uses a plain Bradley-Terry fit, which rewards models that answer at length or with a lot of markdown formatting even when the answer isn't actually better. This adds style control (same idea as LMArena): we fit the per-model strengths together with a few style features — answer length, markdown headers, bold, lists — so those get regressed out and the Elo reflects substance rather than presentation.

## How

- `utils/ranking/style_control.py`: style-controlled Bradley-Terry solver. It's a logistic regression (`P(a beats b) = sigmoid(beta_a - beta_b + style·gamma)`) solved with Newton's method, pure numpy so no new dependency. Same Elo scale, bootstrap CIs and degenerate-model (NaN) handling as the MM solver next to it.
- `utils/ranking/queries.py`: `fetch_votes` also joins the two answers' content and token counts.
- `utils/ranking/compute.py`: `_compute_ranking` builds the style features, uses the style-controlled fit, logs the style coefficients and exposes them on `RankingResult`.
- `tests/ranking/test_style_control.py`: unit tests for the solver.

## Result

On the public arena export (~139k decisive votes) all the style coefficients come out positive, with length the strongest. Once formatting is controlled for, a few terse-but-good models move up (e.g. gpt-5.3, claude-3-7-sonnet) and some style-inflated ones move down.

Draft for now — I haven't run it against the real DB yet, wanted feedback on the approach first.