### PR TITLE
fix: locale selection ignored when DEFAULT_LOCALE is set

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -22,7 +22,18 @@ defineCustomServerStrategy('custom-url', {
     } else if (locale) {
       return locale
     } else if (DEFAULT_LOCALE) {
-      return DEFAULT_LOCALE
+      // Only apply DEFAULT_LOCALE if no user cookie is already set.
+      // Paraglide runs custom strategies before built-in ones (including cookie),
+      // so without this check DEFAULT_LOCALE would silently override the user's
+      // locale preference stored in PARAGLIDE_LOCALE.
+      const cookieLocale = request.headers
+        .get('cookie')
+        ?.split('; ')
+        .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
+        ?.split('=')[1]
+      if (!cookieLocale) {
+        return DEFAULT_LOCALE
+      }
     }
   }
 })


### PR DESCRIPTION
On instances with DEFAULT_LOCALE set (e.g. the FR instance), selecting a
locale other than the default had no effect. The page would reload but stay
on DEFAULT_LOCALE.

Paraglide executes custom server strategies before built-in ones, including
the cookie strategy. As a result, the custom-url strategy was always returning
DEFAULT_LOCALE, which took priority over the PARAGLIDE_LOCALE cookie set by
setLocale().

Fix: only return DEFAULT_LOCALE from the custom strategy when no locale cookie
is already present, so user preference stored in the cookie is respected.