### PR TITLE
fix: CORS middleware order and unauthorized redirect on load

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -47,6 +47,12 @@ origins = [
     "http://localhost:8008",
 ]
 
+app.middleware("http")(auth_middleware)
+app.middleware("http")(anonymous_middleware)
+
+# Registered last so it wraps the auth/anonymous middlewares (Starlette builds
+# the stack with the last-registered middleware outermost), otherwise auth_middleware
+# short-circuits CORS preflight/401 responses before CORS headers are added.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -54,9 +60,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-app.middleware("http")(auth_middleware)
-app.middleware("http")(anonymous_middleware)
 
 # Prometheus metrics instrumentation
 Instrumentator().instrument(app).expose(app, endpoint="/metrics")

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -1,3 +1,14 @@
-export const handleError = (error: unknown) => {
+import { goto } from '$app/navigation'
+import { UnauthorizedError } from '$lib/fastapi-client'
+import type { HandleClientError } from '@sveltejs/kit'
+
+// Catches UnauthorizedError thrown by any load() before the root layout's
+// onMount registers the redirect/modal handler (e.g. on first navigation),
+// so we don't fall through to the generic error page.
+export const handleError: HandleClientError = ({ error }) => {
+  if (error instanceof UnauthorizedError) {
+    goto('/login?redirect=' + encodeURIComponent(location.pathname))
+    return
+  }
   console.error(error)
 }

--- a/frontend/src/routes/arene/+layout.ts
+++ b/frontend/src/routes/arene/+layout.ts
@@ -4,6 +4,7 @@ import type { LayoutLoad } from './$types'
 export const ssr = false // auth error on server side
 
 export const load: LayoutLoad = async () => {
+  // Unauthorized errors are handled globally, see hooks.client.ts
   // FIXME types
   const comparisons = await api.request<unknown>('/arena/comparison/list')
 


### PR DESCRIPTION
## Summary

- Register CORSMiddleware after the auth/anonymous middlewares in backend/main.py, since Starlette builds the stack with the last-registered middleware outermost. auth_middleware was wrapping CORSMiddleware, so its 401 responses (including CORS preflight on /arena routes) never got CORS headers.
- Add a global handleError in hooks.client.ts that redirects to /login on UnauthorizedError. A load() can throw before the root layout's onMount registers the redirect/modal handler (e.g. on first navigation), which surfaced as a generic SvelteKit error page instead of sending the user to login.

## Changes

- `backend/main.py`: move CORSMiddleware registration after auth/anonymous middlewares
- `frontend/src/hooks.client.ts`: handle UnauthorizedError globally in handleError