### PR TITLE
feat(front): pré-sélection de modèles via le paramètre d'URL vs

### DIFF
--- a/frontend/src/routes/arene/components/ViewPrompt.svelte
+++ b/frontend/src/routes/arene/components/ViewPrompt.svelte
@@ -44,13 +44,15 @@
     if (!vsParam) return
 
     const humanIdToModel = new Map(models.map((llm) => [llm.human_id, llm.id!]))
-    const validIds = [...new Set(
-      vsParam
-        .split(',')
-        .map((slug) => slug.trim())
-        .map((slug) => humanIdToModel.get(slug))
-        .filter((id): id is string => !!id)
-    )].slice(0, 2)
+    const validIds = [
+      ...new Set(
+        vsParam
+          .split(',')
+          .map((slug) => slug.trim())
+          .map((slug) => humanIdToModel.get(slug))
+          .filter((id): id is string => !!id)
+      )
+    ].slice(0, 2)
 
     if (validIds.length > 0) {
       mode.value = 'custom'

--- a/frontend/src/routes/arene/components/ViewPrompt.svelte
+++ b/frontend/src/routes/arene/components/ViewPrompt.svelte
@@ -44,16 +44,20 @@
     if (!vsParam) return
 
     const humanIdToModel = new Map(models.map((llm) => [llm.human_id, llm.id!]))
-    const validIds = vsParam
-      .split(',')
-      .map((slug) => slug.trim())
-      .map((slug) => humanIdToModel.get(slug))
-      .filter((id): id is string => !!id)
-      .slice(0, 2)
+    const validIds = [...new Set(
+      vsParam
+        .split(',')
+        .map((slug) => slug.trim())
+        .map((slug) => humanIdToModel.get(slug))
+        .filter((id): id is string => !!id)
+    )].slice(0, 2)
 
     if (validIds.length > 0) {
       mode.value = 'custom'
       modelsSelection.value = validIds
+    } else {
+      mode.value = 'random'
+      modelsSelection.value = []
     }
 
     const params = new SvelteURLSearchParams(page.url.searchParams)

--- a/frontend/src/routes/arene/components/ViewPrompt.svelte
+++ b/frontend/src/routes/arene/components/ViewPrompt.svelte
@@ -6,7 +6,10 @@
   import { m } from '$lib/i18n/messages.js'
   import { getModelsContext } from '$lib/models'
   import { sanitize } from '$lib/utils/commons'
-  import { tick } from 'svelte'
+  import { goto } from '$app/navigation'
+  import { page } from '$app/state'
+  import { onMount, tick } from 'svelte'
+  import { SvelteURLSearchParams } from 'svelte/reactivity'
   import { GuidedPromptSuggestions, ModelSelector } from '.'
 
   let {
@@ -35,6 +38,29 @@
   let webSearch = $state(false)
 
   const disabled = $derived(prompt == '' || !!promptError || loading)
+
+  onMount(() => {
+    const vsParam = page.url.searchParams.get('vs')
+    if (!vsParam) return
+
+    const humanIdToModel = new Map(models.map((llm) => [llm.human_id, llm.id!]))
+    const validIds = vsParam
+      .split(',')
+      .map((slug) => slug.trim())
+      .map((slug) => humanIdToModel.get(slug))
+      .filter((id): id is string => !!id)
+      .slice(0, 2)
+
+    if (validIds.length > 0) {
+      mode.value = 'custom'
+      modelsSelection.value = validIds
+    }
+
+    const params = new SvelteURLSearchParams(page.url.searchParams)
+    params.delete('vs')
+    const qs = params.toString()
+    goto(qs ? `${page.url.pathname}?${qs}` : page.url.pathname, { replaceState: true })
+  })
 
   function selectPartialText(start?: number, end?: number): void {
     if (promptEl) {


### PR DESCRIPTION
## Objectif

Permet de partager un lien vers l'arène avec des modèles pré-sélectionnés, pour par exemple comparer deux modèles précis depuis un article, un tweet ou un email.

## Fonctionnement

Un lien de la forme `/arene?vs=llama-4-scout,llama-maverick` déclenche au chargement de la page :

1. Lecture du paramètre `vs` depuis l'URL
2. Résolution de chaque slug (`human_id`) en UUID de modèle
3. Activation du mode `custom` et pré-remplissage de la sélection (persisté via `localStorage`)
4. Suppression du paramètre de l'URL (`replaceState`) pour ne pas polluer l'historique

Le `ModelSelector` affiche alors naturellement les modèles pré-cochés, sans modification supplémentaire de l'UI. Le backend `pick_two()` gère déjà le mode custom à 1 ou 2 modèles, donc aucun changement backend n'est nécessaire.

## Cas gérés

- **2 modèles** : duel complet entre les deux modèles choisis
- **1 seul modèle** : le second est tiré aléatoirement par le backend (déjà implémenté)
- **Slug inconnu / modèle archivé** : ignoré silencieusement, dégradation vers le mode random
- **Combiné avec `?cgu_acceptees`** : le param `vs` est retiré mais les autres sont préservés

## Exemples d'URLs

- `/arene?vs=llama-4-scout,llama-maverick` — duel complet
- `/arene?vs=llama-maverick` — un modèle, le 2e aléatoire
- `/arene?cgu_acceptees&vs=gemini-3.1-pro-preview,trinity-large-thinking` — combiné

## Limites

- Le rate-limit custom (3/h, 5/d par IP) reste actif — à surveiller si un lien est massivement partagé derrière un même NAT.
- Les slugs utilisent `human_id` (ex: `llama-4-scout`), pas l'UUID interne.

## Checklist

- [x] Code en anglais, UI/messages en français
- [x] Pas de CSS custom (réutilise `ModelSelector` existant)
- [x] Pas de secret en clair
- [x] `pnpm check` — pas de nouvelle erreur
- [x] Testé en local (2 modèles, 1 modèle, slug invalide, combiné avec cgu)