### PR TITLE
Content-safety guardrail on arena prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,13 @@ export OPENROUTER_API_KEY=
 # Web search API
 export LINKUP_API_KEY=
 
+# Content-safety guardrail. Any litellm-routable model works, but the parser
+# expects Nemotron's "User Safety: ... / Safety Categories: ..." output format.
+export GUARDRAIL_MODEL=openrouter/nvidia/nemotron-3.5-content-safety:free
+# export GUARDRAIL_ENABLED=true     # run the check + record verdicts (shadow mode)
+# export GUARDRAIL_ENFORCE=false    # actually block egregious prompts
+# export GUARDRAIL_TIMEOUT=2.5
+
 # Development
 # export MOCK_RESPONSE=true
 # export LANGUIA_DEBUG=true

--- a/backend/arena/moderation.py
+++ b/backend/arena/moderation.py
@@ -1,0 +1,176 @@
+"""
+Content-safety guardrail for user prompts.
+
+Sends the user message to NVIDIA Nemotron 3.5 Content Safety (Aegis 2.0 taxonomy)
+via OpenRouter and decides whether a small set of egregious categories should be
+blocked before any arena model is called. Everything else passes through.
+
+Two independent switches (careful rollout):
+- GUARDRAIL_ENABLED: run the check, log + persist the verdict (shadow mode).
+- GUARDRAIL_ENFORCE: actually block. When False, the verdict is observed only
+  and the prompt always proceeds.
+
+Fails open: if the guardrail errors or times out, the prompt is allowed (this is
+a comparison tool, not a hard gate). Fail-open is NOT fail-silent: failures are
+logged at error level and sent to Sentry so a dark guard is visible.
+
+Model output looks like:
+    User Safety: safe
+    User Safety: unsafe\nSafety Categories: Guns and Illegal Weapons, Criminal Planning/Confessions
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import litellm
+import sentry_sdk
+
+from backend.config import settings
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+logger = logging.getLogger("languia")
+
+# French refusals (platform default locale). No em dashes.
+_GENERIC = (
+    "Votre message n'a pas pu être envoyé car il enfreint nos conditions "
+    "d'utilisation. Veuillez le reformuler."
+)
+_SELF_HARM = (
+    "Si vous traversez une période difficile ou avez des pensées suicidaires, "
+    "vous n'êtes pas seul·e. Le 3114, numéro national de prévention du suicide, "
+    "est joignable gratuitement et de façon confidentielle 24h/24 et 7j/7."
+)
+
+# Keywords matched against the lowercased category line. Punctuation in the
+# emitted labels is unstable ("Guns and Illegal Weapons" vs "Guns/Illegal
+# Weapons"), so we match on stable substrings rather than exact category names.
+_OTHER_BLOCK_KEYWORDS = ("weapon", "criminal planning", "controlled", "hate", "sexual")
+
+
+@dataclass
+class GuardrailVerdict:
+    """Result of one guardrail check. Persisted on the Turn and logged."""
+
+    safety: str  # "safe" | "unsafe" | "error"
+    categories: list[str]
+    block_message: str | None  # French refusal if egregious, else None
+    enforced: bool  # whether GUARDRAIL_ENFORCE was on for this check
+    model: str
+    latency_ms: int | None = None
+
+    @property
+    def should_block(self) -> bool:
+        """Block only when enforcing AND the prompt hit an egregious category."""
+        return self.enforced and self.block_message is not None
+
+    def as_record(self) -> dict:
+        """JSON-serializable form stored on Turn.guardrail."""
+        return {
+            "safety": self.safety,
+            "categories": self.categories,
+            "blocked": self.block_message is not None,  # would-block (egregious)
+            "enforced": self.enforced,
+            "model": self.model,
+            "latency_ms": self.latency_ms,
+        }
+
+
+def classify(content: str) -> str | None:
+    """
+    Decide whether a Nemotron verdict should block. Returns the French refusal
+    message to show the user, or None to allow. Pure function (no network) so it
+    can be unit-tested against recorded model outputs.
+    """
+    text = content.lower()
+    if "unsafe" not in text:
+        return None
+
+    # CSAM ("Sexual (minor)") always blocks, no Needs Caution override.
+    if "minor" in text:
+        return _GENERIC
+
+    # Self-harm always shows the 3114 prevention line, exempt from the Needs
+    # Caution veto: missing a flagged suicide prompt is worse than occasionally
+    # showing the resource on a false positive.
+    if "suicide" in text or "self harm" in text or "self-harm" in text:
+        return _SELF_HARM
+
+    # Needs Caution is the model's own hedge flag: suppress blocks on the
+    # borderline cases (e.g. violent fiction, harm-reduction drug talk).
+    if "needs caution" in text:
+        return None
+
+    if any(k in text for k in _OTHER_BLOCK_KEYWORDS):
+        return _GENERIC
+
+    return None
+
+
+def _categories(content: str) -> list[str]:
+    """Parse the 'Safety Categories: a, b' line into a list (best effort)."""
+    if "Safety Categories:" not in content:
+        return []
+    tail = content.split("Safety Categories:", 1)[1]
+    return [c.strip() for c in tail.replace("\n", " ").split(",") if c.strip()]
+
+
+async def check_prompt(
+    text: str, request: "Request | None" = None
+) -> GuardrailVerdict | None:
+    """
+    Run the guardrail on a user prompt. Returns a GuardrailVerdict (for logging
+    and persistence) or None when the guardrail is disabled / unconfigured.
+
+    The caller blocks only when `verdict.should_block` is True; otherwise the
+    prompt proceeds and the verdict is recorded for observability.
+
+    This is a synchronous pre-check, so it adds the guardrail's latency before
+    streaming starts. If that becomes a problem it can run concurrently with the
+    model streams and abort on a block, since the prompt is known up front.
+    """
+    if not settings.GUARDRAIL_ENABLED or not settings.OPENROUTER_API_KEY:
+        return None
+
+    started = time.monotonic()
+
+    try:
+        response = await litellm.acompletion(
+            model=settings.GUARDRAIL_MODEL,
+            api_key=settings.OPENROUTER_API_KEY,
+            messages=[{"role": "user", "content": text}],
+            stream=False,
+            timeout=settings.GUARDRAIL_TIMEOUT,
+            max_tokens=128,
+            # Disable THINK mode: we want the terse "User Safety: ..." verdict in
+            # content, not a chain-of-thought that overflows max_tokens.
+            reasoning={"enabled": False},
+        )
+        content = response.choices[0].message.content or ""
+    except Exception as e:
+        # Fail open, but make it visible: a dark guard must not be silent.
+        logger.error(f"guardrail_check_failed: {e}", extra={"request": request})
+        if settings.SENTRY_DSN:
+            sentry_sdk.capture_exception(e)
+        return GuardrailVerdict(
+            safety="error",
+            categories=[],
+            block_message=None,
+            enforced=settings.GUARDRAIL_ENFORCE,
+            model=settings.GUARDRAIL_MODEL,
+            latency_ms=int((time.monotonic() - started) * 1000),
+        )
+
+    verdict = GuardrailVerdict(
+        safety="unsafe" if "unsafe" in content.lower() else "safe",
+        categories=_categories(content),
+        block_message=classify(content),
+        enforced=settings.GUARDRAIL_ENFORCE,
+        model=settings.GUARDRAIL_MODEL,
+        latency_ms=int((time.monotonic() - started) * 1000),
+    )
+    logger.info(f"guardrail_verdict: {verdict.as_record()}", extra={"request": request})
+    return verdict

--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -7,6 +7,7 @@ from fastapi.responses import StreamingResponse
 
 from backend.arena.captcha import generate_challenge
 from backend.arena.models import AddFirstTextBody, AddTextBody
+from backend.arena.moderation import GuardrailVerdict, check_prompt
 from backend.arena.reveal import RevealData, get_reveal_data
 from backend.arena.services import (
     add_comparison_turn,
@@ -19,8 +20,10 @@ from backend.arena.services import (
 )
 from backend.arena.session import (
     ComparisonMetadata,
+    increment_blocked_prompts,
     increment_custom_selections,
     increment_input_chars,
+    is_block_cooldown,
     is_custom_selection_ratelimited,
     is_ratelimited,
     retreive_comparison_metadata,
@@ -67,6 +70,33 @@ def assert_not_rate_limited(request: Request) -> None:
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Vous avez trop sollicité les modèles parmi les plus onéreux, veuillez réessayer dans quelques heures. Vous pouvez toujours solliciter des modèles plus petits.",
         )
+
+
+def assert_not_block_cooldown(request: Request) -> None:
+    """Cool down IPs that keep tripping the content-safety guardrail."""
+    if is_block_cooldown(get_ip(request)):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Trop de messages bloqués ont été envoyés depuis votre connexion. Veuillez patienter avant de réessayer.",
+        )
+
+
+async def run_guardrail(
+    text: str, field: str, request: Request
+) -> GuardrailVerdict | None:
+    """
+    Run the content-safety guardrail on a user prompt. Raises a 422 (shaped like
+    a Pydantic validation error so the frontend renders it under the input) when
+    the prompt is blocked, otherwise returns the verdict to persist on the turn.
+    """
+    verdict = await check_prompt(text, request)
+    if verdict and verdict.should_block:
+        increment_blocked_prompts(get_ip(request))
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=[{"loc": ["body", field], "msg": verdict.block_message, "type": "value_error"}],
+        )
+    return verdict
 
 
 def get_comparison_id(id: UUID = Header(..., alias="X-Comparison-Id")) -> UUID:
@@ -122,7 +152,10 @@ async def get_challenge() -> dict:
     return generate_challenge()
 
 
-@router.post("/add_first_text", dependencies=[Depends(assert_not_rate_limited)])
+@router.post(
+    "/add_first_text",
+    dependencies=[Depends(assert_not_rate_limited), Depends(assert_not_block_cooldown)],
+)
 async def add_first_text(args: AddFirstTextBody, request: Request) -> StreamingResponse:
     """
     Process user's first message and initiate Comparison.
@@ -160,6 +193,8 @@ async def add_first_text(args: AddFirstTextBody, request: Request) -> StreamingR
                 detail="rate_limit_custom_selection",
             )
         increment_custom_selections(ip)
+
+    guardrail = await run_guardrail(args.prompt_value, "prompt_value", request)
 
     # Select LLMs
     llms_data = get_llms_data()
@@ -204,7 +239,10 @@ async def add_first_text(args: AddFirstTextBody, request: Request) -> StreamingR
 
         # Add first turn and save it to db (to at least save the user prompt)
         comparison, turn = await add_comparison_turn(
-            comparison.id, args.prompt_value, web_search_results
+            comparison.id,
+            args.prompt_value,
+            web_search_results,
+            guardrail=guardrail.as_record() if guardrail else None,
         )
         store_comparison_metadata(comparison.id, is_streaming=True)
 
@@ -227,7 +265,10 @@ async def add_first_text(args: AddFirstTextBody, request: Request) -> StreamingR
     return create_sse_response(event_stream(comparison))
 
 
-@router.post("/add_text", dependencies=[Depends(assert_not_rate_limited)])
+@router.post(
+    "/add_text",
+    dependencies=[Depends(assert_not_rate_limited), Depends(assert_not_block_cooldown)],
+)
 async def add_text(
     args: AddTextBody,
     metadata: ComparisonMetadataAnno,
@@ -257,12 +298,18 @@ async def add_text(
         extra={"request": request},
     )
 
+    guardrail = await run_guardrail(args.message, "message", request)
+
     # Assert last turn has vote
 
     # Stream responses
     async def event_stream() -> AsyncGenerator[str]:
         # Add new turn and save it to db (to at least save the user prompt)
-        comparison, turn = await add_comparison_turn(metadata.id, args.message)
+        comparison, turn = await add_comparison_turn(
+            metadata.id,
+            args.message,
+            guardrail=guardrail.as_record() if guardrail else None,
+        )
         store_comparison_metadata(comparison.id, is_streaming=True)
 
         yield format_sse_event({"type": "add", "turn": TurnPublic.model_validate(turn)})

--- a/backend/arena/services.py
+++ b/backend/arena/services.py
@@ -125,11 +125,13 @@ async def add_comparison_turn(
     comparison_id: uuid.UUID,
     prompt: str,
     web_search_results: list[LinkupSearchTextResult] | None = None,
+    guardrail: dict | None = None,
 ) -> tuple[ComparisonRead, TurnRead]:
     async with get_session() as session:
         db_turn = Turn.model_validate(
             TurnCreate(
                 comparison_id=comparison_id,
+                guardrail=guardrail,
                 user_msg=UserMessage(
                     content=prompt,
                     web_search_results=(

--- a/backend/arena/session.py
+++ b/backend/arena/session.py
@@ -12,11 +12,13 @@ from typing import Awaitable
 from pydantic import BaseModel, ValidationError
 
 from backend.config import (
+    RATELIMIT_BLOCKED_PROMPTS_PER_HOUR,
     RATELIMIT_CUSTOM_SELECTION_PER_DAY,
     RATELIMIT_CUSTOM_SELECTION_PER_HOUR,
     RATELIMIT_PRICEY_MODELS_INPUT,
 )
 from utils.storage.redis import (
+    REDIS_BLOCKED_COUNT_KEY,
     REDIS_COMPARISON_KEY,
     REDIS_CUSTOM_DAILY_KEY,
     REDIS_CUSTOM_HOURLY_KEY,
@@ -168,4 +170,32 @@ def is_ratelimited(ip: str) -> bool:
     if counter and int(counter) > RATELIMIT_PRICEY_MODELS_INPUT * 2:
         return True
     else:
+        return False
+
+
+def increment_blocked_prompts(ip: str) -> None:
+    """
+    Count guardrail-blocked prompts per IP in a rolling 1h window (cooldown for
+    abuse / jailbreak probing). Fails open: a Redis error must not break the flow.
+    """
+    try:
+        client = get_redis_client()
+        client.incr(REDIS_BLOCKED_COUNT_KEY.format(ip=ip))
+        client.expire(REDIS_BLOCKED_COUNT_KEY.format(ip=ip), 3600)
+    except Exception as e:
+        logger.error(f"[SESSION] Error incrementing blocked count for '{ip}': {e}")
+
+
+def is_block_cooldown(ip: str) -> bool:
+    """
+    True if an IP has had too many guardrail-blocked prompts in the window.
+    Fails open (returns False) on Redis error so a hiccup can't lock users out.
+    """
+    try:
+        client = get_redis_client()
+        counter = client.get(REDIS_BLOCKED_COUNT_KEY.format(ip=ip))
+        assert not isinstance(counter, Awaitable)
+        return bool(counter and int(counter) >= RATELIMIT_BLOCKED_PROMPTS_PER_HOUR)
+    except Exception as e:
+        logger.error(f"[SESSION] Error checking block cooldown for '{ip}': {e}")
         return False

--- a/backend/config.py
+++ b/backend/config.py
@@ -39,6 +39,15 @@ class Settings(BaseSettings):
     VOTES_OBJECTIVE: int = 300_000
     ALTCHA_HMAC_KEY: str = ""
 
+    # Content-safety guardrail (Nemotron via OpenRouter). No-ops without OPENROUTER_API_KEY.
+    # ENABLED runs the check and records the verdict (shadow mode); ENFORCE must
+    # also be on for an egregious prompt to actually be blocked. Ship in shadow
+    # first, watch the verdicts, then turn ENFORCE on.
+    GUARDRAIL_ENABLED: bool = True
+    GUARDRAIL_ENFORCE: bool = False
+    GUARDRAIL_MODEL: str = "openrouter/nvidia/nemotron-3.5-content-safety:free"
+    GUARDRAIL_TIMEOUT: float = 2.5
+
     # Response caching
     CACHE_ENABLED: bool = False
     CACHE_PROBABILITY: float = 0.5  # Probability of serving a cached response on hit
@@ -104,6 +113,13 @@ RATELIMIT_PRICEY_MODELS_INPUT = 50_000
 # Rate limiting for custom model selection per IP
 RATELIMIT_CUSTOM_SELECTION_PER_HOUR = 3
 RATELIMIT_CUSTOM_SELECTION_PER_DAY = 5
+
+# Cooldown for IPs that hit the content-safety guardrail too often (abuse /
+# jailbreak probing). Counts only enforced blocks in a rolling window; once an
+# IP crosses the threshold it is cooled down for the rest of the window WITHOUT
+# calling the guardrail (protects OpenRouter quota). Kept generous because gov
+# users share NAT IPs (hospitals, ministries) and must not be locked out.
+RATELIMIT_BLOCKED_PROMPTS_PER_HOUR = 15
 
 # Character limit for blind mode (comparison without model names)
 BLIND_MODE_INPUT_CHAR_LEN_LIMIT = 60_000

--- a/tests/arena/test_moderation.py
+++ b/tests/arena/test_moderation.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for the content-safety guardrail's pure parsing/decision logic
+(no network, no DB).
+
+Run with pytest, or directly:
+    uv run python tests/arena/test_moderation.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.arena.moderation import _GENERIC, _SELF_HARM, _categories, classify
+
+
+def test_safe_prompt_is_allowed():
+    assert classify("User Safety: safe") is None
+
+
+def test_violence_alone_is_allowed():
+    assert classify("User Safety: unsafe\nSafety Categories: Violence") is None
+
+
+def test_needs_caution_suppresses_block():
+    assert (
+        classify("User Safety: unsafe\nSafety Categories: Violence, Needs Caution")
+        is None
+    )
+
+
+def test_egregious_categories_block():
+    assert classify(
+        "User Safety: unsafe\nSafety Categories: Guns and Illegal Weapons, Criminal Planning/Confessions"
+    ) is _GENERIC
+    assert classify(
+        "User Safety: unsafe\nSafety Categories: Hate/Identity Hate, Violence"
+    ) is _GENERIC
+    assert classify(
+        "User Safety: unsafe\nSafety Categories: Controlled/Regulated Substances"
+    ) is _GENERIC
+    assert classify("User Safety: unsafe\nSafety Categories: Sexual") is _GENERIC
+
+
+def test_self_harm_redirects_even_with_needs_caution():
+    assert (
+        classify("User Safety: unsafe\nSafety Categories: Suicide and Self Harm")
+        is _SELF_HARM
+    )
+    assert (
+        classify(
+            "User Safety: unsafe\nSafety Categories: Suicide and Self Harm, Needs Caution"
+        )
+        is _SELF_HARM
+    )
+
+
+def test_csam_blocks_even_with_needs_caution():
+    assert classify(
+        "User Safety: unsafe\nSafety Categories: Sexual (minor), Needs Caution"
+    ) is _GENERIC
+
+
+def test_pii_alone_is_not_blocked():
+    assert classify("User Safety: unsafe\nSafety Categories: PII/Privacy") is None
+
+
+def test_category_parsing():
+    assert _categories("User Safety: safe") == []
+    assert _categories(
+        "User Safety: unsafe\nSafety Categories: Hate/Identity Hate, Violence"
+    ) == ["Hate/Identity Hate", "Violence"]
+
+
+def run():
+    test_safe_prompt_is_allowed()
+    test_violence_alone_is_allowed()
+    test_needs_caution_suppresses_block()
+    test_egregious_categories_block()
+    test_self_harm_redirects_even_with_needs_caution()
+    test_csam_blocks_even_with_needs_caution()
+    test_pii_alone_is_not_blocked()
+    test_category_parsing()
+    print("All guardrail classify cases passed.")
+
+
+if __name__ == "__main__":
+    run()

--- a/utils/database/alembic/versions/b7c4d1e8f9a2_add_turn_guardrail.py
+++ b/utils/database/alembic/versions/b7c4d1e8f9a2_add_turn_guardrail.py
@@ -1,0 +1,29 @@
+"""add Turn 'guardrail'
+
+Revision ID: b7c4d1e8f9a2
+Revises: 89de92001a7e
+Create Date: 2026-06-22 10:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7c4d1e8f9a2'
+down_revision: Union[str, Sequence[str], None] = '89de92001a7e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('turn', sa.Column('guardrail', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('turn', 'guardrail')

--- a/utils/database/models/turn.py
+++ b/utils/database/models/turn.py
@@ -38,6 +38,10 @@ class TurnBase(SQLModel):
     # Set when the user submits their choice vote (once per turn). Used to
     # measure how long they took to vote after both models finished.
     voted_at: OptionalDatetime = None
+    # Content-safety guardrail verdict for this turn's user prompt (see
+    # backend/arena/moderation.py GuardrailVerdict.as_record). Raw-only: not
+    # exposed in TurnPublic, intended for the -raw dataset, not the public one.
+    guardrail: Annotated[dict | None, Field(sa_type=JSONB)] = None
 
     # a
     llm_msg_a_id: LLMMessageId = None

--- a/utils/storage/redis.py
+++ b/utils/storage/redis.py
@@ -16,6 +16,7 @@ REDIS_COMPARISON_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}comparison:{{id}}"
 REDIS_USER_CHAR_COUNT: Final[str] = f"{REDIS_INSTANCE_PREFIX}ip:{{ip}}"
 REDIS_CUSTOM_HOURLY_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}custom_hourly:{{ip}}"
 REDIS_CUSTOM_DAILY_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}custom_daily:{{ip}}"
+REDIS_BLOCKED_COUNT_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}guardrail_blocked:{{ip}}"
 REDIS_VOTE_COUNT_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}count"
 REDIS_RANKING_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}rankings_and_prefs"
 REDIS_LLM_RESPONSES_KEY: Final[str] = (


### PR DESCRIPTION
Adds an optional content-safety check on arena prompts. Each prompt is sent to a guardrail model (Nemotron via OpenRouter, set by GUARDRAIL_MODEL) before the arena models are called.

Two switches: GUARDRAIL_ENABLED runs the check and records a verdict on the turn, GUARDRAIL_ENFORCE (off by default) actually blocks a small set of egregious categories (CSAM, weapons, criminal planning, controlled substances, hate, sexual), with self-harm redirected to the 3114 prevention line. The plan is to ship in shadow mode, watch the verdicts, then enable enforcement.

It fails open: any guardrail error or timeout lets the prompt through, logged and sent to Sentry. IPs that repeatedly trip the guardrail get a short per-IP cooldown, reusing the existing Redis rate-limit pattern.

The verdict is persisted on a new turn.guardrail column (excluded from the public API and intended for the raw dataset only). Surfacing it into the raw dataset export is a follow-up, since that needs the dataset equivalence test run against a database.