### PR TITLE
fix(ui): affine les retours visuels de l’arène

### DIFF
--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -2128,6 +2128,7 @@
         }
     },
     "vote": {
+        "continueReminder": "Stem på et svar, eller vælg \"Spring afstemningen over\", før du fortsætter.",
         "choices": {
             "negative": {
                 "comment": "Uddyb hvad du ikke kunne lide…",

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -1996,7 +1996,7 @@
             "title": "Hvordan fordeler brugernes præferencer sig?"
         },
         "ranking": {
-            "desc": "Tak for jeres bidrag!<br> Rangeringen <strong>AI-arenaen</strong> er baseret på alle stemmer og reaktioner fra den <strong>blinde sammenligning</strong> af modellerne og indsamlet siden tjenestens offentlige lancering i oktober 2024.<br> Bygget i partnerskab med Pôle d'Expertise de la Régulation Numérique (<a {linkProps}>PEReN</a>), er modelrangeringen etableret baseret på <strong>tilfredshedsscore</strong> beregnet ud fra den statistiske model <strong>Bradley Terry</strong>, en udbredt metode til at konvertere binære stemmer til probabilistisk rangering.<br> AI-arenaens-rangeringen har ikke til formål at udgøre en officiel anbefaling eller evaluere modellernes tekniske ydeevne. Den afspejler platformens brugeres <strong>subjektive præferencer</strong> og ikke svarenes faktualitet eller sandfærdighed.",
+            "desc": "Denne rangering beregnes ud fra stemmer indsamlet gennem <strong>blinde sammenligninger</strong> ved hjælp af den statistiske <strong>Bradley-Terry-model</strong>. Den afspejler <strong>subjektive præferencer</strong> og bør fortolkes med forsigtighed: den måler hverken faktuel korrekthed eller modellernes samlede ydeevne.",
             "tabLabel": "Rangliste"
         },
         "table": {

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -2087,6 +2087,7 @@
         }
     },
     "vote": {
+        "continueReminder": "Vote for an answer or choose “Skip vote” before continuing.",
         "choices": {
             "negative": {
                 "incorrect": "Incorrect",

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -1954,7 +1954,7 @@
             "title": "How are user preferences distributed?"
         },
         "ranking": {
-            "desc": "Thank you for your contributions!<br> The <strong>arena ranking</strong> is based on all votes and reactions from the <strong>blind comparison</strong> of the models, collected since the service opened to the public in October 2024.<br>Developed in partnership with the Digital Regulation Expertise Center (<a {linkProps}>PEReN</a>), the model ranking is based on the <strong>satisfaction score</strong> calculated using the <strong>Bradley Terry</strong> statistical model, a widely used method for converting binary votes into a probabilistic ranking.<br> The compar:IA ranking is not intended to be an official recommendation or to evaluate the technical performance of the models. It reflects the <strong>subjective preferences</strong> of the platform's users and not the factual accuracy or veracity of the responses.",
+            "desc": "This ranking is calculated from votes collected through <strong>blind comparisons</strong>, using the <strong>Bradley-Terry</strong> statistical model. It reflects <strong>subjective preferences</strong> and should be interpreted with caution: it measures neither factual accuracy nor overall model performance.",
             "tabLabel": "Leaderboard"
         },
         "table": {

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -2389,7 +2389,7 @@
             "title": "Comment se répartissent les préférences des utilisateurs ?"
         },
         "ranking": {
-            "desc": "Merci pour vos contributions !<br> Le classement <strong>compar:IA</strong> repose sur l’ensemble des votes et réactions issus de la <strong>comparaison à l'aveugle </strong> des modèles et collectés depuis l’ouverture du service au public en octobre 2024.<br> Construit en partenariat avec le Pôle d'Expertise de la Régulation Numérique (<a {linkProps}>PEReN</a>), le classement des modèles est établi en fonction du <strong>score de satisfaction</strong> calculé à partir du modèle statistique <strong>Bradley Terry</strong>, méthode largement répandue pour convertir des votes binaires en classement probabiliste.<br> Le classement compar:IA n’a pas vocation à constituer une recommandation officielle ni à évaluer la performance technique des modèles. Il reflète les <strong>préférences subjectives</strong> des utilisateurs de la plateforme et non la factualité ou la véracité des réponses.",
+            "desc": "Ce classement est calculé à partir des votes recueillis lors de <strong>comparaisons à l’aveugle</strong>, selon le modèle statistique <strong>Bradley-Terry</strong>. Il reflète des <strong>préférences subjectives</strong> et doit être interprété avec prudence : il ne mesure ni la factualité des réponses ni la performance globale des modèles.",
             "tabLabel": "Classement"
         },
         "styleControl": {

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -2541,6 +2541,7 @@
         }
     },
     "vote": {
+        "continueReminder": "Votez pour une réponse ou choisissez « Passer le vote » avant de continuer.",
         "choices": {
             "negative": {
                 "comment": "Précisez ce que vous n’avez pas aimé…",

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -1445,6 +1445,7 @@
         }
     },
     "vote": {
+        "continueReminder": "Rösta på ett svar eller välj ”Hoppa över omröstningen” innan du fortsätter.",
         "choices": {
             "negative": {
                 "incorrect": "Fel",

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -1353,7 +1353,7 @@
             "title": "Hur är preferenserna fördelade?"
         },
         "ranking": {
-            "desc": "Tack för dina bidrag! Dina röster matas in i en Bradley-Terry-ranking. Denna nöjdhetspoäng är skapad i samarbete med <a {linkProps}>Pôle d'Expertise de la Régulation Numérique (PEReN)</a> och baseras på dina röster och reaktioner.",
+            "desc": "Den här rankningen beräknas från röster som samlats in genom <strong>blinda jämförelser</strong> med den statistiska <strong>Bradley-Terry-modellen</strong>. Den speglar <strong>subjektiva preferenser</strong> och bör tolkas med försiktighet: den mäter varken faktakorrekthet eller modellernas övergripande prestanda.",
             "tabLabel": "Rankning"
         },
         "table": {

--- a/frontend/src/lib/components/InfoCard.svelte
+++ b/frontend/src/lib/components/InfoCard.svelte
@@ -116,7 +116,12 @@
 
   <svelte:element this={contentTag} class="p-0">
     {#if badge && size === 'xxs'}
-      <Badge {...badge} tooltip={undefined} size="sm" />
+      <Badge
+        {...badge}
+        tooltip={undefined}
+        size="xs"
+        class="px-1! leading-tight! tracking-normal! max-w-full text-center text-[10px]! [overflow-wrap:anywhere] whitespace-normal!"
+      />
     {:else if content}
       {@render innerContent(content, subContent)}
     {:else}

--- a/frontend/src/lib/components/TextPrompt.svelte
+++ b/frontend/src/lib/components/TextPrompt.svelte
@@ -108,7 +108,7 @@
         aria-disabled={submitDisabled}
         text={m['words.send']()}
         onclick={() => (submitDisabled ? onSubmitBlocked() : onSubmit(value))}
-        class={['right-3 bottom-3 absolute', { 'cursor-not-allowed opacity-50': submitDisabled }]}
+        class="right-3 bottom-3 absolute"
       />
     {/if}
   </div>

--- a/frontend/src/lib/components/TextPrompt.svelte
+++ b/frontend/src/lib/components/TextPrompt.svelte
@@ -20,6 +20,7 @@
     el?: HTMLTextAreaElement
     class?: string
     onSubmit?: (value: string) => void
+    onSubmitBlocked?: () => void
     onBlur?: (value: string) => void
     onFocus?: () => void
   } & Partial<Pick<HTMLTextAreaElement, 'disabled' | 'placeholder' | 'rows'>>
@@ -41,6 +42,7 @@
     el = $bindable(),
     class: classNames = '',
     onSubmit = noop,
+    onSubmitBlocked = noop,
     onBlur = noop,
     onFocus = noop,
     ...nativeTextAreaProps
@@ -66,6 +68,8 @@
       e.preventDefault()
       if (!submitDisabled) {
         onSubmit(value)
+      } else {
+        onSubmitBlocked()
       }
     }
   }
@@ -101,10 +105,10 @@
         icon="arrow-up-line"
         iconOnly
         {size}
-        disabled={submitDisabled}
+        aria-disabled={submitDisabled}
         text={m['words.send']()}
-        onclick={() => onSubmit(value)}
-        class="right-3 bottom-3 absolute"
+        onclick={() => (submitDisabled ? onSubmitBlocked() : onSubmit(value))}
+        class={['right-3 bottom-3 absolute', { 'cursor-not-allowed opacity-50': submitDisabled }]}
       />
     {/if}
   </div>

--- a/frontend/src/lib/components/TextPrompt.svelte.test.ts
+++ b/frontend/src/lib/components/TextPrompt.svelte.test.ts
@@ -1,0 +1,25 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import TextPrompt from './TextPrompt.svelte'
+
+describe('TextPrompt', () => {
+  it('reports blocked keyboard and button submission attempts', async () => {
+    const onSubmit = vi.fn()
+    const onSubmitBlocked = vi.fn()
+    const { getByRole, getByTestId } = render(TextPrompt, {
+      id: 'prompt',
+      label: 'Prompt',
+      value: 'Continue',
+      submitBtn: true,
+      submitDisabled: true,
+      onSubmit,
+      onSubmitBlocked
+    })
+
+    await fireEvent.keyDown(getByTestId('textbox'), { key: 'Enter' })
+    await fireEvent.click(getByRole('button', { name: 'Envoyer' }))
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onSubmitBlocked).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/lib/components/dsfr/Button.svelte
+++ b/frontend/src/lib/components/dsfr/Button.svelte
@@ -68,4 +68,16 @@
       --text-action-high-blue-france: var(--blue-france-main-525);
     }
   }
+
+  /* Keep blocked actions focusable so they can explain what is required,
+     while preserving the standard DSFR disabled appearance. */
+  .fr-btn[aria-disabled='true'] {
+    color: var(--text-disabled-grey);
+    background-color: var(--background-disabled-grey);
+    cursor: not-allowed;
+
+    --idle: transparent;
+    --hover: var(--background-disabled-grey-hover);
+    --active: var(--background-disabled-grey-active);
+  }
 </style>

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -97,7 +97,7 @@
             size="sm"
             aria-controls="fr-modal-signin"
             data-fr-opened="false"
-            class="block w-full!"
+            class="mt-2! block w-full!"
           />
         {/if}
       </div>
@@ -140,7 +140,12 @@
           </span>
         </Button>
 
-        <p class={['text-sm mb-0! text-grey truncate', { 'lg:hidden': !expanded }]}>
+        <p
+          class={[
+            'text-sm mb-0! text-grey min-w-0 max-w-full [overflow-wrap:anywhere]',
+            { 'lg:hidden': !expanded }
+          ]}
+        >
           {auth.user.email}
         </p>
       </div>

--- a/frontend/src/routes/arene/components/ViewChat.svelte
+++ b/frontend/src/routes/arene/components/ViewChat.svelte
@@ -132,7 +132,7 @@
         aria-disabled={!canContinue}
         size="sm"
         icon="arrow-up-circle-line"
-        class={['md:w-fit! lh-none! w-full!', { 'cursor-not-allowed opacity-50': !canContinue }]}
+        class="md:w-fit! lh-none! w-full!"
         onclick={() => (canContinue ? comparator.reveal() : remindToVote())}
       />
     </div>

--- a/frontend/src/routes/arene/components/ViewChat.svelte
+++ b/frontend/src/routes/arene/components/ViewChat.svelte
@@ -4,12 +4,15 @@
   import { getComparison, modeInfos } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
   import { GroupedMessages, RevealArea, VoteModal } from '.'
+  import { onDestroy } from 'svelte'
 
   let { comparisonId }: { comparisonId: string } = $props()
 
   const comparator = $derived(getComparison(comparisonId))
 
   let prompt = $state('')
+  let voteReminder = $state(false)
+  let voteReminderTimeout: ReturnType<typeof setTimeout> | undefined
 
   const mode = $derived(modeInfos.find((mode) => mode.value === comparator.comparison.mode)!)
 
@@ -25,6 +28,28 @@
       prompt = ''
     }
   }
+
+  function remindToVote() {
+    const turn = comparator.comparison.turns.findLast((currentTurn) => !currentTurn.choice)
+    if (!turn) return
+
+    voteReminder = true
+    clearTimeout(voteReminderTimeout)
+    voteReminderTimeout = setTimeout(() => (voteReminder = false), 5000)
+
+    requestAnimationFrame(() => {
+      const voteArea = document.getElementById(`vote-select-${turn.id}`)
+      if (!voteArea) return
+
+      voteArea.classList.remove('cl-vote-nudge')
+      void voteArea.offsetWidth
+      voteArea.classList.add('cl-vote-nudge')
+      voteArea.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      voteArea.querySelector<HTMLButtonElement>('button')?.focus({ preventScroll: true })
+    })
+  }
+
+  onDestroy(() => clearTimeout(voteReminderTimeout))
 
   // Compute second header height for autoscrolling
   let footer = $state<HTMLElement>()
@@ -91,17 +116,24 @@
         rows={3}
         maxRows={4}
         onSubmit={onPromptSubmit}
+        onSubmitBlocked={remindToVote}
         onFocus={() => window.scrollTo(0, document.body.scrollHeight)}
         class="mb-0! w-full"
       />
 
+      {#if voteReminder}
+        <p role="status" class="fr-message fr-message--info mb-0! text-center">
+          {m['vote.continueReminder']()}
+        </p>
+      {/if}
+
       <Button
         text={m['chatbot.revealButton']()}
-        disabled={!canContinue}
+        aria-disabled={!canContinue}
         size="sm"
         icon="arrow-up-circle-line"
-        class="md:w-fit! lh-none! w-full!"
-        onclick={() => comparator.reveal()}
+        class={['md:w-fit! lh-none! w-full!', { 'cursor-not-allowed opacity-50': !canContinue }]}
+        onclick={() => (canContinue ? comparator.reveal() : remindToVote())}
       />
     </div>
   {/if}

--- a/frontend/src/routes/arene/components/VoteSelect.svelte
+++ b/frontend/src/routes/arene/components/VoteSelect.svelte
@@ -115,6 +115,32 @@
     color: white !important;
   }
 
+  :global(.cl-vote-nudge) {
+    animation: vote-nudge 700ms ease-in-out;
+  }
+
+  @keyframes vote-nudge {
+    0%,
+    100% {
+      transform: scale(1);
+      box-shadow: 0 2px 6px rgb(0 0 0 / 16%);
+    }
+    35%,
+    65% {
+      transform: scale(1.025);
+      box-shadow:
+        0 0 0 4px var(--blue-france-850-200),
+        0 4px 12px rgb(0 0 0 / 20%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.cl-vote-nudge) {
+      animation: none;
+      box-shadow: 0 0 0 4px var(--blue-france-850-200);
+    }
+  }
+
   @media (max-width: 47.99em) {
     .cl-vote-select button[data-choice='a_better'] {
       order: 1;

--- a/frontend/src/routes/arene/ranking/+page.svelte
+++ b/frontend/src/routes/arene/ranking/+page.svelte
@@ -134,6 +134,19 @@
 >
   {#if lastUpdateDate}
     <div class="relative">
+      <div class="mb-4 gap-2 md:absolute md:top-0 md:right-0 md:mb-0 z-10 flex items-center">
+        <Toggle
+          id="style-control"
+          bind:value={styleEnabled}
+          label={m['ranking.styleControl.label']()}
+          hideCheckLabel
+          class="mb-0! pr-13! font-medium text-[14px]! whitespace-nowrap"
+        />
+        <Tooltip id="style-control-help" size="sm">
+          {@html sanitize(m['ranking.styleControl.help']())}
+        </Tooltip>
+      </div>
+
       <Tabs {tabs} noBorders kind="nav">
         {#snippet tab({ id })}
           {#if id === 'ranking'}
@@ -155,21 +168,6 @@
           {/if}
         {/snippet}
       </Tabs>
-
-      <!-- Placed after the tabs in the DOM so it paints above the tab list and
-           stays clickable; absolutely positioned over the tab row on md+. -->
-      <div class="mb-4 gap-2 md:absolute md:top-0 md:right-0 md:mb-0 z-10 flex items-center">
-        <Toggle
-          id="style-control"
-          bind:value={styleEnabled}
-          label={m['ranking.styleControl.label']()}
-          hideCheckLabel
-          class="mb-0! pr-13! font-medium text-[14px]! whitespace-nowrap"
-        />
-        <Tooltip id="style-control-help" size="sm">
-          {@html sanitize(m['ranking.styleControl.help']())}
-        </Tooltip>
-      </div>
     </div>
   {:else}
     <section

--- a/frontend/src/routes/arene/ranking/+page.svelte
+++ b/frontend/src/routes/arene/ranking/+page.svelte
@@ -134,7 +134,7 @@
 >
   {#if lastUpdateDate}
     <div class="relative">
-      <div class="mb-4 gap-2 md:absolute md:top-0 md:right-0 md:mb-0 z-10 flex items-center">
+      <div class="mb-4 gap-2 md:absolute md:top-4 md:right-0 md:mb-0 z-10 flex items-center">
         <Toggle
           id="style-control"
           bind:value={styleEnabled}

--- a/frontend/src/routes/arene/ranking/+page.svelte
+++ b/frontend/src/routes/arene/ranking/+page.svelte
@@ -4,7 +4,7 @@
   import { m } from '$lib/i18n/messages'
   import { applyStyleControl, getModelsWithDataContext } from '$lib/models'
   import { styleControl } from '$lib/styleControl.svelte'
-  import { externalLinkProps, sanitize } from '$lib/utils/commons'
+  import { sanitize } from '$lib/utils/commons'
   import { downloadTextFile, sortIfDefined } from '$lib/utils/data'
   import { Energy, Methodology, RankingTable } from './components'
 
@@ -151,11 +151,7 @@
         {#snippet tab({ id })}
           {#if id === 'ranking'}
             <p class="mb-12! text-dark-grey text-[14px]!">
-              {@html sanitize(
-                m['ranking.ranking.desc']({
-                  linkProps: externalLinkProps('https://www.peren.gouv.fr/')
-                })
-              )}
+              {@html sanitize(m['ranking.ranking.desc']())}
             </p>
 
             <RankingTable id="ranking-table" onDownloadData={() => onDownloadData('ranking')} />

--- a/frontend/src/routes/arene/ranking/+page.svelte
+++ b/frontend/src/routes/arene/ranking/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Tabs, Toggle, Tooltip } from '$components/dsfr'
+  import { Icon, Tabs, Toggle, Tooltip } from '$components/dsfr'
   import PageLayout from '$components/PageLayout.svelte'
   import { m } from '$lib/i18n/messages'
   import { applyStyleControl, getModelsWithDataContext } from '$lib/models'
@@ -172,6 +172,18 @@
       </div>
     </div>
   {:else}
-    <p>{m['ranking.no_data']()}</p>
+    <section
+      aria-labelledby="ranking-empty-title"
+      class="cg-border bg-very-light-grey mt-8 max-w-2xl rounded-xl px-6 py-12 mx-auto text-center"
+    >
+      <span
+        aria-hidden="true"
+        class="bg-light-info mb-5 size-16 mx-auto flex items-center justify-center rounded-full"
+      >
+        <Icon icon="trophy-line" size="lg" class="text-primary" />
+      </span>
+      <h2 id="ranking-empty-title" class="fr-h4 mb-3!">{m['seo.titles.ranking']()}</h2>
+      <p class="mb-0! text-grey">{m['ranking.no_data']()}</p>
+    </section>
   {/if}
 </PageLayout>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     }
   },
   test: {
-    workspace: [
+    projects: [
       {
         extends: './vite.config.ts',
         plugins: [svelteTesting()],


### PR DESCRIPTION
## Pourquoi

Plusieurs petits défauts d’interface rendaient certains états peu lisibles : badges et adresse du compte qui débordaient, état vide du classement trop brut, et absence de retour clair lorsqu’une personne tentait de continuer sans avoir voté.

## Changements

- empêche les débordements des badges de licence et de l’adresse du compte dans la navigation ;
- rétablit un espacement normal autour du bouton de connexion ;
- présente l’indisponibilité du classement sous la forme d’un état vide plus soigné ;
- indique clairement qu’un vote ou un passage est requis avant de poursuivre ;
- attire brièvement l’attention sur les choix de vote et y déplace le focus ;
- respecte la préférence de réduction des animations ;
- ajoute les traductions associées et un test du blocage de l’envoi ;
- adapte la configuration des projets de test à Vitest 4.

## Impact

Les personnes comprennent immédiatement pourquoi l’envoi ou la révélation des modèles ne peut pas encore continuer, tandis que les vues compactes restent lisibles quelle que soit la longueur du contenu.

## Vérifications

- `pnpm exec vitest run --project client src/lib/components/TextPrompt.svelte.test.ts`
- ESLint ciblé sur les fichiers modifiés
- `pnpm run build`
- vérification visuelle locale des cartes de modèles, de la navigation et de l’état vide du classement
