### PR TITLE
feat(admin): admin backoffice and user roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,13 @@ export SMTP_HOST=smtp-relay.brevo.com
 export SMTP_PORT=587
 export SMTP_USERNAME="<brevo account email>"
 export SMTP_PASSWORD="<SMTP key from Brevo Settings - SMTP & API>"
+
+# Auth
+# "anonymous_first" (default) or "sign_in_required"
+# export AUTH_ACCESS_POLICY=anonymous_first
+# export AUTH_DOMAIN_ALLOWLIST='["beta.gouv.fr"]'
+# export AUTH_SESSION_LENGTH_DAYS=30
+
+# Admin
+# Comma-separated list of emails to promote to admin role on startup (created if absent)
+# export ADMIN_EMAILS='["admin@example.com"]'

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ db-schema-dump: ## Dump current database schema (requires COMPARIA_DB_URI)
 
 db-seed-admins: ## Promote ADMIN_EMAILS users to admin role (requires COMPARIA_DB_URI)
 	@if [ -z "$$COMPARIA_DB_URI" ]; then echo "Error: COMPARIA_DB_URI is not set"; exit 1; fi
-	$(UV) run python -m utils.database.cli db seed-admins
+	./comparia-cli db seed-admins
 
 redis: ## Launch Redis using docker compose
 	@$(MAKE) network

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ db-schema-dump: ## Dump current database schema (requires COMPARIA_DB_URI)
 	@if [ -z "$$COMPARIA_DB_URI" ]; then echo "Error: COMPARIA_DB_URI is not set"; exit 1; fi
 	pg_dump "$$COMPARIA_DB_URI" --schema-only --no-owner --no-privileges
 
+db-seed-admins: ## Promote ADMIN_EMAILS users to admin role (requires COMPARIA_DB_URI)
+	@if [ -z "$$COMPARIA_DB_URI" ]; then echo "Error: COMPARIA_DB_URI is not set"; exit 1; fi
+	$(UV) run python -m utils.database.cli db seed-admins
+
 redis: ## Launch Redis using docker compose
 	@$(MAKE) network
 	@echo "Starting Redis..."

--- a/backend/admin/router.py
+++ b/backend/admin/router.py
@@ -1,0 +1,101 @@
+import uuid
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+
+from backend.admin.services import delete_user, list_users, set_user_role
+from backend.auth.dependencies import require_admin
+from backend.auth.email import send_login_code
+from backend.auth.services import request_login_code
+from utils.database.models.auth import User
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class UserOut(BaseModel):
+    id: uuid.UUID
+    email: str
+    role: str
+    created_at: str
+    last_seen_at: str
+    source: str
+
+
+class UsersPage(BaseModel):
+    items: list[UserOut]
+    total: int
+    page: int
+    page_size: int
+
+
+class SetRoleBody(BaseModel):
+    role: Literal["user", "admin"]
+
+
+class InviteBody(BaseModel):
+    email: str
+
+
+@router.get("/users", response_model=UsersPage)
+async def get_users(
+    _admin: Annotated[User, Depends(require_admin)],
+    search: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+) -> UsersPage:
+    rows, total = await list_users(search=search, page=page, page_size=page_size)
+    return UsersPage(
+        items=[
+            UserOut(
+                id=row.id,
+                email=row.email,
+                role=row.role,
+                created_at=row.created_at.isoformat(),
+                last_seen_at=row.last_seen_at.isoformat(),
+                source=row.source,
+            )
+            for row in rows
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.patch("/users/{user_id}/role", response_model=UserOut)
+async def patch_user_role(
+    user_id: uuid.UUID,
+    body: SetRoleBody,
+    _admin: Annotated[User, Depends(require_admin)],
+) -> UserOut:
+    user = await set_user_role(user_id, body.role)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return UserOut(
+        id=user.id,
+        email=user.email,
+        role=user.role,
+        created_at=user.created_at.isoformat(),
+        last_seen_at=user.last_seen_at.isoformat(),
+        source="email_code",
+    )
+
+
+@router.delete("/users/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_user(
+    user_id: uuid.UUID,
+    _admin: Annotated[User, Depends(require_admin)],
+) -> None:
+    deleted = await delete_user(user_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+
+@router.post("/users/invite", status_code=status.HTTP_204_NO_CONTENT)
+async def invite_user(
+    body: InviteBody,
+    _admin: Annotated[User, Depends(require_admin)],
+) -> None:
+    code = await request_login_code(body.email)
+    await send_login_code(body.email, code)

--- a/backend/admin/services.py
+++ b/backend/admin/services.py
@@ -1,0 +1,86 @@
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlmodel import col, func, select
+
+from utils.database.models.auth import LoginCode, User
+from utils.database.session import get_session
+
+
+@dataclass
+class UserRow:
+    id: uuid.UUID
+    email: str
+    role: str
+    created_at: datetime
+    last_seen_at: datetime
+    source: str
+
+
+async def list_users(
+    search: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[UserRow], int]:
+    async with get_session() as session:
+        base = select(User).where(User.deleted_at.is_(None))
+        if search:
+            base = base.where(col(User.email).ilike(f"%{search}%"))
+
+        count_result = await session.exec(
+            select(func.count()).select_from(base.subquery())
+        )
+        total = count_result.one()
+
+        result = await session.exec(
+            base.order_by(col(User.created_at).desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+        users = result.all()
+
+        rows = []
+        for user in users:
+            used_code = await session.exec(
+                select(LoginCode).where(
+                    LoginCode.user_id == user.id,
+                    LoginCode.used_at.is_not(None),
+                )
+            )
+            source = "email_code" if used_code.first() else "unknown"
+            rows.append(
+                UserRow(
+                    id=user.id,
+                    email=user.email,
+                    role=user.role,
+                    created_at=user.created_at,
+                    last_seen_at=user.last_seen_at,
+                    source=source,
+                )
+            )
+
+        return rows, total
+
+
+async def set_user_role(user_id: uuid.UUID, role: str) -> User | None:
+    async with get_session() as session:
+        user = await session.get(User, user_id)
+        if not user or user.deleted_at is not None:
+            return None
+        user.role = role
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+async def delete_user(user_id: uuid.UUID) -> bool:
+    async with get_session() as session:
+        user = await session.get(User, user_id)
+        if not user or user.deleted_at is not None:
+            return False
+        user.deleted_at = datetime.now()
+        session.add(user)
+        await session.commit()
+        return True

--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -1,0 +1,16 @@
+from fastapi import HTTPException, Request, status
+
+from backend.auth.services import get_user_from_token
+from utils.database.models.auth import User
+
+
+async def require_admin(request: Request) -> User:
+    token = request.cookies.get("auth_session")
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    user = await get_user_from_token(token)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    if user.role != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    return user

--- a/backend/auth/email.py
+++ b/backend/auth/email.py
@@ -1,53 +1,36 @@
-import asyncio
 import logging
-import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+
+import brevo
+from brevo.transactional_emails.types.send_transac_email_request_sender import (
+    SendTransacEmailRequestSender,
+)
+from brevo.transactional_emails.types.send_transac_email_request_to_item import (
+    SendTransacEmailRequestToItem,
+)
 
 from backend.config import settings
 
 logger = logging.getLogger("languia")
 
-_HTML_TEMPLATE = """\
-<!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"></head>
-<body style="font-family: arial, helvetica, sans-serif; color: #3b3f44; font-size: 16px; line-height: 1.5; max-width: 600px; margin: 0 auto; padding: 20px;">
-  <p>Bonjour,</p>
-  <p>Voici votre code de connexion à ComparIA&nbsp;:</p>
-  <p style="font-size: 32px; font-weight: bold; letter-spacing: 8px; text-align: center; padding: 20px 0;">{code}</p>
-  <p>Ce code est valable 10&nbsp;minutes. Si vous n'avez pas demandé à vous connecter, ignorez cet email.</p>
-  <p>L'équipe ComparIA</p>
-</body>
-</html>
-"""
-
 
 async def send_login_code(to_email: str, code: str) -> None:
-    if not settings.SMTP_HOST:
+    if not settings.BREVO_API_KEY or not settings.BREVO_LOGIN_CODE_TEMPLATE_ID:
         logger.info(f"[AUTH] Login code for {to_email}: {code}")
         return
-    logger.info(f"[AUTH] Sending login code via SMTP from={settings.EMAIL_FROM} to={to_email} host={settings.SMTP_HOST}")
+
+    logger.info(f"[AUTH] Sending login code via Brevo from={settings.EMAIL_FROM} to={to_email}")
     try:
-        await asyncio.to_thread(_send_smtp, to_email, code)
-        logger.info(f"[AUTH] Login code sent via SMTP to {to_email}")
+        client = brevo.AsyncBrevo(api_key=settings.BREVO_API_KEY)
+        await client.transactional_emails.send_transac_email(
+            to=[SendTransacEmailRequestToItem(email=to_email)],
+            sender=SendTransacEmailRequestSender(
+                email=settings.EMAIL_FROM,
+                name=settings.EMAIL_FROM_NAME,
+            ),
+            template_id=settings.BREVO_LOGIN_CODE_TEMPLATE_ID,
+            params={"code": code},
+        )
+        logger.info(f"[AUTH] Login code sent via Brevo to {to_email}")
     except Exception as e:
-        logger.error(f"[AUTH] SMTP failed for {to_email}: {e}")
+        logger.error(f"[AUTH] Brevo failed for {to_email}: {e}")
         raise
-
-
-def _send_smtp(to_email: str, code: str) -> None:
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = "Votre code de connexion ComparIA"
-    msg["From"] = f"{settings.EMAIL_FROM_NAME} <{settings.EMAIL_FROM}>"
-    msg["To"] = to_email
-    msg.attach(MIMEText(_HTML_TEMPLATE.format(code=code), "html", "utf-8"))
-
-    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT, timeout=10) as smtp:
-        smtp.ehlo()
-        if settings.SMTP_STARTTLS:
-            smtp.starttls()
-            smtp.ehlo()
-        if settings.SMTP_USERNAME and settings.SMTP_PASSWORD:
-            smtp.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
-        smtp.sendmail(settings.EMAIL_FROM, to_email, msg.as_string())

--- a/backend/auth/email.py
+++ b/backend/auth/email.py
@@ -1,36 +1,46 @@
+import asyncio
 import logging
-
-import brevo
-from brevo.transactional_emails.types.send_transac_email_request_sender import (
-    SendTransacEmailRequestSender,
-)
-from brevo.transactional_emails.types.send_transac_email_request_to_item import (
-    SendTransacEmailRequestToItem,
-)
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 
 from backend.config import settings
 
 logger = logging.getLogger("languia")
 
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body style="font-family: arial, helvetica, sans-serif; color: #3b3f44; font-size: 16px; line-height: 1.5; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <p>Bonjour,</p>
+  <p>Voici votre code de connexion à ComparIA&nbsp;:</p>
+  <p style="font-size: 32px; font-weight: bold; letter-spacing: 8px; text-align: center; padding: 20px 0;">{code}</p>
+  <p>Ce code est valable 10&nbsp;minutes. Si vous n'avez pas demandé à vous connecter, ignorez cet email.</p>
+  <p>L'équipe ComparIA</p>
+</body>
+</html>
+"""
+
 
 async def send_login_code(to_email: str, code: str) -> None:
-    if not settings.BREVO_API_KEY or not settings.BREVO_LOGIN_CODE_TEMPLATE_ID:
+    if not settings.SMTP_HOST:
         logger.info(f"[AUTH] Login code for {to_email}: {code}")
         return
+    await asyncio.to_thread(_send_smtp, to_email, code)
 
-    logger.info(f"[AUTH] Sending login code via Brevo from={settings.EMAIL_FROM} to={to_email}")
-    try:
-        client = brevo.AsyncBrevo(api_key=settings.BREVO_API_KEY)
-        await client.transactional_emails.send_transac_email(
-            to=[SendTransacEmailRequestToItem(email=to_email)],
-            sender=SendTransacEmailRequestSender(
-                email=settings.EMAIL_FROM,
-                name=settings.EMAIL_FROM_NAME,
-            ),
-            template_id=settings.BREVO_LOGIN_CODE_TEMPLATE_ID,
-            params={"code": code},
-        )
-        logger.info(f"[AUTH] Login code sent via Brevo to {to_email}")
-    except Exception as e:
-        logger.error(f"[AUTH] Brevo failed for {to_email}: {e}")
-        raise
+
+
+def _send_smtp(to_email: str, code: str) -> None:
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Votre code de connexion ComparIA"
+    msg["From"] = f"{settings.EMAIL_FROM_NAME} <{settings.EMAIL_FROM}>"
+    msg["To"] = to_email
+    msg.attach(MIMEText(_HTML_TEMPLATE.format(code=code), "html", "utf-8"))
+
+    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as smtp:
+        if settings.SMTP_STARTTLS:
+            smtp.starttls()
+        if settings.SMTP_USERNAME and settings.SMTP_PASSWORD:
+            smtp.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
+        smtp.sendmail(settings.EMAIL_FROM, to_email, msg.as_string())

--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -146,7 +146,7 @@ async def get_me(request: Request) -> dict:
     user = await get_user_from_token(token)
     if not user:
         return {"user": None}
-    return {"user": {"email": user.email}}
+    return {"user": {"email": user.email, "role": user.role}}
 
 
 =======

--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -21,11 +21,7 @@ logger = logging.getLogger("languia")
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-<<<<<<< HEAD
 _EMAIL_RATELIMIT_PER_HOUR = 15
-=======
-_EMAIL_RATELIMIT_PER_HOUR = 5
->>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
 
 
 class AuthConfig(BaseModel):
@@ -84,7 +80,6 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
             )
 
     code = await request_login_code(body.email)
-<<<<<<< HEAD
     try:
         await send_login_code(body.email, code)
     except Exception:
@@ -92,9 +87,6 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Failed to send login code, please try again later.",
         )
-=======
-    await send_login_code(body.email, code)
->>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
 
 
 @router.post("/email/verify")
@@ -137,7 +129,6 @@ async def logout(request: Request, response: Response) -> None:
     response.delete_cookie("auth_session")
 
 
-<<<<<<< HEAD
 @router.get("/me")
 async def get_me(request: Request) -> dict:
     token = request.cookies.get("auth_session")
@@ -149,8 +140,6 @@ async def get_me(request: Request) -> dict:
     return {"user": {"email": user.email, "role": user.role}}
 
 
-=======
->>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
 @router.post("/logout-all", status_code=status.HTTP_204_NO_CONTENT)
 async def logout_all(request: Request, response: Response) -> None:
     token = request.cookies.get("auth_session")

--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -21,7 +21,11 @@ logger = logging.getLogger("languia")
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
+<<<<<<< HEAD
 _EMAIL_RATELIMIT_PER_HOUR = 15
+=======
+_EMAIL_RATELIMIT_PER_HOUR = 5
+>>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
 
 
 class AuthConfig(BaseModel):
@@ -80,6 +84,7 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
             )
 
     code = await request_login_code(body.email)
+<<<<<<< HEAD
     try:
         await send_login_code(body.email, code)
     except Exception:
@@ -87,6 +92,9 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Failed to send login code, please try again later.",
         )
+=======
+    await send_login_code(body.email, code)
+>>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
 
 
 @router.post("/email/verify")
@@ -129,6 +137,7 @@ async def logout(request: Request, response: Response) -> None:
     response.delete_cookie("auth_session")
 
 
+<<<<<<< HEAD
 @router.get("/me")
 async def get_me(request: Request) -> dict:
     token = request.cookies.get("auth_session")
@@ -140,6 +149,8 @@ async def get_me(request: Request) -> dict:
     return {"user": {"email": user.email}}
 
 
+=======
+>>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
 @router.post("/logout-all", status_code=status.HTTP_204_NO_CONTENT)
 async def logout_all(request: Request, response: Response) -> None:
     token = request.cookies.get("auth_session")

--- a/backend/config.py
+++ b/backend/config.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
     GUARDRAIL_TIMEOUT: float = 2.5
 
     # Auth
+<<<<<<< HEAD
     # "anonymous_first": sign-in optional; "sign_in_required": blocks /arena/* without session
     AUTH_ACCESS_POLICY: Literal["anonymous_first", "sign_in_required"] = "anonymous_first"
     # If non-empty, only emails from these domains can request a login code (e.g. ["beta.gouv.fr"])
@@ -64,6 +65,16 @@ class Settings(BaseSettings):
     SMTP_USERNAME: str | None = None
     SMTP_PASSWORD: str | None = None
     SMTP_STARTTLS: bool = True
+=======
+    AUTH_ACCESS_POLICY: Literal["anonymous_first", "sign_in_required"] = "anonymous_first"
+    AUTH_DOMAIN_ALLOWLIST: list[str] = []
+    AUTH_SESSION_LENGTH_DAYS: int = 30
+    AUTH_TERMS_VERSION: str = "1.0"
+
+    # Brevo email
+    BREVO_API_KEY: str | None = None
+    BREVO_LOGIN_CODE_TEMPLATE_ID: int | None = None
+>>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
     EMAIL_FROM: str = "noreply@comparia.beta.gouv.fr"
     EMAIL_FROM_NAME: str = "ComparIA"
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -49,7 +49,6 @@ class Settings(BaseSettings):
     GUARDRAIL_TIMEOUT: float = 2.5
 
     # Auth
-<<<<<<< HEAD
     # "anonymous_first": sign-in optional; "sign_in_required": blocks /arena/* without session
     AUTH_ACCESS_POLICY: Literal["anonymous_first", "sign_in_required"] = "anonymous_first"
     # If non-empty, only emails from these domains can request a login code (e.g. ["beta.gouv.fr"])
@@ -65,16 +64,6 @@ class Settings(BaseSettings):
     SMTP_USERNAME: str | None = None
     SMTP_PASSWORD: str | None = None
     SMTP_STARTTLS: bool = True
-=======
-    AUTH_ACCESS_POLICY: Literal["anonymous_first", "sign_in_required"] = "anonymous_first"
-    AUTH_DOMAIN_ALLOWLIST: list[str] = []
-    AUTH_SESSION_LENGTH_DAYS: int = 30
-    AUTH_TERMS_VERSION: str = "1.0"
-
-    # Brevo email
-    BREVO_API_KEY: str | None = None
-    BREVO_LOGIN_CODE_TEMPLATE_ID: int | None = None
->>>>>>> 4d56b96b (feat(auth): email passwordless auth router and services)
     EMAIL_FROM: str = "noreply@comparia.beta.gouv.fr"
     EMAIL_FROM_NAME: str = "ComparIA"
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
 
     # Auth
     # "anonymous_first": sign-in optional; "sign_in_required": blocks /arena/* without session
+    ADMIN_EMAILS: list[str] = []
     AUTH_ACCESS_POLICY: Literal["anonymous_first", "sign_in_required"] = "anonymous_first"
     # If non-empty, only emails from these domains can request a login code (e.g. ["beta.gouv.fr"])
     AUTH_DOMAIN_ALLOWLIST: list[str] = []

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,10 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from backend.admin.router import router as admin_router
 from backend.arena.router import router as arena_router
 from backend.auth.middleware import auth_middleware
 from backend.auth.router import router as auth_router
@@ -11,7 +14,16 @@ from backend.logger import configure_logger, configure_uvicorn_logging
 from backend.sentry import init_sentry
 from backend.utils.countries import get_vote_count
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    if settings.COMPARIA_DB_URI and settings.ADMIN_EMAILS:
+        from utils.database.actions.seed import seed_admins
+        await seed_admins()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 logger = configure_logger()
 configure_uvicorn_logging()
@@ -50,6 +62,7 @@ Instrumentator().instrument(app).expose(app, endpoint="/metrics")
 app.include_router(models_router)
 app.include_router(arena_router)
 app.include_router(auth_router)
+app.include_router(admin_router)
 
 
 @app.get("/counter")

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -3,6 +3,7 @@ import { api } from '$lib/fastapi-client'
 
 export interface AuthUser {
   email: string
+  role: string
 }
 
 export interface AuthConfig {
@@ -14,6 +15,10 @@ export const auth = $state<{ user: AuthUser | null; config: AuthConfig | null }>
   user: null,
   config: null
 })
+
+export function isAdmin(): boolean {
+  return auth.user?.role === 'admin'
+}
 
 export async function initAuth(): Promise<void> {
   if (!browser) return

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import { goto } from '$app/navigation'
+  import { page } from '$app/state'
+  import { initAuth, isAdmin } from '$lib/auth.svelte'
+  import { onMount } from 'svelte'
+
+  let { children } = $props()
+  let ready = $state(false)
+
+  onMount(async () => {
+    await initAuth()
+    if (!isAdmin()) {
+      goto('/')
+      return
+    }
+    ready = true
+  })
+
+  const tabs = [
+    { href: '/admin/branding', label: 'Branding' },
+    { href: '/admin', label: 'Users' },
+    { href: '/admin/content', label: 'Content' },
+  ]
+</script>
+
+{#if ready}
+  <div class="min-h-screen bg-gray-50">
+    <header class="border-b border-gray-200 bg-white px-6 py-3 flex items-center justify-between">
+      <span class="text-sm font-medium text-gray-500">ComparIA</span>
+      <nav class="flex gap-1">
+        {#each tabs as tab}
+          <a
+            href={tab.href}
+            class="rounded px-4 py-1.5 text-sm font-medium no-underline transition-colors
+              {page.url.pathname === tab.href
+              ? 'bg-gray-900 text-white'
+              : 'text-gray-600 hover:bg-gray-100'}"
+          >
+            {tab.label}
+          </a>
+        {/each}
+      </nav>
+    </header>
+
+    {@render children()}
+  </div>
+{/if}

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { goto } from '$app/navigation'
-  import { page } from '$app/state'
   import { initAuth, isAdmin } from '$lib/auth.svelte'
   import { onMount } from 'svelte'
 
@@ -15,33 +14,13 @@
     }
     ready = true
   })
-
-  const tabs = [
-    { href: '/admin/branding', label: 'Branding' },
-    { href: '/admin', label: 'Users' },
-    { href: '/admin/content', label: 'Content' },
-  ]
 </script>
 
 {#if ready}
-  <div class="min-h-screen bg-gray-50">
-    <header class="border-b border-gray-200 bg-white px-6 py-3 flex items-center justify-between">
-      <span class="text-sm font-medium text-gray-500">ComparIA</span>
-      <nav class="flex gap-1">
-        {#each tabs as tab}
-          <a
-            href={tab.href}
-            class="rounded px-4 py-1.5 text-sm font-medium no-underline transition-colors
-              {page.url.pathname === tab.href
-              ? 'bg-gray-900 text-white'
-              : 'text-gray-600 hover:bg-gray-100'}"
-          >
-            {tab.label}
-          </a>
-        {/each}
-      </nav>
+  <div class="min-h-screen bg-[--background-alt-grey]">
+    <header class="border-b border-[--border-default-grey] bg-white px-6 py-3 flex items-center">
+      <span class="fr-text--sm text-[--text-mention-grey] font-medium">ComparIA Admin</span>
     </header>
-
     {@render children()}
   </div>
 {/if}

--- a/frontend/src/routes/(admin)/admin/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/+page.svelte
@@ -15,13 +15,11 @@
   let users = $state<UserRow[]>([])
   let total = $state(0)
   let loading = $state(true)
-  let search = $state<string>('')
 
   async function fetchUsers() {
     loading = true
     try {
       const params = new URLSearchParams({ page: '1', page_size: '50' })
-      if (search) params.set('search', search)
       const data = await api.request<{ items: UserRow[]; total: number }>(
         `/admin/users?${params}`,
         { credentials: 'include' }
@@ -54,110 +52,40 @@
   ]
 
   const tableRows = $derived(users.map((u) => ({ ...u })))
-
-  // Auth settings stubs
-  let accessMode = $state<'none' | 'optional' | 'required'>('optional')
-  let emailOtpEnabled = $state(false)
-  let oidcEnabled = $state(false)
 </script>
 
 <div class="px-8 py-8">
   <div class="mb-6 flex items-baseline justify-between">
-    <h1 class="text-2xl font-bold">Users</h1>
-    <span class="text-sm text-gray-400">Authentication mode and registered users</span>
+    <h1 class="fr-h3 mb-0!">Users</h1>
+    <span class="fr-text--sm text-[--text-mention-grey]">Registered users</span>
   </div>
 
-  <div class="gap-8 grid grid-cols-[400px_1fr]">
-    <!-- Auth settings (stub) -->
-    <section>
-      <h2 class="mb-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
-        Authentication settings
-      </h2>
+  <Table
+    caption="Users"
+    hideCaption
+    {cols}
+    rows={tableRows}
+  >
+    {#snippet headerRight()}
+      <Button text="Invite user" disabled />
+    {/snippet}
 
-      <div class="mb-6">
-        <p class="mb-2 text-sm font-medium">Access mode</p>
-
-        {#each [
-          { value: 'none', label: 'No authentication', desc: 'Anonymous usage only. Matches the current public default.' },
-          { value: 'optional', label: 'Anonymous + sign-in', desc: 'Anyone can browse; signing in unlocks saved history and verified-pro features.' },
-          { value: 'required', label: 'Sign-in required', desc: 'No anonymous access. Default mode for sector-restricted deployments (e.g. Compar:IA Santé).' },
-        ] as opt}
-          <label class="mb-3 flex cursor-not-allowed gap-3 opacity-60">
-            <input
-              type="radio"
-              name="access_mode"
-              value={opt.value}
-              bind:group={accessMode}
-              disabled
-              class="mt-0.5 shrink-0"
-            />
-            <div>
-              <span class="text-sm font-medium">{opt.label}</span>
-              <p class="m-0 text-xs text-gray-500">{opt.desc}</p>
-            </div>
-          </label>
-        {/each}
-      </div>
-
-      <div class="rounded-lg border border-gray-200 bg-white p-4">
-        <label class="mb-2 flex cursor-not-allowed items-center gap-2 opacity-60">
-          <input type="checkbox" bind:checked={emailOtpEnabled} disabled />
-          <span class="text-sm font-medium">One-time code (email)</span>
-        </label>
-        <p class="mb-2 ml-5 text-xs text-gray-400">SMTP credentials must be set in environment variables.</p>
-        <Badge variant="orange" size="sm" text="SMTP not configured in env" class="ml-5" />
-
-        <hr class="my-4 border-gray-100" />
-
-        <label class="mb-4 flex cursor-not-allowed items-center gap-2 opacity-60">
-          <input type="checkbox" bind:checked={oidcEnabled} disabled />
-          <span class="text-sm font-medium">OIDC single sign-on</span>
-        </label>
-        <p class="ml-5 text-xs text-gray-400">Identity provider via discovery URL.</p>
-      </div>
-
-      <div class="mt-4 flex gap-2">
-        <Button text="Save changes" disabled />
-        <Button text="Discard" variant="secondary" disabled />
-      </div>
-    </section>
-
-    <!-- User management -->
-    <section>
-      <h2 class="mb-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
-        User management
-      </h2>
-
-      <Table
-        caption="Users"
-        hideCaption
-        {cols}
-        rows={tableRows}
-        bind:search
-      >
-        {#snippet headerRight()}
-          <Button text="Invite user" disabled />
-        {/snippet}
-
-        {#snippet cell(row, col)}
-          {#if col.id === 'email'}
-            <span class="text-sm">{row.email}</span>
-          {:else if col.id === 'source'}
-            <Badge size="sm" text={row.source} variant="light-info" />
-          {:else if col.id === 'created_at'}
-            <span class="text-sm text-gray-500">{relativeTime(row.created_at)}</span>
-          {:else if col.id === 'actions'}
-            <span class="text-sm text-gray-300">—</span>
-          {/if}
-        {/snippet}
-      </Table>
-
-      {#if !loading}
-        <p class="mt-2 text-xs text-gray-400">
-          {total} user{total !== 1 ? 's' : ''}.
-          New users are created on first SSO login or via invite.
-        </p>
+    {#snippet cell(row, col)}
+      {#if col.id === 'email'}
+        <span class="fr-text--sm">{row.email}</span>
+      {:else if col.id === 'source'}
+        <Badge size="sm" text={row.source} variant="light-info" />
+      {:else if col.id === 'created_at'}
+        <span class="fr-text--sm text-[--text-mention-grey]">{relativeTime(row.created_at)}</span>
+      {:else if col.id === 'actions'}
+        <span class="fr-text--sm text-[--text-disabled-grey]">—</span>
       {/if}
-    </section>
-  </div>
+    {/snippet}
+  </Table>
+
+  {#if !loading}
+    <p class="fr-text--sm mt-2! text-[--text-mention-grey]">
+      {total} user{total !== 1 ? 's' : ''}.
+    </p>
+  {/if}
 </div>

--- a/frontend/src/routes/(admin)/admin/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/+page.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import { Badge, Button, Table } from '$components/dsfr'
+  import { api } from '$lib/fastapi-client'
+  import { onMount } from 'svelte'
+
+  interface UserRow {
+    id: string
+    email: string
+    role: string
+    source: string
+    created_at: string
+    last_seen_at: string
+  }
+
+  let users = $state<UserRow[]>([])
+  let total = $state(0)
+  let loading = $state(true)
+  let search = $state<string>('')
+
+  async function fetchUsers() {
+    loading = true
+    try {
+      const params = new URLSearchParams({ page: '1', page_size: '50' })
+      if (search) params.set('search', search)
+      const data = await api.request<{ items: UserRow[]; total: number }>(
+        `/admin/users?${params}`,
+        { credentials: 'include' }
+      )
+      users = data.items
+      total = data.total
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(fetchUsers)
+
+  function relativeTime(iso: string): string {
+    const diff = Date.now() - new Date(iso).getTime()
+    const days = Math.floor(diff / 86400000)
+    if (days === 0) return 'today'
+    if (days === 1) return '1 day ago'
+    if (days < 30) return `${days} days ago`
+    const months = Math.floor(days / 30)
+    if (months === 1) return '1 month ago'
+    return `${months} months ago`
+  }
+
+  const cols = [
+    { id: 'email', label: 'Email' },
+    { id: 'source', label: 'Source' },
+    { id: 'created_at', label: 'Added' },
+    { id: 'actions', label: 'Actions' },
+  ]
+
+  const tableRows = $derived(users.map((u) => ({ ...u })))
+
+  // Auth settings stubs
+  let accessMode = $state<'none' | 'optional' | 'required'>('optional')
+  let emailOtpEnabled = $state(false)
+  let oidcEnabled = $state(false)
+</script>
+
+<div class="px-8 py-8">
+  <div class="mb-6 flex items-baseline justify-between">
+    <h1 class="text-2xl font-bold">Users</h1>
+    <span class="text-sm text-gray-400">Authentication mode and registered users</span>
+  </div>
+
+  <div class="gap-8 grid grid-cols-[400px_1fr]">
+    <!-- Auth settings (stub) -->
+    <section>
+      <h2 class="mb-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+        Authentication settings
+      </h2>
+
+      <div class="mb-6">
+        <p class="mb-2 text-sm font-medium">Access mode</p>
+
+        {#each [
+          { value: 'none', label: 'No authentication', desc: 'Anonymous usage only. Matches the current public default.' },
+          { value: 'optional', label: 'Anonymous + sign-in', desc: 'Anyone can browse; signing in unlocks saved history and verified-pro features.' },
+          { value: 'required', label: 'Sign-in required', desc: 'No anonymous access. Default mode for sector-restricted deployments (e.g. Compar:IA Santé).' },
+        ] as opt}
+          <label class="mb-3 flex cursor-not-allowed gap-3 opacity-60">
+            <input
+              type="radio"
+              name="access_mode"
+              value={opt.value}
+              bind:group={accessMode}
+              disabled
+              class="mt-0.5 shrink-0"
+            />
+            <div>
+              <span class="text-sm font-medium">{opt.label}</span>
+              <p class="m-0 text-xs text-gray-500">{opt.desc}</p>
+            </div>
+          </label>
+        {/each}
+      </div>
+
+      <div class="rounded-lg border border-gray-200 bg-white p-4">
+        <label class="mb-2 flex cursor-not-allowed items-center gap-2 opacity-60">
+          <input type="checkbox" bind:checked={emailOtpEnabled} disabled />
+          <span class="text-sm font-medium">One-time code (email)</span>
+        </label>
+        <p class="mb-2 ml-5 text-xs text-gray-400">SMTP credentials must be set in environment variables.</p>
+        <Badge variant="orange" size="sm" text="SMTP not configured in env" class="ml-5" />
+
+        <hr class="my-4 border-gray-100" />
+
+        <label class="mb-4 flex cursor-not-allowed items-center gap-2 opacity-60">
+          <input type="checkbox" bind:checked={oidcEnabled} disabled />
+          <span class="text-sm font-medium">OIDC single sign-on</span>
+        </label>
+        <p class="ml-5 text-xs text-gray-400">Identity provider via discovery URL.</p>
+      </div>
+
+      <div class="mt-4 flex gap-2">
+        <Button text="Save changes" disabled />
+        <Button text="Discard" variant="secondary" disabled />
+      </div>
+    </section>
+
+    <!-- User management -->
+    <section>
+      <h2 class="mb-4 text-xs font-semibold uppercase tracking-wider text-gray-400">
+        User management
+      </h2>
+
+      <Table
+        caption="Users"
+        hideCaption
+        {cols}
+        rows={tableRows}
+        bind:search
+      >
+        {#snippet headerRight()}
+          <Button text="Invite user" disabled />
+        {/snippet}
+
+        {#snippet cell(row, col)}
+          {#if col.id === 'email'}
+            <span class="text-sm">{row.email}</span>
+          {:else if col.id === 'source'}
+            <Badge size="sm" text={row.source} variant="light-info" />
+          {:else if col.id === 'created_at'}
+            <span class="text-sm text-gray-500">{relativeTime(row.created_at)}</span>
+          {:else if col.id === 'actions'}
+            <span class="text-sm text-gray-300">—</span>
+          {/if}
+        {/snippet}
+      </Table>
+
+      {#if !loading}
+        <p class="mt-2 text-xs text-gray-400">
+          {total} user{total !== 1 ? 's' : ''}.
+          New users are created on first SSO login or via invite.
+        </p>
+      {/if}
+    </section>
+  </div>
+</div>

--- a/utils/database/actions/__init__.py
+++ b/utils/database/actions/__init__.py
@@ -11,3 +11,4 @@ from .migrate_system_messages import migrate_system_messages
 from .migrate_turns import migrate_turns
 from .migrate_user_messages import migrate_user_messages
 from .migrate_votes import migrate_votes
+from .seed import seed_admins

--- a/utils/database/actions/seed.py
+++ b/utils/database/actions/seed.py
@@ -1,0 +1,35 @@
+import logging
+
+from sqlmodel import select
+
+from backend.config import settings
+from utils.database.models.auth import User
+from utils.database.session import get_session
+
+logger = logging.getLogger("comparia.db")
+
+
+async def seed_admins() -> None:
+    """Upsert admin role for emails listed in ADMIN_EMAILS setting."""
+    if not settings.ADMIN_EMAILS:
+        logger.info("[seed] ADMIN_EMAILS is empty, nothing to do")
+        return
+
+    if not settings.COMPARIA_DB_URI:
+        logger.warning("[seed] COMPARIA_DB_URI is not set, skipping seed_admins")
+        return
+
+    async with get_session() as session:
+        for email in settings.ADMIN_EMAILS:
+            result = await session.exec(select(User).where(User.email == email))
+            user = result.first()
+            if user:
+                if user.role != "admin":
+                    user.role = "admin"
+                    session.add(user)
+                    logger.info(f"[seed] promoted {email} to admin")
+                else:
+                    logger.info(f"[seed] {email} is already admin")
+            else:
+                logger.warning(f"[seed] {email} not found in auth_user, skipping")
+        await session.commit()

--- a/utils/database/actions/seed.py
+++ b/utils/database/actions/seed.py
@@ -31,5 +31,6 @@ async def seed_admins() -> None:
                 else:
                     logger.info(f"[seed] {email} is already admin")
             else:
-                logger.warning(f"[seed] {email} not found in auth_user, skipping")
+                session.add(User(email=email, role="admin"))
+                logger.info(f"[seed] created admin user {email}")
         await session.commit()

--- a/utils/database/alembic/env.py
+++ b/utils/database/alembic/env.py
@@ -6,17 +6,17 @@ from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlmodel import SQLModel
+
+from backend.config import settings
+
+# Import all table models to populate SQLModel.metadata
+from utils.database.models import Comparison, Turn  # noqa: F401
 from utils.database.models.auth import (  # noqa: F401
     AuthSession,
     ConsentLog,
     LoginCode,
     User,
 )
-
-from backend.config import settings
-
-# Import all table models to populate SQLModel.metadata
-from utils.database.models import Comparison, Turn  # noqa: F401
 from utils.database.models.llms import (  # noqa: F401
     LLMData,
     LLMEndpoint,

--- a/utils/database/alembic/versions/d1f4a2e7c9b5_add_user_role.py
+++ b/utils/database/alembic/versions/d1f4a2e7c9b5_add_user_role.py
@@ -1,0 +1,33 @@
+"""add_user_role
+
+Revision ID: d1f4a2e7c9b5
+Revises: b2d4a7e9c1f3
+Create Date: 2026-06-25 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+revision: str = 'd1f4a2e7c9b5'
+down_revision: Union[str, Sequence[str], None] = 'b2d4a7e9c1f3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'auth_user',
+        sa.Column(
+            'role',
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            server_default='user',
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('auth_user', 'role')

--- a/utils/database/cli.py
+++ b/utils/database/cli.py
@@ -18,6 +18,7 @@ from .actions import (
     migrate_turns,
     migrate_user_messages,
     migrate_votes,
+    seed_admins,
 )
 from .lint import lint, log_archived
 
@@ -43,6 +44,7 @@ cli_db.command(lint)
 cli_db.command(log_archived)
 cli_db.command(llm_analyze)
 cli_db.command(backfill_pii_spam)
+cli_db.command(seed_admins, name="seed-admins")
 cli_db.command(cli_archive)
 cli_db.command(cli_migrate)
 

--- a/utils/database/models/auth.py
+++ b/utils/database/models/auth.py
@@ -13,6 +13,7 @@ class User(SQLModel, table=True):
 
     id: ModelId
     email: str = Field(unique=True)
+    role: str = Field(default="user")
     created_at: AutoDatetime
     last_seen_at: AutoDatetime
     deleted_at: OptionalDatetime = None

--- a/uv.lock
+++ b/uv.lock
@@ -253,21 +253,6 @@ wheels = [
 ]
 
 [[package]]
-name = "brevo-python"
-version = "4.0.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/79/573272ac0ac158e5498690daf06452fbca1785dcd1f85bdcb7bcda86d090/brevo_python-4.0.10.tar.gz", hash = "sha256:3ba2808937556b02d7afe4aaf6392438e1af3a8db77ef97349e46307bbf27311", size = 428199, upload-time = "2026-04-10T14:10:25.699Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/b7/cf28d6ac954cc98f2f5297f52bc57f3032f6360e0ad77d1fb36518ef4691/brevo_python-4.0.10-py3-none-any.whl", hash = "sha256:4fb38f4143ce2c440b35e574696f2ae667cf6454d592409af7750eb675703de0", size = 877575, upload-time = "2026-04-10T14:10:24.21Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,21 @@ wheels = [
 ]
 
 [[package]]
+name = "brevo-python"
+version = "4.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/79/573272ac0ac158e5498690daf06452fbca1785dcd1f85bdcb7bcda86d090/brevo_python-4.0.10.tar.gz", hash = "sha256:3ba2808937556b02d7afe4aaf6392438e1af3a8db77ef97349e46307bbf27311", size = 428199, upload-time = "2026-04-10T14:10:25.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b7/cf28d6ac954cc98f2f5297f52bc57f3032f6360e0ad77d1fb36518ef4691/brevo_python-4.0.10-py3-none-any.whl", hash = "sha256:4fb38f4143ce2c440b35e574696f2ae667cf6454d592409af7750eb675703de0", size = 877575, upload-time = "2026-04-10T14:10:24.21Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
## Summary

- Add user role field (user/admin) on User model with alembic migration
- Admin backend router with user listing and role management
- CLI command to seed admin users from ADMIN_EMAILS env var
- Admin frontend layout with guard and users page

## Changes

**Backend**
- `backend/admin/` - admin router and services (GET /admin/users, PATCH role, DELETE, POST invite)
- `backend/auth/dependencies.py` - require_admin FastAPI dependency
- `backend/auth/router.py` - include role in GET /auth/me response
- `backend/config.py` - add ADMIN_EMAILS setting
- `backend/main.py` - mount admin router
- `utils/database/models/auth.py` - add role field to User
- `utils/database/alembic/versions/d1f4a2e7b5_add_user_role.py` - migration
- `utils/database/actions/seed.py` - seed_admins() from ADMIN_EMAILS
- `utils/database/cli.py` - register seed-admins CLI command
- `Makefile` - db-seed-admins target

**Frontend**
- `frontend/src/lib/auth.svelte.ts` - add role to AuthUser, expose isAdmin()
- `frontend/src/routes/(admin)/+layout.svelte` - admin layout with guard
- `frontend/src/routes/(admin)/admin/+page.svelte` - users list page

**Config**
- `.env.example` - ADMIN_EMAILS, AUTH_ACCESS_POLICY vars

## TODO

- [ ] Actions par ligne (promouvoir/rétrograder, supprimer)
- [ ] Invite user flow
- [ ] Search/filter by email

## Test plan

- Set ADMIN_EMAILS=your@email.fr and run db-seed-admins
- Log in and verify /admin is accessible
- Non-admin users are redirected to /