### PR TITLE
fix(front): allow editing model selection before writing the prompt

### DIFF
--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -75,7 +75,7 @@
             "finished": "Raisonnement terminé",
             "inProgress": "Raisonnement en cours…"
         },
-        "revealButton": "Terminer la discussion et découvrir les deux modèles",
+        "revealButton": "Terminer et découvrir les modèles",
         "webSearch": {
             "label": "Résultats de recherche Web associés."
         }

--- a/frontend/src/lib/components/TextPrompt.svelte
+++ b/frontend/src/lib/components/TextPrompt.svelte
@@ -21,6 +21,7 @@
     class?: string
     onSubmit?: (value: string) => void
     onBlur?: (value: string) => void
+    onFocus?: () => void
   } & Partial<Pick<HTMLTextAreaElement, 'disabled' | 'placeholder' | 'rows'>>
 
   let {
@@ -41,6 +42,7 @@
     class: classNames = '',
     onSubmit = noop,
     onBlur = noop,
+    onFocus = noop,
     ...nativeTextAreaProps
   }: TextAreaProps = $props()
 
@@ -84,7 +86,7 @@
       {rows}
       class={[
         roundedClass,
-        'fr-input cg-border bg-white! md:min-h-10! rounded-b-none! border-solid!'
+        'fr-input cg-border bg-white! text-sm! md:text-base md:min-h-10! rounded-b-none! border-solid!'
       ]}
       {...nativeTextAreaProps}
       aria-describedby="messages-{id}"
@@ -92,6 +94,7 @@
       onblur={() => onBlur?.(value)}
       {@attach updateAuto}
       {@attach updateRows}
+      onfocus={onFocus}
     ></textarea>
     {#if submitBtn}
       <Button

--- a/frontend/src/routes/arene/components/GroupedMessages.svelte
+++ b/frontend/src/routes/arene/components/GroupedMessages.svelte
@@ -4,7 +4,7 @@
   import type { AnyAPIVote, ComparisonTurn } from '$lib/chatService.svelte'
   import { scrollTo } from '$lib/helpers/attachments'
   import { m } from '$lib/i18n/messages'
-  import { onMount, type Snippet } from 'svelte'
+  import { type Snippet } from 'svelte'
   import { ErrorDisplay, MessageBot, MessageUser, VoteSelect } from '.'
 
   let {
@@ -22,59 +22,50 @@
     onRetry: () => void
     children: Snippet<[]> | undefined
   } = $props()
-
-  let userBlockElem = $state<HTMLDivElement>()
-  let userMessageSize = $state(0)
-
-  onMount(() => {
-    userMessageSize = userBlockElem!.offsetHeight
-  })
 </script>
 
-<div
-  class="grouped-messages px-4 py-5 md:px-8 xl:px-16 flex flex-col"
-  style="--message-size: {userMessageSize}px;"
-  {@attach scrollTo}
->
-  <div class="mb-5 md:flex" bind:this={userBlockElem}>
+<div class="grouped-messages px-4 py-2 md:py-5 md:px-8 xl:px-16 gap-2 md:gap-5 flex flex-col">
+  <div class="md:flex">
     {@render children?.()}
 
     <MessageUser id={`user-${turn.id}`} message={turn.user_msg} />
   </div>
-  {#if turn.status === 'pending'}
-    <Pending message={m['chatbot.loading']()} class="m-auto" />
-  {:else if turn.status === 'error' && error}
-    <ErrorDisplay {error} class="mt-10" {onRetry} />
-  {:else}
-    <SideSwitcher>
-      <div class="gap-4 sm:gap-6 md:w-full flex">
-        {#if turn.a.llm_msg && turn.b.llm_msg}
-          <MessageBot
-            id="{turn.id}-a"
-            turnSide={turn.a}
-            bot="a"
-            choice={turn.choice}
-            {disabled}
-            onVoteAnnotate={(data) => onVote({ turn_id: turn.id, ...data })}
-          />
+  <div class="grouped-responses flex flex-col" {@attach scrollTo}>
+    {#if turn.status === 'pending'}
+      <Pending message={m['chatbot.loading']()} class="m-auto" />
+    {:else if turn.status === 'error' && error}
+      <ErrorDisplay {error} class="mt-10" {onRetry} />
+    {:else}
+      <SideSwitcher>
+        <div class="gap-4 sm:gap-6 md:w-full flex">
+          {#if turn.a.llm_msg && turn.b.llm_msg}
+            <MessageBot
+              id="{turn.id}-a"
+              turnSide={turn.a}
+              bot="a"
+              choice={turn.choice}
+              {disabled}
+              onVoteAnnotate={(data) => onVote({ turn_id: turn.id, ...data })}
+            />
 
-          <MessageBot
-            id="{turn.id}-b"
-            turnSide={turn.b}
-            bot="b"
-            choice={turn.choice}
-            {disabled}
-            onVoteAnnotate={(data) => onVote({ turn_id: turn.id, ...data })}
-          />
-        {/if}
-      </div>
-    </SideSwitcher>
-  {/if}
+            <MessageBot
+              id="{turn.id}-b"
+              turnSide={turn.b}
+              bot="b"
+              choice={turn.choice}
+              {disabled}
+              onVoteAnnotate={(data) => onVote({ turn_id: turn.id, ...data })}
+            />
+          {/if}
+        </div>
+      </SideSwitcher>
+    {/if}
 
-  {#if turn.status === 'complete' && !turn.choice}
-    <VoteSelect
-      id="vote-select-{turn.id}"
-      onVote={(choice) => onVote({ turn_id: turn.id, choice })}
-    />
-  {/if}
+    {#if turn.status === 'complete' && !turn.choice}
+      <VoteSelect
+        id="vote-select-{turn.id}"
+        onVote={(choice) => onVote({ turn_id: turn.id, choice })}
+      />
+    {/if}
+  </div>
 </div>

--- a/frontend/src/routes/arene/components/ViewChat.svelte
+++ b/frontend/src/routes/arene/components/ViewChat.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { Button, Icon, Tooltip } from '$components/dsfr'
   import Footer from '$components/Footer.svelte'
-  import Pending from '$components/Pending.svelte'
   import TextPrompt from '$components/TextPrompt.svelte'
   import { getComparison, modeInfos } from '$lib/chatService.svelte'
-  import { scrollTo } from '$lib/helpers/attachments'
   import { m } from '$lib/i18n/messages'
   import { GroupedMessages, RevealArea, VoteModal } from '.'
 
@@ -68,10 +66,6 @@
         {/if}
       </GroupedMessages>
     {/each}
-
-    {#if comparator.loading}
-      <Pending message={m['chatbot.loading']()} class="m-auto" {@attach scrollTo} />
-    {/if}
   </div>
 
   {#if comparator.status === 'revealed' && comparator.comparison.reveal}
@@ -81,25 +75,24 @@
     <div
       bind:this={footer}
       id="send-area"
-      class="bottom-0 gap-3 px-4 py-3 md:px-[20%] sticky z-2 mt-auto flex flex-col items-center bg-linear-(--my-gradient)"
+      class="-bottom-24 md:bottom-0 gap-3 px-4 py-3 md:px-[20%] sticky z-2 mt-auto flex flex-col items-center bg-linear-(--my-gradient)"
     >
-      <div class="gap-3 md:flex-row flex w-full flex-col">
-        <TextPrompt
-          id="chatbot-prompt"
-          bind:value={prompt}
-          label={m['chatbot.continuePrompt']()}
-          placeholder={m['chatbot.continuePrompt']()}
-          error={comparator.promptError}
-          hideLabel
-          submitBtn
-          submitDisabled={!canContinue || prompt === ''}
-          size="md"
-          rows={3}
-          maxRows={4}
-          onSubmit={onPromptSubmit}
-          class="mb-0! w-full"
-        />
-      </div>
+      <TextPrompt
+        id="chatbot-prompt"
+        bind:value={prompt}
+        label={m['chatbot.continuePrompt']()}
+        placeholder={m['chatbot.continuePrompt']()}
+        error={comparator.promptError}
+        hideLabel
+        submitBtn
+        submitDisabled={!canContinue || prompt === ''}
+        size="md"
+        rows={3}
+        maxRows={4}
+        onSubmit={onPromptSubmit}
+        onFocus={() => window.scrollTo(0, document.body.scrollHeight)}
+        class="mb-0! w-full"
+      />
 
       <Button
         text={m['chatbot.revealButton']()}
@@ -125,11 +118,22 @@
   }
 
   :global(#chat-area .grouped-messages) {
-    max-height: calc(100vh - var(--second-header-size) - var(--footer-size));
-    scroll-margin-top: calc(var(--second-header-size));
+    :global(.grouped-responses) {
+      max-height: calc(100vh - 2rem);
+      scroll-margin-top: 2rem;
+      min-height: 500px;
 
-    &:last-of-type {
-      height: calc(100vh - var(--second-header-size) - var(--footer-size));
+      @media (min-width: 48em) and (min-height: 48em) {
+        max-height: calc(100vh - var(--footer-size) - 2rem);
+      }
+    }
+
+    :global(&:last-of-type .grouped-responses) {
+      height: calc(100vh - 6rem);
+
+      @media (min-width: 48em) and (min-height: 48em) {
+        height: calc(100vh - var(--footer-size) - 4rem);
+      }
     }
   }
 </style>

--- a/frontend/src/routes/arene/components/ViewPrompt.svelte
+++ b/frontend/src/routes/arene/components/ViewPrompt.svelte
@@ -126,7 +126,7 @@
           bind:mode={mode.value}
           bind:modelsSelection={modelsSelection.value}
           {models}
-          {disabled}
+          disabled={loading}
         />
         <Toggle
           id="web-search"

--- a/frontend/src/routes/arene/components/VoteAnnotate.svelte
+++ b/frontend/src/routes/arene/components/VoteAnnotate.svelte
@@ -69,8 +69,8 @@
     choices={keywordChoices.choices}
     multiple
     {disabled}
-    containerClass="flex flex-wrap gap-3"
-    choiceClass="px-3 py-2 rounded-full lh-none! has-checked:text-primary! text-[14px]! bg-white"
+    containerClass="flex flex-wrap gap-1"
+    choiceClass="px-2 py-1 md:px-3 md:py-2 rounded-full lh-none! has-checked:text-primary! text-xs! md:text-[14px]! bg-white"
     onChange={() => onUpdate(annotations)}
   />
 </form>

--- a/frontend/src/routes/arene/components/VoteSelect.svelte
+++ b/frontend/src/routes/arene/components/VoteSelect.svelte
@@ -38,20 +38,20 @@
   onDestroy(() => clearTimeout(voteTimeout))
 </script>
 
-<form class="px-4 w-full" novalidate onsubmit={onSubmit}>
+<form class="px-1 md:px-4 w-full" novalidate onsubmit={onSubmit}>
   <fieldset
     {id}
     aria-labelledby="{id}-legend {id}-help"
-    class="cl-vote-select xl:max-w-[950px] bg-light-info py-2 px-5 rounded-b-xl shadow-md gap-1 mx-auto flex flex-col"
+    class="cl-vote-select xl:max-w-[950px] bg-light-info py-2 px-2 md:px-5 rounded-b-xl shadow-md gap-1 mx-auto flex flex-col"
   >
     <legend id="display-fieldset-legend" class="sr-only">{m['vote.title']()}</legend>
 
-    <div class="gap-2 grid-cols-2 md:grid-cols-4 grid">
+    <div class="gap-1 md:gap-2 md:grid-cols-4 grid grid-cols-2">
       {#each choices as choice (choice.value)}
         <button
           type="submit"
           class={[
-            'cl-vote-choice rounded-lg p-2 text-xs! bg-white cg-border flex items-center',
+            'cl-vote-choice rounded-lg px-1 py-2 md:p-2 text-xs! bg-white cg-border flex items-center',
             { 'cl-vote-picked': pickedChoice === choice.value }
           ]}
           data-choice={choice.value}
@@ -71,7 +71,10 @@
       </button>
     </div>
 
-    <p id="{id}-help" class="mb-0! text-grey lh-normal! text-center text-[11px]!">
+    <p
+      id="{id}-help"
+      class="mb-0! text-grey lh-normal! md:not-sr-only sr-only text-center text-[11px]!"
+    >
       {@html sanitize(
         m['vote.turn.important']({
           linkProps: propsToAttrs({


### PR DESCRIPTION
On the first-prompt screen the model selector was disabled until you typed something, because it reused the submit button's disabled flag (empty prompt, prompt error, or loading). That blocks a common case: arriving with a model pair carried over from a previous discussion and wanting to change it before writing. It also just reads as broken.

The selector now only disables while a request is loading. Submit stays gated on an empty/invalid prompt as before.