### PR TITLE
Corrige le lien du dataset Hugging Face sur la page Datasets

### DIFF
--- a/frontend/src/routes/(pages)/datasets/+page.svelte
+++ b/frontend/src/routes/(pages)/datasets/+page.svelte
@@ -11,7 +11,7 @@
 
   const datasetCard = {
     img: `/datasets/conversations-${locale === 'fr' ? 'fr' : 'en'}.png`,
-    link: 'https://huggingface.co/datasets/comparIA/comparia-fr-arena',
+    link: 'https://huggingface.co/datasets/ministere-culture/comparia-fr-arena',
     title: m['datasets.access.repos.arena.title'](),
     desc: m['datasets.access.repos.arena.desc']()
   }


### PR DESCRIPTION
Le lien de la carte du dataset sur la page `/datasets` pointait encore vers l'ancien namespace `comparIA/comparia-fr-arena`. Il utilise désormais `ministere-culture/comparia-fr-arena`.

- Un seul fichier modifié : `frontend/src/routes/(pages)/datasets/+page.svelte`