### PR TITLE
rename admin customization route, type user role as literal

### DIFF
--- a/backend/admin/router.py
+++ b/backend/admin/router.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, EmailStr
@@ -22,7 +21,7 @@ from utils.database.models.app_settings import (
     AppSettingsPatch,
     AppSettingsPublic,
 )
-from utils.database.models.auth import UserPublic
+from utils.database.models.auth import UserPublic, UserRole
 from utils.database.settings import get_app_settings, update_app_settings
 
 router = APIRouter(
@@ -40,7 +39,7 @@ class UsersPage(BaseModel):
 
 
 class SetRoleBody(BaseModel):
-    role: Literal["user", "admin"]
+    role: UserRole
 
 
 class InviteBody(BaseModel):

--- a/backend/admin/services.py
+++ b/backend/admin/services.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from sqlmodel import col, func, select
 
-from utils.database.models.auth import InviteToken, LoginCode, User, UserPublic
+from utils.database.models.auth import InviteToken, LoginCode, User, UserPublic, UserRole
 from utils.database.session import get_session
 
 
@@ -95,7 +95,7 @@ async def cancel_user_invite(user_id: uuid.UUID) -> bool:
         return True
 
 
-async def set_user_role(user_id: uuid.UUID, role: str) -> User | None:
+async def set_user_role(user_id: uuid.UUID, role: UserRole) -> User | None:
     async with get_session() as session:
         user = await session.get(User, user_id)
         if not user or user.deleted_at is not None:

--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -4,11 +4,10 @@ from fastapi import Depends, HTTPException, Request, status
 
 from backend.auth.services import _hash, get_user_from_token
 from backend.config import ANONYMOUS_SESSION_COOKIE
-from utils.database.models.auth import User
+from utils.database.models.auth import User, UserRole
 
 
-# FIXME role should be a literal, update db model
-async def optional_user(request: Request, role: str | None = None) -> User | None:
+async def optional_user(request: Request, role: UserRole | None = None) -> User | None:
     token = request.cookies.get("auth_session")
     if not token:
         return None
@@ -20,8 +19,7 @@ async def optional_user(request: Request, role: str | None = None) -> User | Non
     return user
 
 
-# FIXME role should be a literal, update db model
-async def require_user(request: Request, role: str | None = None) -> User:
+async def require_user(request: Request, role: UserRole | None = None) -> User:
     token = request.cookies.get("auth_session")
     if not token:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -29,7 +29,7 @@
         "nav": {
             "users": "Brugere",
             "llms": "LLMs",
-            "personnalisation": "Tilpasning",
+            "customization": "Tilpasning",
             "authentification": "Autentificering"
         },
         "panelLink": "Administration",
@@ -39,7 +39,7 @@
             "save": "Gem",
             "saving": "Gemmer...",
             "saved": "Indstillinger opdateret",
-            "personnalisation": {
+            "customization": {
                 "platformName": "Platformens navn",
                 "votesObjective": "Stemmemål",
                 "logo": {

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -28,7 +28,7 @@
         "nav": {
             "users": "Users",
             "llms": "LLMs",
-            "personnalisation": "Customization",
+            "customization": "Customization",
             "authentification": "Authentication"
         },
         "panelLink": "Admin panel",
@@ -38,7 +38,7 @@
             "save": "Save",
             "saving": "Saving...",
             "saved": "Settings updated",
-            "personnalisation": {
+            "customization": {
                 "platformName": "Platform name",
                 "votesObjective": "Votes objective",
                 "logo": {

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -35,7 +35,7 @@
         "nav": {
             "users": "Utilisateurs",
             "llms": "LLMs",
-            "personnalisation": "Personnalisation",
+            "customization": "Personnalisation",
             "authentification": "Authentification"
         },
         "panelLink": "Administration",
@@ -45,7 +45,7 @@
             "save": "Enregistrer",
             "saving": "Enregistrement...",
             "saved": "Paramètres mis à jour",
-            "personnalisation": {
+            "customization": {
                 "platformName": "Nom de la plateforme",
                 "votesObjective": "Objectif de votes",
                 "logo": {

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -20,8 +20,8 @@
 
   const navLinks: NavLink[] = $derived([
     {
-      label: m['admin.nav.personnalisation'](),
-      href: '/admin/personnalisation',
+      label: m['admin.nav.customization'](),
+      href: '/admin/customization',
       icon: 'i-ri-palette-line'
     },
     {

--- a/frontend/src/routes/(admin)/admin/+page.server.ts
+++ b/frontend/src/routes/(admin)/admin/+page.server.ts
@@ -1,5 +1,5 @@
 import { redirect } from '@sveltejs/kit'
 
 export function load() {
-  redirect(302, '/admin/personnalisation')
+  redirect(302, '/admin/customization')
 }

--- a/frontend/src/routes/(admin)/admin/customization/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/customization/+page.svelte
@@ -63,7 +63,7 @@
       await api.request('/admin/settings/logo', { method: 'PUT', body: formData, headers: {} })
       hasCustomLogo = true
       logoVersion++
-      useToast(m['admin.settings.personnalisation.logo.updated'](), 4000)
+      useToast(m['admin.settings.customization.logo.updated'](), 4000)
     } catch (err) {
       useToast((err as Error).message, 6000, 'error')
     } finally {
@@ -77,7 +77,7 @@
     try {
       await api.request('/admin/settings/logo', { method: 'DELETE', headers: {} })
       hasCustomLogo = false
-      useToast(m['admin.settings.personnalisation.logo.resetDone'](), 4000)
+      useToast(m['admin.settings.customization.logo.resetDone'](), 4000)
     } catch (err) {
       useToast((err as Error).message, 6000, 'error')
     } finally {
@@ -87,8 +87,8 @@
 </script>
 
 <PageLayout
-  seoTitle={m['admin.nav.personnalisation']()}
-  title={m['admin.nav.personnalisation']()}
+  seoTitle={m['admin.nav.customization']()}
+  title={m['admin.nav.customization']()}
   subtitle={m['admin.settings.subtitle']()}
 >
   {#if loading}
@@ -97,13 +97,13 @@
     <form onsubmit={save} class="max-w-[480px]">
       <Input
         id="settings-platform-name"
-        label={m['admin.settings.personnalisation.platformName']()}
+        label={m['admin.settings.customization.platformName']()}
         bind:value={platformName}
         groupClass="mt-4!"
       />
 
       <div class="mt-4!">
-        <p class="fr-label mb-2!">{m['admin.settings.personnalisation.logo.label']()}</p>
+        <p class="fr-label mb-2!">{m['admin.settings.customization.logo.label']()}</p>
         <div class="gap-4 flex items-center">
           <img
             src={logoSrc}
@@ -113,7 +113,7 @@
           <div class="gap-2 flex flex-col">
             <label class="fr-label">
               <span class="fr-sr-only"
-                >{m['admin.settings.personnalisation.logo.chooseFile']()}</span
+                >{m['admin.settings.customization.logo.chooseFile']()}</span
               >
               <input
                 type="file"
@@ -127,21 +127,21 @@
                 type="button"
                 variant="secondary"
                 size="sm"
-                text={m['admin.settings.personnalisation.logo.reset']()}
+                text={m['admin.settings.customization.logo.reset']()}
                 disabled={uploadingLogo}
                 onclick={resetLogo}
               />
             {/if}
           </div>
         </div>
-        <p class="fr-hint-text mt-1!">{m['admin.settings.personnalisation.logo.hint']()}</p>
+        <p class="fr-hint-text mt-1!">{m['admin.settings.customization.logo.hint']()}</p>
       </div>
 
       <Input
         id="settings-votes-objective"
         type="number"
         min="0"
-        label={m['admin.settings.personnalisation.votesObjective']()}
+        label={m['admin.settings.customization.votesObjective']()}
         bind:value={votesObjective}
         groupClass="mt-4!"
       />

--- a/utils/database/models/auth.py
+++ b/utils/database/models/auth.py
@@ -1,11 +1,13 @@
 import uuid
-from typing import Annotated
+from typing import Annotated, Literal
 
-from sqlmodel import Field, Relationship, SQLModel
+from sqlmodel import Field, Relationship, SQLModel, String
 
 from .utils import AutoDatetime, Datetime, ModelId, OptionalDatetime
 
 UserId = Annotated[uuid.UUID, Field(foreign_key="auth_user.id")]
+
+UserRole = Literal["user", "admin"]
 
 
 class User(SQLModel, table=True):
@@ -13,7 +15,7 @@ class User(SQLModel, table=True):
 
     id: ModelId
     email: str = Field(unique=True)
-    role: str = Field(default="user")
+    role: Annotated[UserRole, Field(sa_type=String)] = "user"
     created_at: AutoDatetime
     last_seen_at: AutoDatetime
     deleted_at: OptionalDatetime = None
@@ -26,7 +28,7 @@ class User(SQLModel, table=True):
 class UserPublic(SQLModel):
     id: uuid.UUID
     email: str
-    role: str
+    role: UserRole
     created_at: str
     last_seen_at: str
     source: str


### PR DESCRIPTION
## Summary
- rename the admin personnalisation route and its i18n keys to customization
- type the user role field as a Literal instead of str, both in the DB model and across admin endpoints

## Test plan
- [ ] backend imports and json schema generation checked manually
- [ ] frontend type-checked