### PR TITLE
feat: add maintenance mode

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from backend.llms.router import router as models_router
 from backend.logger import configure_logger, configure_uvicorn_logging
 from backend.sentry import init_sentry
 from backend.utils.countries import get_vote_count
+from utils.storage.redis import get_maintenance_mode
 
 app = FastAPI()
 
@@ -53,3 +54,8 @@ async def get_counter():
         "count": await get_vote_count(),
         "objective": settings.VOTES_OBJECTIVE,
     }
+
+
+@app.get("/maintenance/status")
+async def maintenance_status():
+    return {"enabled": get_maintenance_mode()}

--- a/comparia-cli
+++ b/comparia-cli
@@ -7,6 +7,7 @@ from cyclopts import App
 from utils.database.cli import cli_db
 from utils.dataset.run import main as generate_datasets
 from utils.logger import configure_logger
+from utils.maintenance.cli import cli_maintenance
 from utils.ranking.run import main as generate_rankings
 
 cli = App()
@@ -17,6 +18,7 @@ cli_gen.command(generate_datasets, name="datasets")
 
 cli.command(cli_gen)
 cli.command(cli_db)
+cli.command(cli_maintenance)
 
 if __name__ == "__main__":
     configure_logger(logging.getLogger("comparia"))

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -1425,6 +1425,10 @@
             "title": "Hvorfor er din stemme vigtig?"
         }
     },
+    "maintenance": {
+        "desc": "compar:IA er i øjeblikket under vedligeholdelse. Vi er snart tilbage.",
+        "title": "Siden er under vedligeholdelse"
+    },
     "models": {
         "arch": {
             "title": "Vidste du?"

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -1383,6 +1383,10 @@
             "title": "Why is your vote important?"
         }
     },
+    "maintenance": {
+        "desc": "compar:IA is currently under maintenance. We'll be back shortly.",
+        "title": "Site under maintenance"
+    },
     "models": {
         "arch": {
             "title": "Did you know?"

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1563,6 +1563,10 @@
             "title": "Pourquoi votre vote est important ?"
         }
     },
+    "maintenance": {
+        "desc": "compar:IA est actuellement en maintenance. Nous serons de retour très prochainement.",
+        "title": "Site en maintenance"
+    },
     "models": {
         "arch": {
             "title": "Le saviez-vous ?"

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,10 +1,11 @@
 import { env } from '$env/dynamic/private'
+import { api } from '$lib/fastapi-client'
 import { HOST_TO_LOCALE } from '$lib/global.svelte'
 import { defineCustomServerStrategy } from '$lib/i18n/runtime'
 import { paraglideMiddleware } from '$lib/i18n/server'
 import { logger } from '$lib/logger.server'
 import { httpRequestCounter, httpRequestDuration } from '$lib/metrics'
-import type { Handle } from '@sveltejs/kit'
+import { redirect, type Handle } from '@sveltejs/kit'
 
 const MATOMO_ID = env.MATOMO_ID || ''
 const MATOMO_URL = env.MATOMO_URL || ''
@@ -59,6 +60,39 @@ const paraglideHandle: Handle = ({ event, resolve }) => {
   })
 }
 
+const MAINTENANCE_PATH = '/maintenance'
+const MAINTENANCE_CHECK_TTL_MS = 20_000
+
+// Cached per Node process so we don't hit the backend on every single request
+let maintenanceCache: { enabled: boolean; checkedAt: number } | null = null
+
+// Maintenance mode: re-checked at most every MAINTENANCE_CHECK_TTL_MS, so a
+// fresh navigation sees the flag within that window (unlike client-side
+// polling, already-open idle tabs are only caught on their next navigation).
+const maintenanceHandle: Handle = async ({ event, resolve }) => {
+  if (event.url.pathname.startsWith(MAINTENANCE_PATH) || event.url.pathname.startsWith('/_app')) {
+    return resolve(event)
+  }
+
+  const now = Date.now()
+  if (!maintenanceCache || now - maintenanceCache.checkedAt >= MAINTENANCE_CHECK_TTL_MS) {
+    let enabled = maintenanceCache?.enabled ?? false
+    try {
+      ;({ enabled } = await api.request<{ enabled: boolean }>('/maintenance/status'))
+    } catch (error) {
+      // Fail open: don't take the whole site down if the status check itself fails
+      logger.error('Maintenance status check failed', { error: `${error}` })
+    }
+    maintenanceCache = { enabled, checkedAt: now }
+  }
+
+  if (maintenanceCache.enabled) {
+    redirect(307, MAINTENANCE_PATH)
+  }
+
+  return resolve(event)
+}
+
 // Metrics middleware
 const metricsHandle: Handle = async ({ event, resolve }) => {
 	// Skip metrics endpoint itself
@@ -92,7 +126,10 @@ const metricsHandle: Handle = async ({ event, resolve }) => {
 	return response
 }
 
-// Compose handles: metrics first, then paraglide
+// Compose handles: maintenance first, then metrics, then paraglide
 export const handle: Handle = async ({ event, resolve }) => {
-	return metricsHandle({ event, resolve: (e) => paraglideHandle({ event: e, resolve }) })
+	return maintenanceHandle({
+		event,
+		resolve: (e) => metricsHandle({ event: e, resolve: (e2) => paraglideHandle({ event: e2, resolve }) })
+	})
 }

--- a/frontend/src/routes/maintenance/+page.svelte
+++ b/frontend/src/routes/maintenance/+page.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import Footer from '$components/Footer.svelte'
+  import { Header } from '$components/header'
+  import { m } from '$lib/i18n/messages'
+  import ovoidPictoSrc from '@gouvfr/dsfr/dist/artwork/background/ovoid.svg'
+  import errorPictoSrc from '@gouvfr/dsfr/dist/artwork/pictograms/system/technical-error.svg'
+</script>
+
+<Header />
+
+<main>
+  <div class="fr-container">
+    <div
+      class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center"
+    >
+      <div class="fr-py-0 fr-col-12 fr-col-md-6">
+        <h1>{m['maintenance.title']()}</h1>
+        <p class="fr-text--lead fr-mb-3w">{m['maintenance.desc']()}</p>
+      </div>
+      <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="fr-responsive-img fr-artwork"
+          aria-hidden="true"
+          width="160"
+          height="200"
+          viewBox="0 0 160 200"
+        >
+          <use class="fr-artwork-motif" href={ovoidPictoSrc + '#artwork-motif'}></use>
+          <use class="fr-artwork-background" href={ovoidPictoSrc + '#artwork-background'}></use>
+          <g transform="translate(40, 60)">
+            <use class="fr-artwork-decorative" href={errorPictoSrc + '#artwork-decorative'}></use>
+            <use class="fr-artwork-minor" href={errorPictoSrc + '#artwork-minor'}></use>
+            <use class="fr-artwork-major" href={errorPictoSrc + '#artwork-major'}></use>
+          </g>
+        </svg>
+      </div>
+    </div>
+  </div>
+</main>
+
+<Footer />

--- a/utils/maintenance/actions.py
+++ b/utils/maintenance/actions.py
@@ -1,0 +1,38 @@
+import logging
+
+from utils.storage.redis import get_redis_client, maintenance_key_for_instance
+
+logger = logging.getLogger("comparia.maintenance")
+
+
+def maintenance_on(instance: str) -> None:
+    """
+    Enable maintenance mode for the given instance.
+
+    Args:
+        instance: Country portal to target (fr, da, ...)
+    """
+    get_redis_client().set(maintenance_key_for_instance(instance), "1")
+    logger.info(f"Maintenance mode enabled for '{instance}'")
+
+
+def maintenance_off(instance: str) -> None:
+    """
+    Disable maintenance mode for the given instance.
+
+    Args:
+        instance: Country portal to target (fr, da, ...)
+    """
+    get_redis_client().delete(maintenance_key_for_instance(instance))
+    logger.info(f"Maintenance mode disabled for '{instance}'")
+
+
+def maintenance_status(instance: str) -> None:
+    """
+    Show maintenance mode status for the given instance.
+
+    Args:
+        instance: Country portal to target (fr, da, ...)
+    """
+    enabled = get_redis_client().get(maintenance_key_for_instance(instance)) == "1"
+    logger.info(f"'{instance}': {'enabled' if enabled else 'disabled'}")

--- a/utils/maintenance/actions.py
+++ b/utils/maintenance/actions.py
@@ -1,5 +1,8 @@
 import logging
 
+from sqlalchemy import create_engine, text
+
+from backend.config import settings
 from utils.storage.redis import get_redis_client, maintenance_key_for_instance
 
 logger = logging.getLogger("comparia.maintenance")
@@ -36,3 +39,30 @@ def maintenance_status(instance: str) -> None:
     """
     enabled = get_redis_client().get(maintenance_key_for_instance(instance)) == "1"
     logger.info(f"'{instance}': {'enabled' if enabled else 'disabled'}")
+
+
+def maintenance_disconnect_db() -> None:
+    """
+    Terminate other open connections to the database targeted by COMPARIA_DB_URI.
+
+    Only affects that database, not other databases on the same Postgres
+    server. Which instance this hits depends on which instance's env
+    (COMPARIA_DB_URI) is loaded when running this command.
+    """
+    if not settings.COMPARIA_DB_URI:
+        raise Exception("COMPARIA_DB_URI is not set")
+
+    engine = create_engine(settings.COMPARIA_DB_URI)
+    try:
+        with engine.connect() as conn:
+            result = conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = current_database() AND pid <> pg_backend_pid()"
+                )
+            )
+            terminated = len(result.fetchall())
+            conn.commit()
+        logger.info(f"Terminated {terminated} other connection(s) to the database")
+    finally:
+        engine.dispose()

--- a/utils/maintenance/cli.py
+++ b/utils/maintenance/cli.py
@@ -1,0 +1,17 @@
+import logging
+
+from cyclopts import App
+
+from utils.logger import configure_logger
+
+from .actions import maintenance_off, maintenance_on, maintenance_status
+
+cli_maintenance = App(name="maintenance", help="Maintenance mode utilities.")
+cli_maintenance.command(maintenance_on, name="on")
+cli_maintenance.command(maintenance_off, name="off")
+cli_maintenance.command(maintenance_status, name="status")
+
+
+if __name__ == "__main__":
+    configure_logger(logging.getLogger("comparia"))
+    cli_maintenance()

--- a/utils/maintenance/cli.py
+++ b/utils/maintenance/cli.py
@@ -4,12 +4,18 @@ from cyclopts import App
 
 from utils.logger import configure_logger
 
-from .actions import maintenance_off, maintenance_on, maintenance_status
+from .actions import (
+    maintenance_disconnect_db,
+    maintenance_off,
+    maintenance_on,
+    maintenance_status,
+)
 
 cli_maintenance = App(name="maintenance", help="Maintenance mode utilities.")
 cli_maintenance.command(maintenance_on, name="on")
 cli_maintenance.command(maintenance_off, name="off")
 cli_maintenance.command(maintenance_status, name="status")
+cli_maintenance.command(maintenance_disconnect_db, name="disconnect-db")
 
 
 if __name__ == "__main__":

--- a/utils/storage/redis.py
+++ b/utils/storage/redis.py
@@ -26,6 +26,7 @@ REDIS_ALTCHA_PREFIX: Final[str] = f"{REDIS_INSTANCE_PREFIX}altcha:"
 REDIS_WEB_SEARCH_KEY: Final[str] = (
     f"{REDIS_INSTANCE_PREFIX}web_search_cache:{{prompt_hash}}"
 )
+REDIS_MAINTENANCE_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}maintenance_mode"
 
 
 @lru_cache
@@ -51,3 +52,21 @@ def hash_content(content: str) -> str:
     """Normalize and hash content."""
     normalized = content.strip().lower()
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def get_maintenance_mode() -> bool:
+    return get_redis_client().get(REDIS_MAINTENANCE_KEY) == "1"
+
+
+def set_maintenance_mode(enabled: bool) -> None:
+    client = get_redis_client()
+    if enabled:
+        client.set(REDIS_MAINTENANCE_KEY, "1")
+    else:
+        client.delete(REDIS_MAINTENANCE_KEY)
+
+
+def maintenance_key_for_instance(instance: str) -> str:
+    """Build the maintenance mode key for an arbitrary instance (fr, da, ...),
+    regardless of the current process' own DEFAULT_COUNTRY_PORTAL."""
+    return f"{instance}:maintenance_mode"


### PR DESCRIPTION
## Summary

- Add a Redis-backed maintenance flag per instance (fr, da, ...), read by a new GET /maintenance/status endpoint (Redis only, no DB dependency)
- Frontend hooks.server.ts checks the flag (cached 20s per process) and redirects to a new /maintenance page
- Add a maintenance command group to comparia-cli: on/off/status INSTANCE (Redis flag) and disconnect-db (terminates other connections to the currently loaded COMPARIA_DB_URI, to release locks before a migration/restore)

Backend-side request blocking (503 on all routes) and forcing already-open tabs to reload are left for a later iteration.

## Changes

- `utils/storage/redis.py`: maintenance key + get/set helpers, maintenance_key_for_instance
- `backend/main.py`: GET /maintenance/status
- `utils/maintenance/`: actions (on/off/status/disconnect-db) + cli, registered in comparia-cli
- `frontend/src/hooks.server.ts`: maintenanceHandle, first in the handle chain
- `frontend/src/routes/maintenance/+page.svelte`: new maintenance page
- `frontend/locales/messages/{fr,en,da}.json`: maintenance.title / maintenance.desc