### PR TITLE
Fix: delete comparisons and related items with unknown llm_id_a|b

### DIFF
--- a/utils/database/actions/__init__.py
+++ b/utils/database/actions/__init__.py
@@ -1,7 +1,7 @@
 from .archive_blacklisted_grok import archive_blacklisted_grok
 from .archive_corrupted import archive_corrupted
 from .archive_spam import archive_spam
-from .archive_unknown_llms import archive_unknown_llms
+from .archive_unknown_llms import archive_unknown_llms, delete_unknown_llms_comparisons
 from .backfill_pii_spam import backfill_pii_spam
 from .llm_analyze import llm_analyze
 from .migrate_comparisons import migrate_comparisons

--- a/utils/database/actions/archive_unknown_llms.py
+++ b/utils/database/actions/archive_unknown_llms.py
@@ -1,7 +1,7 @@
 import logging
 
 import polars as pl
-from sqlmodel import and_, col, or_, select
+from sqlmodel import and_, col, delete, or_, select
 
 from utils.utils import LLMS_GENERATED_DATA_FILE, read_json
 
@@ -50,3 +50,48 @@ async def archive_unknown_llms(*, commit: bool = False) -> None:
         logger.warning(f"{count:4} comparisons with unknown LLM id: '{id}'")
 
     await archive(ids, "unknown_llm", commit=commit)
+
+
+async def delete_unknown_llms_comparisons(*, commit: bool = False) -> None:
+    """
+    Delete comparisons that refers to an unknown LLM (not in LLM list).
+    """
+    logger.info(f"Searching for unknown LLMs.")
+    llm_ids = list(
+        set(
+            [
+                id
+                for id, data in read_json(LLMS_GENERATED_DATA_FILE)["models"].items()
+                if data["status"] in ("enabled", "archived", "disabled")
+            ]
+        )
+    )
+
+    async with get_session() as session:
+        query = select(Comparison).where(
+            or_(
+                col(Comparison.llm_id_a).not_in(llm_ids),
+                col(Comparison.llm_id_b).not_in(llm_ids),
+            )
+        )
+
+        results = (await session.exec(query)).all()
+
+        extra_ids = set(
+            [c.llm_id_a for c in results] + [c.llm_id_b for c in results]
+        ).difference(llm_ids)
+
+        def count(id: str):
+            return len([c for c in results if c.llm_id_a == id or c.llm_id_b == id])
+
+        logger.warning(
+            f"Found {len(extra_ids)} unknown llm ids:\n{"\n".join(f" - {count(id)}: '{id}'" for id in extra_ids)}"
+        )
+
+        if not commit:
+            logger.warning(f"Would have removed {len(results)} comparisons.")
+        else:
+            logger.warning(f"Will remove {len(results)} comparisons.")
+            for r in results:
+                await session.delete(r)
+            await session.commit()

--- a/utils/database/cli.py
+++ b/utils/database/cli.py
@@ -10,6 +10,7 @@ from .actions import (
     archive_spam,
     archive_unknown_llms,
     backfill_pii_spam,
+    delete_unknown_llms_comparisons,
     llm_analyze,
     migrate_comparisons,
     migrate_llm_messages,
@@ -27,6 +28,7 @@ cli_archive = App(name="archive", help="Individual archival utilities.")
 cli_archive.command(archive_spam, name="spam")
 cli_archive.command(archive_corrupted, name="corrupted")
 cli_archive.command(archive_unknown_llms, name="unknown_llms")
+cli_archive.command(delete_unknown_llms_comparisons, name="delete_unknown_llms")
 cli_archive.command(archive_blacklisted_grok, name="blacklisted_grok")
 
 cli_migrate = App(

--- a/utils/database/models/comparison.py
+++ b/utils/database/models/comparison.py
@@ -91,6 +91,7 @@ class ComparisonWithAnalyzeData(ComparisonBase):
 class Comparison(ComparisonWithAnalyzeData, table=True):
     turns: list[Turn] = Relationship(
         back_populates="comparison",
+        cascade_delete=True,
         sa_relationship_kwargs={"lazy": "selectin", "order_by": "Turn.created_at"},
     )
 

--- a/utils/database/models/turn.py
+++ b/utils/database/models/turn.py
@@ -57,7 +57,8 @@ class TurnBase(SQLModel):
 class Turn(TurnBase, table=True):
     comparison: "Comparison" = Relationship(back_populates="turns")
     user_msg: UserMessage = Relationship(
-        sa_relationship_kwargs={"uselist": False, "lazy": "joined"}
+        cascade_delete=True,
+        sa_relationship_kwargs={"uselist": False, "lazy": "joined"},
     )
     llm_msg_a: LLMMessage | None = Relationship(
         sa_relationship_kwargs={"foreign_keys": "[Turn.llm_msg_a_id]", "lazy": "joined"}

--- a/utils/database/models/turn.py
+++ b/utils/database/models/turn.py
@@ -61,10 +61,20 @@ class Turn(TurnBase, table=True):
         sa_relationship_kwargs={"uselist": False, "lazy": "joined"},
     )
     llm_msg_a: LLMMessage | None = Relationship(
-        sa_relationship_kwargs={"foreign_keys": "[Turn.llm_msg_a_id]", "lazy": "joined"}
+        cascade_delete=True,
+        sa_relationship_kwargs={
+            "foreign_keys": "[Turn.llm_msg_a_id]",
+            "lazy": "joined",
+            "single_parent": True,
+        },
     )
     llm_msg_b: LLMMessage | None = Relationship(
-        sa_relationship_kwargs={"foreign_keys": "[Turn.llm_msg_b_id]", "lazy": "joined"}
+        cascade_delete=True,
+        sa_relationship_kwargs={
+            "foreign_keys": "[Turn.llm_msg_b_id]",
+            "lazy": "joined",
+            "single_parent": True,
+        },
     )
 
 


### PR DESCRIPTION
- added `cascade_delete=True` to:
  - Comparison.turns
  - Turn.user_msg
  - Turn.llm_msg_a
  - Turn.llm_msg_b
 - added `"single_parent": True` to Turn.llm_msg_a|b `sa_relationship_kwargs`
 
 # Infra
- [ ] run `./comparia-cli db archive delete_unknown_llms` to see number of affected comparisons
- [ ] run `./comparia-cli db archive delete_unknown_llms --commit` to actually delete those 