### PR TITLE
fix(arene): total tokens in reveal card

### DIFF
--- a/backend/arena/reveal.py
+++ b/backend/arena/reveal.py
@@ -10,9 +10,11 @@ import logging
 from typing import TypedDict
 from uuid import UUID
 
+from litellm.litellm_core_utils.token_counter import token_counter
+
 from backend.llms.data import get_llms_data
 from backend.llms.utils import Consumption, get_llm_consumption
-from utils.database.models import BotPos, ComparisonRead
+from utils.database.models import BotPos, ComparisonRead, TurnRead
 
 logger = logging.getLogger("languia")
 
@@ -27,6 +29,38 @@ class RevealData(TypedDict):
     chosen_llm: BotPos | None
     a: RevealModelData
     b: RevealModelData
+
+
+def count_input_tokens(
+    comparison: ComparisonRead, pos: BotPos, turns: list[TurnRead], model: str
+) -> int:
+    """
+    Estimate input tokens sent to the model across the revealed conversation.
+    Each generation receives the current user message and the previous messages
+    for that model side, so previous turns are counted again when they are resent.
+    """
+    input_tokens = 0
+    history: list[str | None] = []
+
+    if system_msg := getattr(comparison, f"system_msg_{pos}"):
+        history.append(system_msg)
+
+    for turn in turns:
+        current_messages = [*history, turn.user_msg.content]
+        input_tokens += token_counter(
+            text=[message for message in current_messages if message],
+            model=model,
+        )
+
+        history.append(turn.user_msg.content)
+        if llm_msg := getattr(turn, f"llm_msg_{pos}"):
+            history.extend(
+                message
+                for message in [llm_msg.reasoning_content, llm_msg.content]
+                if message
+            )
+
+    return input_tokens
 
 
 def get_chosen_llm(comparison: ComparisonRead) -> BotPos | None:
@@ -95,10 +129,22 @@ async def get_reveal_data(comparison: ComparisonRead) -> RevealData:
         "a": get_llm_consumption(
             llms[comparison.llm_id_a],
             sum(turn.llm_msg_a.tokens for turn in comparison.turns),
+            count_input_tokens(
+                comparison,
+                "a",
+                comparison.turns,
+                str(comparison.llm_id_a),
+            ),
         ),
         "b": get_llm_consumption(
             llms[comparison.llm_id_b],
             sum(turn.llm_msg_b.tokens for turn in comparison.turns),
+            count_input_tokens(
+                comparison,
+                "b",
+                comparison.turns,
+                str(comparison.llm_id_b),
+            ),
         ),
     }
 

--- a/backend/llms/utils.py
+++ b/backend/llms/utils.py
@@ -120,7 +120,8 @@ def get_llm_impact(
 
     Args:
         llm: APILLMDataBase with 'params' and optional 'active_params' (MoE)
-        token_count: Total output tokens generated
+        tokens: Total output tokens generated
+        input_tokens: Total input tokens sent to the model
         request_latency: Time taken for inference (optional, for more accurate calculations)
 
     Returns:
@@ -183,6 +184,8 @@ def get_llm_impact(
 class Consumption(TypedDict):
     # Token usage
     tokens: int
+    input_tokens: int
+    total_tokens: int
     # Environmental metrics (CO2)
     co2_kg: int | float
     # Energy metrics
@@ -199,6 +202,7 @@ class Consumption(TypedDict):
 def get_llm_consumption(
     llm: "APILLMDataBase",
     tokens: int,
+    input_tokens: int = 0,
     request_latency: float | None = None,
 ) -> Consumption:
     """
@@ -223,6 +227,8 @@ def get_llm_consumption(
 
     return {
         "tokens": tokens,
+        "input_tokens": input_tokens,
+        "total_tokens": input_tokens + tokens,
         "co2_kg": co2_kg,
         "energy_mwh": kwh * 1000 * 1000,
         "energy_kwh": kwh,

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -1986,6 +1986,10 @@
         "title": "From votes to a leaderboard"
     },
     "reveal": {
+        "context": {
+            "max": "Max context: {count}k tokens",
+            "used": "{count}<span {midProps}> tokens</span> <span {smallProps}>used</span>"
+        },
         "equivalent": {
             "co2": {
                 "label": "CO <sub>2</sub> emitted",
@@ -2031,6 +2035,7 @@
         "impacts": {
             "energy": {
                 "label": "energy consumed",
+                "short": "{count} mWh consumed",
                 "tooltip": "Measured in milliwatt-hours, energy consumption represents the electricity used by the model to process a query and generate the corresponding response. Generally, the larger a model (in billions of parameters), the more energy is required to produce a token."
             },
             "size": {

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1766,6 +1766,7 @@
                 "archived": {
                     "checkedLabel": "Visibles",
                     "help": "Par défaut, seuls les modèles actifs dans le comparateur sont visibles.",
+                    "legend": "Archivés",
                     "label": "Modèles archivés",
                     "uncheckedLabel": "Non visibles"
                 },
@@ -2335,6 +2336,10 @@
         "title": "Des votes… au classement des modèles"
     },
     "reveal": {
+        "context": {
+            "max": "Contexte max : {count}k jetons",
+            "used": "{count}<span {midProps}> jetons</span> <span {smallProps}>utilisés</span>"
+        },
         "equivalent": {
             "co2": {
                 "label": "CO<sub>2</sub> émis",
@@ -2380,6 +2385,7 @@
         "impacts": {
             "energy": {
                 "label": "énergie conso.",
+                "short": "{count} mWh consommés",
                 "tooltip": "Mesurée en milliwattheures, l’énergie consommée représente l'électricité utilisée par le modèle pour traiter une requête et générer la réponse correspondante. Plus un modèle est grand (en milliards de paramètres), plus il faut d'énergie pour produire un token."
             },
             "size": {

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -149,6 +149,8 @@ interface APIEquivalence {
 
 interface APIConsoData {
   tokens: number
+  input_tokens?: number
+  total_tokens?: number
   co2_kg: number
   scaled_co2_kg: number
   scaled_co2_t: number

--- a/frontend/src/lib/components/ModelCard.svelte
+++ b/frontend/src/lib/components/ModelCard.svelte
@@ -49,7 +49,7 @@
         </div>
       </h6>
 
-      <dl class="fr-card__desc p-0 gap-2 mt-0! grid grid-cols-3">
+      <dl class="fr-card__desc p-0 gap-2 mt-0! sm:grid-cols-3 grid grid-cols-2">
         {#each cards as card (card.id)}
           <InfoCard
             {...card}

--- a/frontend/src/lib/components/dsfr/CheckboxGroup.svelte
+++ b/frontend/src/lib/components/dsfr/CheckboxGroup.svelte
@@ -8,6 +8,7 @@
     options,
     value = $bindable([]),
     row = false,
+    normalizeAllSelection = true,
     legendClass = '',
     labelClass = '',
     legendSlot,
@@ -18,6 +19,7 @@
     options: Option[]
     value: string[]
     row?: boolean
+    normalizeAllSelection?: boolean
     legendClass?: ClassValue
     labelClass?: ClassValue
     legendSlot?: Snippet<[{ legend: string }]>
@@ -27,7 +29,9 @@
   const all = $derived(options.find((opt) => opt.value === 'all'))
   const opts = $derived(options.filter((opt) => opt.value !== 'all'))
 
-  const allSelected = $derived(value.length === options.length || value.length === 0)
+  const allSelected = $derived(
+    value.length === options.length || (normalizeAllSelection && value.length === 0)
+  )
   const ariaAllSelected = $derived(allSelected ? 'true' : value.length === 0 ? 'false' : 'mixed')
 
   function toggleAll() {
@@ -36,7 +40,7 @@
   }
 
   $effect(() => {
-    if (allSelected) value = []
+    if (normalizeAllSelection && allSelected) value = []
   })
 </script>
 

--- a/frontend/src/routes/arene/components/RevealCard.svelte
+++ b/frontend/src/routes/arene/components/RevealCard.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import AILogo from '$components/AILogo.svelte'
-  import { Badge, Button, Icon, Tooltip } from '$components/dsfr'
+  import { Badge, Button } from '$components/dsfr'
   import InfoCard from '$components/InfoCard.svelte'
   import ModelInfoModal from '$components/ModelInfoModal.svelte'
   import type { RevealModelData } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
-  import { ENERGY_CLASS_COLORS, getModelCards, getModelsContext, MODALITIES } from '$lib/models'
-  import { sanitize } from '$lib/utils/commons'
-  import { MiniCard } from '.'
+  import { ENERGY_CLASS_COLORS, getModelCards, getModelsContext } from '$lib/models'
+  import { propsToAttrs } from '$lib/utils/commons'
 
   let { data, selected }: { data: RevealModelData; selected: boolean } = $props()
   const { models, commons } = getModelsContext()
@@ -19,10 +18,21 @@
     const cards = getModelCards(model, 'sm', commons)
     return [
       cards.size,
-      cards.arch,
-      cards.context,
-      cards.modalities,
-      cards.price,
+      {
+        ...cards.context,
+        content:
+          data.total_tokens === undefined
+            ? m['words.NA']()
+            : m['reveal.context.used']({
+                count: data.total_tokens,
+                midProps: propsToAttrs({ class: 'text-sm!' }),
+                smallProps: propsToAttrs({ class: 'text-xs!' })
+              }),
+        subContent: model.context_tokens
+          ? m['reveal.context.max']({ count: Math.floor(model.context_tokens / 1000) })
+          : m['words.NA'](),
+        desc: undefined
+      },
       cards.sovereignty,
       cards.rank,
       cards.energy
@@ -124,116 +134,23 @@
   <div class="gap-4 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 grid">
     {#each cards as card, i (i)}
       <InfoCard {...card} id="{model.id}-{card.id}" iconClass="text-info" size="sm">
-        {#if card.id === 'price'}
-          <div class="gap-2 flex w-full flex-wrap justify-between">
-            {#each card.contents as c, i (i)}
-              <div class="">
-                <p class="mb-0! font-bold text-lg! leading-[1.1]!">
-                  ${@html sanitize(c.content)}
-                </p>
-                <p class="text-xxs! text-grey mb-0!">
-                  {c.subContent}
-                </p>
-              </div>
-            {/each}
-          </div>
-        {:else if card.id === 'modalities'}
-          <div class="gap-2 flex flex-wrap justify-between">
-            {#each MODALITIES as mod (mod.id)}
-              {@const active = model.inputs.includes(mod.id)}
-              <div
-                class="text-xxs gap-1 flex flex-col items-center"
-                aria-hidden={active ? 'false' : 'true'}
-              >
-                <Icon
-                  icon={mod.icon}
-                  size="xs"
-                  block
-                  class={active ? 'text-primary' : 'text-[#B3B3B3]'}
-                />
-                <span class={{ 'text-[#B3B3B3]': !active }}>{mod.title}</span>
-              </div>
-            {/each}
-          </div>
-        {:else if card.id === 'energy'}
-          <div
-            class="ps-2 w-80% text-white font-bold flex h-full items-center justify-start"
-            style="background-color: var({ENERGY_CLASS_COLORS[
-              model.energy_class
-            ]}); clip-path: polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%);"
-          >
-            {model.energy_class}
+        {#if card.id === 'energy'}
+          <div class="gap-1 flex flex-col">
+            <div
+              class="ps-2 w-80% text-white font-bold h-8 flex items-center justify-start"
+              style="background-color: var({ENERGY_CLASS_COLORS[
+                model.energy_class
+              ]}); clip-path: polygon(0 0, calc(100% - 10px) 0, 100% 50%, calc(100% - 10px) 100%, 0 100%);"
+            >
+              {model.energy_class}
+            </div>
+            <p class="text-xxs! text-grey mb-0!">
+              {m['reveal.impacts.energy.short']({ count: conso.energy })}
+            </p>
           </div>
         {/if}
       </InfoCard>
     {/each}
-  </div>
-
-  <div class="mt-8 cg-border rounded-sm! bg-light-grey p-3 pb-11">
-    <h6 class="mb-5! text-base! mt-auto!">
-      {m['reveal.impacts.title']()}
-      <Tooltip id="impact-{data.pos}" text={m['reveal.impacts.tooltip']()} />
-    </h6>
-    <div class="flex">
-      <div class="md:basis-2/3 md:flex-row flex basis-1/2 flex-col">
-        <div class="md:w-full relative">
-          <MiniCard
-            id="params-{data.pos}"
-            value={model.params}
-            desc={m['reveal.impacts.size.label']()}
-            tooltip={m['models.openWeight.tooltips.params']()}
-            class="-mb-2 bg-white z-1 h-full "
-          >
-            {m['reveal.impacts.size.count']()}
-            {#if model.license.kind === 'proprietary'}
-              {m['reveal.impacts.size.estimated']()}
-            {/if}
-            {#if model.quantization === 'q8'}
-              {m['reveal.impacts.size.quantized']()}
-            {/if}
-          </MiniCard>
-          <div
-            class="cg-border rounded-sm! p-1 ps-3 pt-2 leading-normal absolute z-0 flex w-full bg-[--beige-gris-galet-950-100] text-[11px]"
-          >
-            <span class="text-[--beige-gris-galet-sun-407-moon-821]">
-              {model.badges.arch.text}
-            </span>
-            <Tooltip
-              id="{model.id}-arch-tooltip"
-              size="xs"
-              text={model.badges.arch.tooltip}
-              class="ms-auto"
-            />
-          </div>
-        </div>
-
-        <strong class="mb-1 md:mx-1 md:my-auto m-auto text-[20px]">×</strong>
-
-        <MiniCard
-          id="tokens-{data.pos}"
-          value={data.tokens}
-          units={m['reveal.impacts.tokens.tokens']()}
-          desc={m['reveal.impacts.tokens.label']()}
-          tooltip={m['reveal.impacts.tokens.tooltip']()}
-          class="md:w-full bg-white"
-        />
-      </div>
-
-      <div class="md:basis-1/3 flex basis-1/2 items-center">
-        <strong class="m-auto">≈</strong>
-
-        <MiniCard
-          id="energy-{data.pos}"
-          value={conso.energy}
-          units="mWh"
-          desc={m['reveal.impacts.energy.label']()}
-          icon="i-ri-flashlight-fill"
-          iconClass="text-info"
-          tooltip={m['reveal.impacts.energy.tooltip']()}
-          class="bg-white h-fit"
-        />
-      </div>
-    </div>
   </div>
 
   <!-- FIXME equivalences legacy? -->

--- a/frontend/src/routes/arene/modeles/+page.svelte
+++ b/frontend/src/routes/arene/modeles/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state'
   import Dropdown from '$components/Dropdown.svelte'
-  import { Button, CheckboxGroup, Search, Select, Toggle } from '$components/dsfr'
+  import { Button, CheckboxGroup, Search, Select } from '$components/dsfr'
   import ModelCard from '$components/ModelCard.svelte'
   import ModelInfoModal from '$components/ModelInfoModal.svelte'
   import PageLayout from '$components/PageLayout.svelte'
@@ -49,6 +49,23 @@
     ]
   }
 
+  const archivedFilter = {
+    id: 'archived',
+    legend: m['models.list.filters.archived.legend'](),
+    options: [
+      {
+        value: 'no',
+        label: m['words.no'](),
+        count: models.filter((llm) => llm.status === 'enabled').length
+      },
+      {
+        value: 'yes',
+        label: m['words.yes'](),
+        count: models.filter((llm) => llm.status === 'archived').length
+      }
+    ]
+  }
+
   const sortingOptions = (['name-asc', 'date-desc', 'params-asc', 'org-asc'] as const).map(
     (value) => ({
       value,
@@ -59,8 +76,8 @@
   let editors = $state<string[]>([])
   let sizes = $state<SizeClasses[]>([])
   let licenses = $state<string[]>([])
+  let archived = $state<string[]>(['no'])
   let sortingMethod = $state<'name-asc' | 'date-desc' | 'params-asc' | 'org-asc'>('name-asc')
-  let showArchived = $state(false)
   let search = $state('')
 
   const filteredModels = $derived.by(() => {
@@ -71,7 +88,10 @@
         const sizeMatch = sizes.length === 0 || sizes.includes(model.size_class)
         const orgMatch = editors.length === 0 || editors.includes(model.lab.name)
         const licenseMatch = licenses.length === 0 || licenses.includes(model.license.name)
-        const archivedMatch = model.status === 'enabled' || showArchived
+        const archivedMatch =
+          archived.length === 0 ||
+          (archived.includes('no') && model.status === 'enabled') ||
+          (archived.includes('yes') && model.status === 'archived')
         return searchMatch && sizeMatch && orgMatch && licenseMatch && archivedMatch
       })
       .sort((a, b) => {
@@ -100,11 +120,21 @@
   })
 
   const allFilter = $derived([editors, sizes, licenses])
-  const filterCount = $derived(allFilter.reduce((acc, f) => acc + (f.length ? 1 : 0), 0))
+  const archivedIsDefault = $derived(archived.length === 1 && archived[0] === 'no')
+  const filterCount = $derived(
+    allFilter.reduce((acc, f) => acc + (f.length ? 1 : 0), 0) + (archivedIsDefault ? 0 : 1)
+  )
 
   function resetFilters(e: MouseEvent) {
     e.preventDefault()
-    allFilter.forEach((arr) => (arr.length = 0))
+    editors.length = 0
+    sizes.length = 0
+    licenses.length = 0
+    archived.splice(0, archived.length, 'no')
+  }
+
+  function getArchivedCount(value: string) {
+    return archivedFilter.options.find((option) => option.value === value)?.count ?? 0
   }
 
   let selectedModel = $state<string>(page.url.hash.replace('#', ''))
@@ -177,34 +207,39 @@
             {/snippet}
           </CheckboxGroup>
         </Dropdown>
+
+        <Dropdown id="dropdown-archived" label={archivedFilter.legend} variant="light">
+          <CheckboxGroup
+            {...archivedFilter}
+            bind:value={archived}
+            legendClass="sr-only"
+            normalizeAllSelection={false}
+            class="mb-0! md:w-max"
+          >
+            {#snippet labelSlot({ option })}
+              <div class="me-4">{option.label}</div>
+              <div class="text-sm ms-auto text-[--grey-625-425]">
+                {getArchivedCount(option.value)}
+              </div>
+            {/snippet}
+          </CheckboxGroup>
+        </Dropdown>
       </div>
 
-      <div class="gap-3 md:flex-row md:items-center lg:col-start-2 flex flex-col">
-        <Button
-          icon="delete-line"
-          size="sm"
-          variant="tertiary"
-          iconOnly
-          title={m['models.list.filters.reset']()}
-          aria-label={m['models.list.filters.reset']()}
-          disabled={filterCount === 0}
-          onclick={resetFilters}
-          class="w-fit!"
-        />
-
-        <Toggle
-          id="archived"
-          bind:value={showArchived}
-          label={m['models.list.filters.archived.label']()}
-          // help={m['models.list.filters.archived.help']()}
-          checkedLabel={m['models.list.filters.archived.checkedLabel']()}
-          uncheckedLabel={m['models.list.filters.archived.uncheckedLabel']()}
-          variant="primary"
-          class="text-xs! lh-loose"
-          labelPos="right"
-          checkLabelClass="text-xxs! mt-1"
-        />
-      </div>
+      {#if filterCount > 0}
+        <div class="gap-3 md:flex-row md:items-center lg:shrink-0 flex flex-col">
+          <Button
+            icon="delete-line"
+            size="sm"
+            variant="tertiary"
+            iconOnly
+            title={m['models.list.filters.reset']()}
+            aria-label={m['models.list.filters.reset']()}
+            onclick={resetFilters}
+            class="w-fit!"
+          />
+        </div>
+      {/if}
     </form>
   </aside>
 

--- a/tests/arena/test_reveal.py
+++ b/tests/arena/test_reveal.py
@@ -1,0 +1,60 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+os.environ["COMPARIA_DB_URI"] = "postgresql://comparia:comparia@localhost/comparia"
+os.environ["LOG_FORMAT"] = "JSON"
+
+from backend.arena import reveal
+
+
+def test_count_input_tokens_counts_prompt_history():
+    calls: list[list[str]] = []
+
+    def fake_token_counter(text: list[str], model: str) -> int:
+        calls.append(text)
+        return len(text)
+
+    comparison = SimpleNamespace(
+        system_msg_a="system",
+        turns=[
+            SimpleNamespace(
+                user_msg=SimpleNamespace(content="first question"),
+                llm_msg_a=SimpleNamespace(
+                    reasoning_content=None,
+                    content="first answer",
+                ),
+            ),
+            SimpleNamespace(
+                user_msg=SimpleNamespace(content="second question"),
+                llm_msg_a=SimpleNamespace(
+                    reasoning_content="second reasoning",
+                    content="second answer",
+                ),
+            ),
+        ],
+    )
+
+    original_token_counter = reveal.token_counter
+    reveal.token_counter = fake_token_counter
+    try:
+        assert (
+            reveal.count_input_tokens(comparison, "a", comparison.turns, "model") == 6
+        )
+        assert calls == [
+            ["system", "first question"],
+            ["system", "first question", "first answer", "second question"],
+        ]
+    finally:
+        reveal.token_counter = original_token_counter
+
+
+def run():
+    test_count_input_tokens_counts_prompt_history()
+    print("Reveal token counting cases passed.")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
The reveal card only showed output tokens, so the "context used" number never matched what the model actually saw across the conversation (system prompt plus resent history each turn).

- Add input token counting (litellm tokenizer, replays the per-turn history sent to each model side) and show input + output as the total in the reveal context card
- Simplify the reveal card's info cards: drop the arch, modalities and price cards, and replace the "params x tokens = energy" breakdown with a compact energy-class badge and short energy line
- Fix the model list card grid dropping to 2 columns on mobile instead of 3, which was pushing the owner badge out of its cell
- Rework the archived-models filter on the model list page from a toggle into a checkbox dropdown with per-option counts, consistent with the other filters