### PR TITLE
fix(auth): exclude /maintenance from sign_in_required wall

### DIFF
--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -130,7 +130,8 @@ const authWallHandle: Handle = ({ event, resolve }) => {
   if (env.AUTH_ACCESS_POLICY !== 'sign_in_required') return resolve(event)
 
   const path = event.url.pathname
-  if (path.startsWith('/login') || path.startsWith('/_app')) return resolve(event)
+  if (path.startsWith('/login') || path.startsWith('/_app') || path.startsWith(MAINTENANCE_PATH))
+    return resolve(event)
 
   const cookie = event.cookies.get('auth_session')
   if (!cookie) {


### PR DESCRIPTION
## Summary

- Fixes a redirect loop between /maintenance and /login when maintenance mode is on under sign_in_required.

## Details

With maintenance mode enabled and AUTH_ACCESS_POLICY=sign_in_required, an unauthenticated visit bounced forever: the maintenance handle redirects everything to /maintenance, the auth wall then redirects /maintenance to /login, and the maintenance handle sends /login back to /maintenance.

The maintenance page is now excluded from the auth wall, so it renders without login. /login still redirects to /maintenance while maintenance is active.

## Changes

- `frontend/src/hooks.server.ts`: skip the sign_in_required wall for /maintenance