### PR TITLE
feat(back): renforce les limites de débit du login par email

### DIFF
--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, EmailStr
 from backend.arena.captcha import verify_altcha_token
 from backend.auth.email import send_login_code
 from backend.auth.services import (
+    _hash,
     accept_invite,
     get_invite_token_info,
     get_user_from_token,
@@ -17,13 +18,16 @@ from backend.auth.services import (
 )
 from backend.config import settings
 from backend.utils.user import get_ip, get_matomo_tracker_from_cookies
-from utils.storage.redis import REDIS_AUTH_EMAIL_REQ, get_redis_client
+from utils.storage.redis import (
+    REDIS_AUTH_EMAIL_REQ,
+    REDIS_AUTH_EMAIL_REQ_EMAIL,
+    REDIS_AUTH_VERIFY_FAIL,
+    get_redis_client,
+)
 
 logger = logging.getLogger("languia")
 
 router = APIRouter(prefix="/auth", tags=["auth"])
-
-_EMAIL_RATELIMIT_PER_HOUR = 15
 
 
 class AuthConfig(BaseModel):
@@ -76,7 +80,17 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
         count = client.incr(key)
         if count == 1:
             client.expire(key, 3600)
-        if count > _EMAIL_RATELIMIT_PER_HOUR:
+        if count > settings.AUTH_EMAIL_REQUEST_PER_IP_PER_HOUR:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many login attempts, try again later.",
+            )
+
+        email_key = REDIS_AUTH_EMAIL_REQ_EMAIL.format(email=_hash(body.email))
+        email_count = client.incr(email_key)
+        if email_count == 1:
+            client.expire(email_key, 3600)
+        if email_count > settings.AUTH_EMAIL_REQUEST_PER_EMAIL_PER_HOUR:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Too many login attempts, try again later.",
@@ -103,6 +117,15 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
             detail="Failed to send login code, please try again later.",
         )
 
+    # A fresh code resets the verify attempt counter so a locked-out user can
+    # retry. The per-email request cap above still bounds total guesses.
+    try:
+        get_redis_client().delete(
+            REDIS_AUTH_VERIFY_FAIL.format(ip=ip, email=_hash(body.email))
+        )
+    except Exception as e:
+        logger.error(f"[AUTH] Redis rate limit check failed: {e}")
+
 
 @router.post("/email/verify")
 async def email_verify(
@@ -111,6 +134,20 @@ async def email_verify(
     ip = get_ip(request)
     user_agent = request.headers.get("user-agent")
     visitor_id = get_matomo_tracker_from_cookies(request.cookies)
+    fail_key = REDIS_AUTH_VERIFY_FAIL.format(ip=ip, email=_hash(body.email))
+
+    try:
+        client = get_redis_client()
+        fail_count = client.get(fail_key)
+        if fail_count and int(fail_count) >= settings.AUTH_VERIFY_MAX_ATTEMPTS:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many attempts, please request a new code.",
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[AUTH] Redis rate limit check failed: {e}")
 
     token = await verify_login_code(
         email=body.email,
@@ -120,10 +157,23 @@ async def email_verify(
         visitor_id=visitor_id,
     )
     if not token:
+        try:
+            client = get_redis_client()
+            fail_count = client.incr(fail_key)
+            if fail_count == 1:
+                client.expire(fail_key, 600)
+        except Exception as e:
+            logger.error(f"[AUTH] Redis rate limit check failed: {e}")
+
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired code.",
         )
+
+    try:
+        get_redis_client().delete(fail_key)
+    except Exception as e:
+        logger.error(f"[AUTH] Redis rate limit check failed: {e}")
 
     response.set_cookie(
         "auth_session",

--- a/backend/config.py
+++ b/backend/config.py
@@ -66,6 +66,16 @@ class Settings(BaseSettings):
     AUTH_SESSION_LENGTH_DAYS: int = 30
     # Bumping this value invalidates existing consent logs and forces re-consent
     AUTH_TERMS_VERSION: str = "1.0"
+
+    # Deliberately high: keyed on IP, so a school class behind one shared NAT
+    # must never be locked out. The real anti-abuse limit is per-email below.
+    AUTH_EMAIL_REQUEST_PER_IP_PER_HOUR: int = 2000
+    AUTH_EMAIL_REQUEST_PER_EMAIL_PER_HOUR: int = 5
+    AUTH_VERIFY_MAX_ATTEMPTS: int = 5
+
+    # Anonymous
+    ANONYMOUS_SESSION_LENGTH_DAYS: int = 30
+
     # Public app origin, used to build absolute links in emails (e.g. invite links)
     COMPARIA_APP_URL: str = "http://localhost:5173"
 
@@ -73,9 +83,6 @@ class Settings(BaseSettings):
     @classmethod
     def _strip_trailing_slash(cls, value: str) -> str:
         return value.rstrip("/")
-
-    # Anonymous
-    ANONYMOUS_SESSION_LENGTH_DAYS: int = 30
 
     # SMTP (Brevo relay or any SMTP provider)
     # If unset, login codes are logged to console instead of being sent by email

--- a/tests/arena/test_auth_ratelimit.py
+++ b/tests/arena/test_auth_ratelimit.py
@@ -1,0 +1,261 @@
+"""
+Unit tests for the email-login rate limits (no network, no real Redis, no DB).
+
+Covers the 600-kids-behind-one-IP property (per-email request cap is isolated
+per email, never shared across a NAT) and the verify brute-force limiter.
+
+Run with pytest, or directly:
+    uv run python tests/arena/test_auth_ratelimit.py
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
+
+import utils.database.models  # noqa: F401 needed before importing backend.auth.router
+
+import backend.auth.router as auth_router
+from backend.config import settings
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from utils.storage.redis import REDIS_AUTH_EMAIL_REQ, REDIS_AUTH_VERIFY_FAIL
+
+
+class FakeRedis:
+    """Minimal string-counter stub matching decode_responses=True behaviour."""
+
+    def __init__(self):
+        self.store: dict[str, int] = {}
+
+    def incr(self, key):
+        self.store[key] = self.store.get(key, 0) + 1
+        return self.store[key]
+
+    def expire(self, key, ttl):
+        pass
+
+    def get(self, key):
+        v = self.store.get(key)
+        return None if v is None else str(v)
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+async def _fake_request_login_code(email):
+    return "123456"
+
+
+async def _fake_send_login_code(email, code):
+    pass
+
+
+@contextlib.contextmanager
+def fake_router(verify_login_code=None):
+    fake = FakeRedis()
+
+    orig = {
+        "get_redis_client": auth_router.get_redis_client,
+        "verify_altcha_token": auth_router.verify_altcha_token,
+        "request_login_code": auth_router.request_login_code,
+        "send_login_code": auth_router.send_login_code,
+        "verify_login_code": auth_router.verify_login_code,
+    }
+    auth_router.get_redis_client = lambda: fake
+    auth_router.verify_altcha_token = lambda payload: (True, None)
+    auth_router.request_login_code = _fake_request_login_code
+    auth_router.send_login_code = _fake_send_login_code
+    if verify_login_code is not None:
+        auth_router.verify_login_code = verify_login_code
+    try:
+        app = FastAPI()
+        app.include_router(auth_router.router)
+        yield TestClient(app), fake
+    finally:
+        for name, func in orig.items():
+            setattr(auth_router, name, func)
+
+
+def test_per_email_request_cap_is_isolated_per_email():
+    with fake_router() as (client, _fake):
+        limit = settings.AUTH_EMAIL_REQUEST_PER_EMAIL_PER_HOUR
+        for _ in range(limit):
+            r = client.post(
+                "/auth/email/request",
+                json={"email": "student1@school.fr", "altcha_payload": "x"},
+            )
+            assert r.status_code == 204
+
+        r = client.post(
+            "/auth/email/request",
+            json={"email": "student1@school.fr", "altcha_payload": "x"},
+        )
+        assert r.status_code == 429
+
+        # Same IP, different student: independent bucket, must not be blocked.
+        r = client.post(
+            "/auth/email/request",
+            json={"email": "student2@school.fr", "altcha_payload": "x"},
+        )
+        assert r.status_code == 204
+
+
+def test_per_ip_request_cap_uses_configured_ceiling():
+    with fake_router() as (client, fake):
+        ip_limit = settings.AUTH_EMAIL_REQUEST_PER_IP_PER_HOUR
+        email_limit = settings.AUTH_EMAIL_REQUEST_PER_EMAIL_PER_HOUR
+        assert ip_limit > email_limit, "IP ceiling must stay looser than the email cap"
+
+        key = REDIS_AUTH_EMAIL_REQ.format(ip="testclient")
+        fake.store[key] = ip_limit  # fast-forward to the edge without ip_limit requests
+
+        r = client.post(
+            "/auth/email/request",
+            json={"email": "student3@school.fr", "altcha_payload": "x"},
+        )
+        assert r.status_code == 429
+
+
+def test_verify_fail_counter_trips_at_max_attempts():
+    async def always_wrong(**kwargs):
+        return None
+
+    with fake_router(verify_login_code=always_wrong) as (client, _fake):
+        max_attempts = settings.AUTH_VERIFY_MAX_ATTEMPTS
+        for _ in range(max_attempts):
+            r = client.post(
+                "/auth/email/verify",
+                json={"email": "student1@school.fr", "code": "000000"},
+            )
+            assert r.status_code == 400
+
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "student1@school.fr", "code": "000000"},
+        )
+        assert r.status_code == 429
+
+
+def test_verify_fail_counter_is_isolated_per_email():
+    async def always_wrong(**kwargs):
+        return None
+
+    with fake_router(verify_login_code=always_wrong) as (client, _fake):
+        max_attempts = settings.AUTH_VERIFY_MAX_ATTEMPTS
+        for _ in range(max_attempts):
+            r = client.post(
+                "/auth/email/verify",
+                json={"email": "student1@school.fr", "code": "000000"},
+            )
+            assert r.status_code == 400
+
+        # Same IP, different student: independent bucket, must not be blocked.
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "student2@school.fr", "code": "000000"},
+        )
+        assert r.status_code == 400
+
+
+def test_successful_verify_clears_fail_counter():
+    calls = {"n": 0}
+
+    async def wrong_then_right(**kwargs):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else "sometoken"
+
+    with fake_router(verify_login_code=wrong_then_right) as (client, fake):
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "student1@school.fr", "code": "000000"},
+        )
+        assert r.status_code == 400
+
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "student1@school.fr", "code": "111111"},
+        )
+        assert r.status_code == 200
+        assert "auth_session" in r.cookies
+
+        key = REDIS_AUTH_VERIFY_FAIL.format(
+            ip="testclient", email=auth_router._hash("student1@school.fr")
+        )
+        assert key not in fake.store
+
+
+def test_new_code_request_resets_verify_counter():
+    async def always_wrong(**kwargs):
+        return None
+
+    with fake_router(verify_login_code=always_wrong) as (client, _fake):
+        for _ in range(settings.AUTH_VERIFY_MAX_ATTEMPTS):
+            client.post(
+                "/auth/email/verify",
+                json={"email": "student1@school.fr", "code": "000000"},
+            )
+        # Locked out.
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "student1@school.fr", "code": "000000"},
+        )
+        assert r.status_code == 429
+
+        # Requesting a fresh code clears the counter; verify is attemptable again.
+        r = client.post(
+            "/auth/email/request",
+            json={"email": "student1@school.fr", "altcha_payload": "x"},
+        )
+        assert r.status_code == 204
+
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "student1@school.fr", "code": "000000"},
+        )
+        assert r.status_code == 400
+
+
+def test_verify_lockout_is_scoped_per_ip():
+    async def always_wrong(**kwargs):
+        return None
+
+    with fake_router(verify_login_code=always_wrong) as (client, _fake):
+        # An attacker who knows a victim's email burns all attempts from its IP.
+        for _ in range(settings.AUTH_VERIFY_MAX_ATTEMPTS):
+            client.post(
+                "/auth/email/verify",
+                json={"email": "victim@school.fr", "code": "000000"},
+            )
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "victim@school.fr", "code": "000000"},
+        )
+        assert r.status_code == 429  # attacker's own IP is locked
+
+        # The victim, from another IP, is not locked out (no cross-IP DoS).
+        r = client.post(
+            "/auth/email/verify",
+            json={"email": "victim@school.fr", "code": "000000"},
+            headers={"x-forwarded-for": "203.0.113.7"},
+        )
+        assert r.status_code == 400
+
+
+def run():
+    test_per_email_request_cap_is_isolated_per_email()
+    test_per_ip_request_cap_uses_configured_ceiling()
+    test_verify_fail_counter_trips_at_max_attempts()
+    test_verify_fail_counter_is_isolated_per_email()
+    test_successful_verify_clears_fail_counter()
+    test_new_code_request_resets_verify_counter()
+    test_verify_lockout_is_scoped_per_ip()
+    print("All auth rate limit cases passed.")
+
+
+if __name__ == "__main__":
+    run()

--- a/utils/storage/redis.py
+++ b/utils/storage/redis.py
@@ -27,6 +27,12 @@ REDIS_LLM_RESPONSES_KEY: Final[str] = (
 )
 REDIS_ALTCHA_PREFIX: Final[str] = f"{REDIS_INSTANCE_PREFIX}altcha:"
 REDIS_AUTH_EMAIL_REQ: Final[str] = f"{REDIS_INSTANCE_PREFIX}auth_email_req:{{ip}}"
+REDIS_AUTH_EMAIL_REQ_EMAIL: Final[str] = (
+    f"{REDIS_INSTANCE_PREFIX}auth_email_req_email:{{email}}"
+)
+REDIS_AUTH_VERIFY_FAIL: Final[str] = (
+    f"{REDIS_INSTANCE_PREFIX}auth_verify_fail:{{ip}}:{{email}}"
+)
 REDIS_WEB_SEARCH_KEY: Final[str] = (
     f"{REDIS_INSTANCE_PREFIX}web_search_cache:{{prompt_hash}}"
 )


### PR DESCRIPTION
## Objectif

Combler trois trous dans le login par code email, sans jamais bloquer une classe de 600 élèves derrière une seule IP partagée. Chaque limite critique est donc indexée sur l'email (propre à chaque élève), pas sur l'IP seule.

## Ce qui était fragile

- `/auth/email/verify` n'avait aucune limite : le code à 6 chiffres (valable 10 min) pouvait être bruteforcé sans fin.
- `/auth/email/request` n'était limité que par IP, donc bombardable en tournant les IP.
- La limite par IP de 15/h bloquait une classe de 600 élèves dès le 16e.

## Ce que fait la PR

- Vérification limitée à 5 tentatives par (IP, email), puis 429. Une nouvelle demande de code remet le compteur à zéro.
- Demande de code plafonnée à 5/h par email, en plus de la limite par IP.
- Limite par IP relevée à 2000/h, configurable.

Trois réglages env avec valeurs par défaut : `AUTH_EMAIL_REQUEST_PER_IP_PER_HOUR` (2000), `AUTH_EMAIL_REQUEST_PER_EMAIL_PER_HOUR` (5), `AUTH_VERIFY_MAX_ATTEMPTS` (5). Les compteurs sont dans Redis et fail-open comme le reste du fichier. Tests dans `tests/arena/test_auth_ratelimit.py`.