### PR TITLE
Consolidate datasets page to a single dataset

### DIFF
--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -111,17 +111,9 @@
             "catch": "Modeludgivere, forskere, virksomheder, nu er det jeres tur!",
             "desc": "Platformens spørgsmål og præferencer er tilgængelige på dansk, engelsk, fransk og forventes udvidet i fremtiden til blandt andet at inkludere svensk. Spørgsmålene afspejler organisk brug – ikke kunstige spørgsmål. Disse datasæt er offentligt tilgængelige på <a {linkProps}>data.gouv.fr</a> og Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "Alle spørgsmål og svar",
-                    "title": "/samtaler"
-                },
-                "reactions": {
-                    "desc": "Alle reaktioner på beskeder",
-                    "title": "/reaktioner"
-                },
-                "votes": {
-                    "desc": "Alle de udtrykte præferencer",
-                    "title": "/stemmer"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Samtaler, svar, reaktioner og præferencer samlet i ét datasæt"
                 }
             },
             "share": "Vis os, hvordan du bruger datasættene",

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -109,17 +109,9 @@
             "catch": "Model publishers, researchers, companies, now it's your turn!",
             "desc": "The platform’s questions and preferences are primarily in French, Danish, Swedish and Lithuanian, capturing organic, real-world usage - not artificial prompts. These datasets are publicly available on <a {linkProps}>data.gouv.fr</a> and Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "All the questions and answers",
-                    "title": "/conversations"
-                },
-                "reactions": {
-                    "desc": "All the reactions to messages",
-                    "title": "/reactions"
-                },
-                "votes": {
-                    "desc": "All the preferences expressed",
-                    "title": "/votes"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Conversations, answers, reactions and preferences gathered in a single dataset"
                 }
             },
             "share": "Show us how you’re using the data",

--- a/frontend/locales/messages/es.json
+++ b/frontend/locales/messages/es.json
@@ -105,8 +105,9 @@
     "datasets": {
         "access": {
             "repos": {
-                "votes": {
-                    "title": "/votos"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Conversaciones, respuestas, reacciones y preferencias reunidas en un solo conjunto de datos"
                 }
             },
             "share": "Comparte con nosotros como usas los datos",

--- a/frontend/locales/messages/et.json
+++ b/frontend/locales/messages/et.json
@@ -109,17 +109,9 @@
             "catch": "Mudelite avaldajad, teadlased, ettevõtted – nüüd on teie kord!",
             "desc": "Keelemudelite võrdlusplatvormi kaudu on kogutud küsimusi ja eelistusi prantsuse, taani, rootsi, leedu ja nüüd ka eesti keeles ning need kajastavad orgaanilist, päriselulist kasutust, mitte tehislikke viipasid. Need andmestikud on avalikult kättesaadavad veebilehel <a {linkProps}>data.gouv.fr</a> ja Hugging Face’is.",
             "repos": {
-                "conversations": {
-                    "desc": "Kõik küsimused ja vastused",
-                    "title": "/vestlused"
-                },
-                "reactions": {
-                    "desc": "Kõik reaktsioonid sõnumitele",
-                    "title": "/reaktsioonid"
-                },
-                "votes": {
-                    "desc": "Kõik eelistused",
-                    "title": "/hääled"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Vestlused, vastused, reaktsioonid ja eelistused ühes andmestikus"
                 }
             },
             "share": "Jagage meiega, kuidas te andmeid kasutate",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -111,17 +111,9 @@
             "catch": "Editeurs de modèles, chercheurs, chercheuses, entreprises, à vous de jouer !",
             "desc": "Les questions et préférences posées sur la plateforme sont majoritairement en français et reflètent des usages réels et non contraints. Ces jeux de données sont accessibles sur <a {linkProps}>data.gouv</a> et Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "Ensemble des réponses et des questions posées",
-                    "title": "/conversations"
-                },
-                "reactions": {
-                    "desc": "Ensemble des réactions exprimées",
-                    "title": "/réactions"
-                },
-                "votes": {
-                    "desc": "Ensemble des préférences exprimées",
-                    "title": "/votes"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Conversations, réponses, réactions et préférences réunies dans un seul jeu de données"
                 }
             },
             "share": "Partagez-nous vos réutilisations",

--- a/frontend/locales/messages/it.json
+++ b/frontend/locales/messages/it.json
@@ -103,17 +103,9 @@
             "catch": "Sviluppatori di modelli, ricercatori, aziende, ora tocca a te!",
             "desc": "Le domande e le preferenze espresse sulla piattaforma sono perlopiù in italiano, francese, danese, svedese e lituano e riflettono un utilizzo reale e non artificiale. Questa raccolta di dati sono disponibili su <a {linkProps}>data.gouv</a> e Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "Tutte le risposte e le domande poste",
-                    "title": "/conversazioni"
-                },
-                "reactions": {
-                    "desc": "Tutte le reazioni espresse",
-                    "title": "/reazioni"
-                },
-                "votes": {
-                    "desc": "Tutte le preferenze espresse",
-                    "title": "/voti"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Conversazioni, risposte, reazioni e preferenze raccolte in un unico dataset"
                 }
             },
             "share": "Condividi con noi come utilizzi i dati",

--- a/frontend/locales/messages/lt.json
+++ b/frontend/locales/messages/lt.json
@@ -104,17 +104,9 @@
             "catch": "Modelio leidėjai, tyrėjai, įmonės, dabar jūsų eilė!",
             "desc": "Platformos klausimai ir pageidavimai yra pateikiami daugiausia prancūzų, danų, švedų ir lietuvių kalbomis, atspindintys natūralų, realaus naudojimo kontekstą, o ne dirbtinius užklausimus. Šie duomenų rinkiniai yra viešai prieinami <a {linkProps}>data.gouv.fr</a> ir Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "Visi klausimai ir atsakymai",
-                    "title": "/pokalbiai"
-                },
-                "reactions": {
-                    "desc": "Visos reakcijos į žinutes",
-                    "title": "/reakcijos"
-                },
-                "votes": {
-                    "desc": "Visi išreikšti pasirinkimai",
-                    "title": "/balsai"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Pokalbiai, atsakymai, reakcijos ir pasirinkimai viename duomenų rinkinyje"
                 }
             },
             "share": "Parodyk mums, kaip panaudoji duomenis",

--- a/frontend/locales/messages/nb_NO.json
+++ b/frontend/locales/messages/nb_NO.json
@@ -109,17 +109,9 @@
             "catch": "Modellutgivere, forskere, selskaper, nå er det deres tur!",
             "desc": "Plattformens spørsmål og preferanser er hovedsakelig på fransk, dansk, svensk og litauisk, på vanlig, dagligdags språk - ikke kunstige spørsmål. Datasettene er offentlig tilgjengelige på <a {linkProps}>data.gouv</a> og Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "Alle spørsmål og svar",
-                    "title": "/samtaler"
-                },
-                "reactions": {
-                    "desc": "Alle reaksjoner på meldinger",
-                    "title": "/reaksjoner"
-                },
-                "votes": {
-                    "desc": "Alle uttrykte preferanser",
-                    "title": "/stemmer"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Samtaler, svar, reaksjoner og preferanser samlet i ett datasett"
                 }
             },
             "share": "Vis oss hvordan du bruker dataene",

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -109,17 +109,9 @@
             "catch": "Modellskapare, forskare, företag, det är er tur!",
             "desc": "Frågorna som ställs på plattformen är mestadels på franska och återspeglar verklig användning utan restriktioner. Dessa datamängder finns tillgängliga på <a {linkProps}>data.gouv</a> och Hugging Face.",
             "repos": {
-                "conversations": {
-                    "desc": "Frågor och svar",
-                    "title": "/konversationer"
-                },
-                "reactions": {
-                    "desc": "Alla reaktioner",
-                    "title": "/reaktioner"
-                },
-                "votes": {
-                    "desc": "Alla uttryckta preferenser",
-                    "title": "/röster"
+                "arena": {
+                    "title": "/comparia-fr-arena",
+                    "desc": "Konversationer, svar, reaktioner och preferenser samlade i en datauppsättning"
                 }
             },
             "share": "Visa hur du använder datan",

--- a/frontend/src/routes/(pages)/datasets/+page.svelte
+++ b/frontend/src/routes/(pages)/datasets/+page.svelte
@@ -9,29 +9,12 @@
   const locale = getLocale()
   const i18nData = getI18nContext()
 
-  const datasetCards = (
-    [
-      {
-        i18nKey: 'conversations',
-        img: `/datasets/conversations-${locale === 'fr' ? 'fr' : 'en'}.png`,
-        link: 'https://huggingface.co/datasets/ministere-culture/comparia-conversations'
-      },
-      {
-        i18nKey: 'reactions',
-        img: `/datasets/reactions-${locale === 'fr' ? 'fr' : 'en'}.png`,
-        link: 'https://huggingface.co/datasets/ministere-culture/comparia-reactions'
-      },
-      {
-        i18nKey: 'votes',
-        img: `/datasets/votes-${locale === 'fr' ? 'fr' : 'en'}.png`,
-        link: 'https://huggingface.co/datasets/ministere-culture/comparia-votes'
-      }
-    ] as const
-  ).map(({ i18nKey, ...card }) => ({
-    ...card,
-    title: m[`datasets.access.repos.${i18nKey}.title`](),
-    desc: m[`datasets.access.repos.${i18nKey}.desc`]()
-  }))
+  const datasetCard = {
+    img: `/datasets/conversations-${locale === 'fr' ? 'fr' : 'en'}.png`,
+    link: 'https://huggingface.co/datasets/comparIA/comparia-fr-arena',
+    title: m['datasets.access.repos.arena.title'](),
+    desc: m['datasets.access.repos.arena.desc']()
+  }
 
   const bunkaCards = (
     [
@@ -81,26 +64,27 @@
           />
         </div>
 
-        <div
-          class="gap-4 sm:grid-cols-3 md:content-center md:gap-6 lg:grid-cols-2 xl:grid-cols-3 grid grid-cols-2"
-        >
-          {#each datasetCards as card, i (i)}
-            <div class="cg-border bg-very-light-grey">
-              <img
-                src={card.img}
-                class="fr-responsive-img rounded-t-xl"
-                data-fr-js-ratio="true"
-                aria-hidden="true"
-                alt=""
-              />
-              <div class="px-3 pt-2 pb-4">
-                <p class="mb-1! text-sm!">
-                  <Link variant="primary" href={card.link} text={card.title} native={false} />
-                </p>
-                <p class="mb-0! text-xs! text-grey">{card.desc}</p>
-              </div>
+        <div class="md:content-center grid">
+          <div class="cg-border bg-very-light-grey mx-auto w-full max-w-xs">
+            <img
+              src={datasetCard.img}
+              class="fr-responsive-img rounded-t-xl"
+              data-fr-js-ratio="true"
+              aria-hidden="true"
+              alt=""
+            />
+            <div class="px-3 pt-2 pb-4">
+              <p class="mb-1! text-sm!">
+                <Link
+                  variant="primary"
+                  href={datasetCard.link}
+                  text={datasetCard.title}
+                  native={false}
+                />
+              </p>
+              <p class="mb-0! text-xs! text-grey">{datasetCard.desc}</p>
             </div>
-          {/each}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
We consolidated conversations, reactions and votes into one dataset, so the datasets page should reflect that.

What changed:
- The page now points to the single `comparIA/comparia-fr-arena` dataset instead of the three `ministere-culture/comparia-*` repos.
- Replaced the three-card grid with a single centered card.
- Updated the `datasets.access.repos.*` strings in every locale (dropped conversations/reactions/votes, added an `arena` entry).

Note: the card still reuses the existing `conversations` screenshot as a placeholder image since we don't have a dedicated one for the new dataset yet. Happy to swap it once we have a proper screenshot.