### PR TITLE
feat: poll maintenance status on the maintenance page to auto-redirect home

### DIFF
--- a/frontend/src/routes/maintenance/+page.svelte
+++ b/frontend/src/routes/maintenance/+page.svelte
@@ -1,9 +1,29 @@
 <script lang="ts">
+  import { goto } from '$app/navigation'
   import Footer from '$components/Footer.svelte'
   import { Header } from '$components/header'
+  import { api } from '$lib/fastapi-client'
   import { m } from '$lib/i18n/messages'
   import ovoidPictoSrc from '@gouvfr/dsfr/dist/artwork/background/ovoid.svg'
   import errorPictoSrc from '@gouvfr/dsfr/dist/artwork/pictograms/system/technical-error.svg'
+  import { onDestroy, onMount } from 'svelte'
+
+  const CHECK_INTERVAL_MS = 20_000
+
+  onMount(() => {
+    const interval = setInterval(async () => {
+      try {
+        const { enabled } = await api.request<{ enabled: boolean }>('/maintenance/status')
+        if (!enabled) {
+          goto('/')
+        }
+      } catch (error) {
+        console.error(`Maintenance status check failed: ${(error as Error).message}`)
+      }
+    }, CHECK_INTERVAL_MS)
+
+    onDestroy(() => clearInterval(interval))
+  })
 </script>
 
 <Header />

--- a/utils/maintenance/actions.py
+++ b/utils/maintenance/actions.py
@@ -1,6 +1,8 @@
 import logging
+from datetime import datetime
 
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
 
 from backend.config import settings
 from utils.storage.redis import get_redis_client, maintenance_key_for_instance
@@ -64,5 +66,32 @@ def maintenance_disconnect_db() -> None:
             terminated = len(result.fetchall())
             conn.commit()
         logger.info(f"Terminated {terminated} other connection(s) to the database")
+    finally:
+        engine.dispose()
+
+
+def maintenance_backup_db() -> None:
+    """
+    Create a backup copy of the database targeted by COMPARIA_DB_URI.
+
+    Runs CREATE DATABASE <dbname>_backup_<timestamp> TEMPLATE <dbname>. Postgres
+    requires no open connections to the source database for this to succeed
+    (see disconnect-db), and the connection issuing the command must not itself
+    be connected to the source database, so this connects to 'postgres' instead.
+    """
+    if not settings.COMPARIA_DB_URI:
+        raise Exception("COMPARIA_DB_URI is not set")
+
+    url = make_url(settings.COMPARIA_DB_URI)
+    source_db = url.database
+    if not source_db:
+        raise Exception("COMPARIA_DB_URI has no database name")
+
+    backup_db = f"{source_db}_backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    engine = create_engine(url.set(database="postgres"))
+    try:
+        with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+            conn.execute(text(f'CREATE DATABASE "{backup_db}" TEMPLATE "{source_db}"'))
+        logger.info(f"Created backup database '{backup_db}' from '{source_db}'")
     finally:
         engine.dispose()

--- a/utils/maintenance/cli.py
+++ b/utils/maintenance/cli.py
@@ -5,6 +5,7 @@ from cyclopts import App
 from utils.logger import configure_logger
 
 from .actions import (
+    maintenance_backup_db,
     maintenance_disconnect_db,
     maintenance_off,
     maintenance_on,
@@ -16,6 +17,7 @@ cli_maintenance.command(maintenance_on, name="on")
 cli_maintenance.command(maintenance_off, name="off")
 cli_maintenance.command(maintenance_status, name="status")
 cli_maintenance.command(maintenance_disconnect_db, name="disconnect-db")
+cli_maintenance.command(maintenance_backup_db, name="copy-db-backup")
 
 
 if __name__ == "__main__":

--- a/utils/storage/redis.py
+++ b/utils/storage/redis.py
@@ -58,14 +58,6 @@ def get_maintenance_mode() -> bool:
     return get_redis_client().get(REDIS_MAINTENANCE_KEY) == "1"
 
 
-def set_maintenance_mode(enabled: bool) -> None:
-    client = get_redis_client()
-    if enabled:
-        client.set(REDIS_MAINTENANCE_KEY, "1")
-    else:
-        client.delete(REDIS_MAINTENANCE_KEY)
-
-
 def maintenance_key_for_instance(instance: str) -> str:
     """Build the maintenance mode key for an arbitrary instance (fr, da, ...),
     regardless of the current process' own DEFAULT_COUNTRY_PORTAL."""


### PR DESCRIPTION
## Summary

- Follow-up to #570. The /maintenance page now polls GET /maintenance/status every 20s and redirects to / once maintenance is disabled, instead of relying on the user's next manual navigation to leave the page.