### PR TITLE
refactor: clarify locale and instance selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ export COMPARIA_DB_URI=postgresql://comparia:comparia@localhost:5432/comparia
 # Redis (optional - disables rate limiting if unset)
 export COMPARIA_REDIS_HOST=localhost
 
+export PUBLIC_API_LOCAL_URL=http://localhost:8008
+
+
 # LLM API key - or use MOCK_RESPONSE=true to skip real API calls
 export OPENROUTER_API_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 # Instance configuration
-export DEFAULT_COUNTRY_PORTAL=fr
 export DEFAULT_LOCALE=fr
 
 # Database

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Copy the example env file and fill in the required values:
 cp .env.example .env
 ```
 
-Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_COUNTRY_PORTAL=da`, `DEFAULT_LOCALE=da`, and point `COMPARIA_DB_URI` to the DA database.
+Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_LOCALE=da` and point `COMPARIA_DB_URI` to the DA database.
 
 Start Postgres and Redis, then run:
 
@@ -39,7 +39,7 @@ source .env
 make dev      # backend on :8008, frontend on :5173
 ```
 
-For the DA instance, copy `.env.example` and set `DEFAULT_COUNTRY_PORTAL=da`, `DEFAULT_LOCALE=da`, and `COMPARIA_DB_URI` to the DA database before sourcing.
+For the DA instance, copy `.env.example` and set `DEFAULT_LOCALE=da` and `COMPARIA_DB_URI` to the DA database before sourcing.
 
 ---
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -32,7 +32,7 @@ class Settings(BaseSettings):
     HF_PUSH_DATASET_KEY: str = ""
     HF_PUSH_DATASET_PATH: str = ""
 
-    DEFAULT_COUNTRY_PORTAL: str = "fr"
+    DEFAULT_LOCALE: str = "fr"
 
     RANKING_INTERVAL_SECONDS: int = 3600  # 1 hour
     REPO_ORG: str = "ministere-culture"
@@ -84,7 +84,7 @@ CONSUMPTION_SCALE_FACTOR: Final[float] = {
     # 48.4% of ppl aged 16–74 in 2025 https://ec.europa.eu/eurostat/fr/web/products-eurostat-news/w/ddn-20251216-3
     # population count of 16-74 https://en.wikipedia.org/wiki/Demographics_of_Denmark
     "da": 4_350_000 * 0.484,
-}[settings.DEFAULT_COUNTRY_PORTAL]
+}[settings.DEFAULT_LOCALE]
 
 # Language model selection modes
 SelectionMode = Literal["random", "big-vs-small", "small-models", "custom"]

--- a/backend/llms/data.py
+++ b/backend/llms/data.py
@@ -42,7 +42,7 @@ class LLMsData(BaseModel):
             if model["status"] != "disabled"
             and (
                 not model["specific_portals"]
-                or settings.DEFAULT_COUNTRY_PORTAL in model["specific_portals"]
+                or settings.DEFAULT_LOCALE in model["specific_portals"]
             )
         }
 

--- a/controller.py
+++ b/controller.py
@@ -8,7 +8,6 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
-from backend.config import DEFAULT_COUNTRY_PORTAL
 from backend.llms.data import get_llms_data
 
 templates = Jinja2Templates(directory="templates")
@@ -56,7 +55,7 @@ def get_models_errors() -> list[str]:  # Return type hint
     response_class=HTMLResponse,
 )
 def index(request: Request) -> HTMLResponse:
-    models = get_llms_data(DEFAULT_COUNTRY_PORTAL)
+    models = get_llms_data()
 
     error_count = dict.fromkeys(models.enabled, 0)
     for model_id, _date, _details in models_errors:

--- a/devops/instances/da/.env.da.example
+++ b/devops/instances/da/.env.da.example
@@ -1,4 +1,4 @@
-DEFAULT_COUNTRY_PORTAL=da
+DEFAULT_LOCALE=da
 
 COMPARIA_DB_URI="postgres://user:pass@host:5432/comparia_da?sslmode=require"
 COMPARIA_REDIS_HOST=localhost

--- a/devops/instances/da/app.compose.da.yml
+++ b/devops/instances/da/app.compose.da.yml
@@ -20,7 +20,7 @@ services:
     environment:
       LOGDIR: /data
       LANGUIA_DEBUG: "true"
-      DEFAULT_COUNTRY_PORTAL: da
+      DEFAULT_LOCALE: da
       COMPARIA_DB_URI: "${COMPARIA_DB_URI_DA:-postgresql://comparia:comparia@postgres:5432/comparia_da}"
       COMPARIA_REDIS_HOST: redis
       OPENROUTER_API_KEY:

--- a/devops/instances/fr/.env.fr.example
+++ b/devops/instances/fr/.env.fr.example
@@ -1,4 +1,4 @@
-DEFAULT_COUNTRY_PORTAL=fr
+DEFAULT_LOCALE=fr
 
 COMPARIA_DB_URI="postgres://user:pass@host:5432/comparia_fr?sslmode=require"
 COMPARIA_REDIS_HOST=localhost

--- a/devops/instances/fr/app.compose.fr.yml
+++ b/devops/instances/fr/app.compose.fr.yml
@@ -20,7 +20,7 @@ services:
     environment:
       LOGDIR: /data
       LANGUIA_DEBUG: "true"
-      DEFAULT_COUNTRY_PORTAL: fr
+      DEFAULT_LOCALE: fr
       COMPARIA_DB_URI: "${COMPARIA_DB_URI_FR:-postgresql://comparia:comparia@postgres:5432/comparia}"
       COMPARIA_REDIS_HOST: redis
       OPENROUTER_API_KEY:

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -22,6 +22,8 @@
         "searchModel": "Søg efter en model",
         "seeMore": "Se mere",
         "selectLanguage": "Vælg sprog",
+        "selectLocale": "Sprog",
+        "selectInstance": "Portal",
         "discover": "Opdag",
         "returnArena": "Tilbage til arenaen"
     },

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -21,7 +21,9 @@
         "scrollRight": "Scroll right",
         "searchModel": "Search for a model",
         "seeMore": "See more",
-        "selectLanguage": "Select a language"
+        "selectLanguage": "Select a language",
+        "selectLocale": "Language",
+        "selectInstance": "Portal"
     },
     "arenaHome": {
         "compareModels": {

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -23,7 +23,9 @@
         "scrollRight": "Défiler vers la droite",
         "searchModel": "Rechercher un modèle",
         "seeMore": "Voir plus",
-        "selectLanguage": "Sélectionner une langue"
+        "selectLanguage": "Sélectionner une langue",
+        "selectLocale": "Langue",
+        "selectInstance": "Portail"
     },
     "arenaHome": {
         "compareModels": {

--- a/frontend/locales/messages/lt.json
+++ b/frontend/locales/messages/lt.json
@@ -16,7 +16,9 @@
         "home": "Pagrindinis puslapis",
         "returnHome": "Grįžti į pagrindinį puslapį",
         "seeMore": "Matyti daugiau",
-        "selectLanguage": "Pasirinkite kalbą"
+        "selectLanguage": "Pasirinkite kalbą",
+        "selectLocale": "Kalba",
+        "selectInstance": "Portalas"
     },
     "arenaHome": {
         "compareModels": {

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -21,7 +21,9 @@
         "scrollRight": "Scrolla till höger",
         "searchModel": "Sök modell",
         "seeMore": "Visa mer",
-        "selectLanguage": "Välj språk"
+        "selectLanguage": "Välj språk",
+        "selectLocale": "Språk",
+        "selectInstance": "Portal"
     },
     "arenaHome": {
         "compareModels": {

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -22,7 +22,18 @@ defineCustomServerStrategy('custom-url', {
     } else if (locale) {
       return locale
     } else if (DEFAULT_LOCALE) {
-      return DEFAULT_LOCALE
+      // Only apply DEFAULT_LOCALE if no user cookie is already set.
+      // Paraglide runs custom strategies before built-in ones (including cookie),
+      // so without this check DEFAULT_LOCALE would silently override the user's
+      // locale preference stored in PARAGLIDE_LOCALE.
+      const cookieLocale = request.headers
+        .get('cookie')
+        ?.split('; ')
+        .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
+        ?.split('=')[1]
+      if (!cookieLocale) {
+        return DEFAULT_LOCALE
+      }
     }
   }
 })

--- a/frontend/src/lib/components/header/LanguageSelector.svelte
+++ b/frontend/src/lib/components/header/LanguageSelector.svelte
@@ -42,6 +42,9 @@
     </Button>
 
     <div class="fr-collapse fr-translate__menu fr-menu" {id}>
+      <p class="fr-text--xs fr-mb-0 px-4 pt-2 text-[var(--text-mention-grey)] uppercase">
+        {m['actions.selectLocale']()}
+      </p>
       <ul class="fr-menu__list">
         {#each localeOptions as locale (locale.code)}
           <li>
@@ -57,6 +60,9 @@
         {/each}
       </ul>
       <hr class="my-1 mx-4 border-[var(--border-default-grey)]" />
+      <p class="fr-text--xs fr-mb-0 px-4 pt-1 text-[var(--text-mention-grey)] uppercase">
+        {m['actions.selectInstance']()}
+      </p>
       <ul class="fr-menu__list">
         {#each INSTANCES as instance (instance.host)}
           <li>

--- a/frontend/src/lib/components/header/LanguageSelector.svelte
+++ b/frontend/src/lib/components/header/LanguageSelector.svelte
@@ -1,24 +1,24 @@
 <script lang="ts">
   import { page } from '$app/state'
   import { Button } from '$components/dsfr'
-  import { LOCALES, type LocaleOption } from '$lib/global.svelte'
+  import { INSTANCES, LOCALES, type Instance, type LocaleOption } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale, setLocale } from '$lib/i18n/runtime'
-  import { SvelteURL } from 'svelte/reactivity'
 
   let { id }: { id: string } = $props()
 
   const currentLocale = getLocale()
+  const currentHost = page.url.host
+
+  const localeOptions = LOCALES.filter((l) => l.host === currentHost)
 
   function onLocaleSelect(locale: LocaleOption) {
-    if (page.url.host !== locale.host) {
-      const url = new SvelteURL(window.location.href)
-      url.host = locale.host
-      url.search = `locale=${locale.code}`
-      window.location.href = url.href
-    } else {
-      setLocale(locale.code)
-    }
+    setLocale(locale.code)
+  }
+
+  function onInstanceSelect(instance: Instance) {
+    if (instance.host === currentHost) return
+    window.location.href = `${window.location.protocol}//${instance.host}`
   }
 </script>
 
@@ -43,15 +43,29 @@
 
     <div class="fr-collapse fr-translate__menu fr-menu" {id}>
       <ul class="fr-menu__list">
-        {#each LOCALES as locale (locale.code)}
+        {#each localeOptions as locale (locale.code)}
           <li>
             <button
               class="fr-translate__language fr-nav__link"
               lang={locale.code}
-              aria-current={locale.code == currentLocale}
+              aria-current={locale.code === currentLocale}
               onclick={() => onLocaleSelect(locale)}
             >
               {locale.long}
+            </button>
+          </li>
+        {/each}
+      </ul>
+      <hr class="my-1 mx-4 border-[var(--border-default-grey)]" />
+      <ul class="fr-menu__list">
+        {#each INSTANCES as instance (instance.host)}
+          <li>
+            <button
+              class="fr-translate__language fr-nav__link"
+              aria-current={instance.host === currentHost}
+              onclick={() => onInstanceSelect(instance)}
+            >
+              {instance.label}
             </button>
           </li>
         {/each}

--- a/frontend/src/lib/global.svelte.ts
+++ b/frontend/src/lib/global.svelte.ts
@@ -8,8 +8,20 @@ const disabledLocaleCodes = env.PUBLIC_DISABLED_LOCALES
   : null
 
 export type LocaleOption = { code: Locale; short: string; long: string; host: string }
+export type Instance = { host: string; label: string }
 
 const DEFAULT_HOST = dev ? 'localhost:5173' : 'comparia.beta.gouv.fr'
+
+export const INSTANCES: Instance[] = dev
+  ? [
+      { host: 'localhost:5173', label: 'ComparIA (FR)' },
+      { host: 'localhost:8080', label: 'AI Arena (DA)' }
+    ]
+  : [
+      { host: 'comparia.beta.gouv.fr', label: 'ComparIA (FR)' },
+      { host: 'ai-arenaen.dk', label: 'AI Arena (DA)' }
+    ]
+
 export const HOST_TO_LOCALE = dev
   ? {
       '127.0.0.1:8080': 'da'

--- a/utils/ranking/run.py
+++ b/utils/ranking/run.py
@@ -43,7 +43,7 @@ def store_to_redis(data: RankingResult) -> None:
             value=json.dumps(data),
         )
         logger.info(
-            f"[SESSION] Stored ranking data for {settings.DEFAULT_COUNTRY_PORTAL}"
+            f"[SESSION] Stored ranking data for {settings.DEFAULT_LOCALE}"
         )
     except Exception as e:
         logger.error(f"[SESSION] Error storing ranking data: {e}")

--- a/utils/storage/redis.py
+++ b/utils/storage/redis.py
@@ -6,9 +6,8 @@ import redis
 
 from backend.config import settings
 
-# TODO drop DEFAULT_COUNTRY_PORTAL env var + add REDIS_INSTANCE_PREFIX?
 REDIS_INSTANCE_PREFIX: Final[str] = (
-    f"{settings.DEFAULT_COUNTRY_PORTAL}:" if settings.DEFAULT_COUNTRY_PORTAL else ""
+    f"{settings.DEFAULT_LOCALE}:" if settings.DEFAULT_LOCALE else ""
 )
 
 # Redis keys (all namespaced by instance portal prefix)


### PR DESCRIPTION
Separate the concepts of locale (language) and instance (portal) that were
previously conflated in a single dropdown.

- fix: selecting EN on the FR instance now applies the locale instead of
  being overridden by DEFAULT_LOCALE (Paraglide runs custom strategies
  before the cookie strategy, so DEFAULT_LOCALE was silently winning)
- refactor: rename DEFAULT_COUNTRY_PORTAL to DEFAULT_LOCALE across backend,
  devops configs, and documentation; remove a broken import in controller.py
- feat: split the language selector dropdown into two sections: locale
  selection (stays on current instance) and instance selection (redirects
  to the other portal); add i18n labels for both sections (fr, en, da, lt, sv)