### PR TITLE
lower default sentry sample rate

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     GIT_COMMIT: str | None = None
     SENTRY_DSN: str | None = None
     SENTRY_ENVIRONMENT: str = "dev"
-    SENTRY_SAMPLE_RATE: float = 1.0
+    SENTRY_SAMPLE_RATE: float = 0.1
     LINKUP_API_KEY: str | None = None
     OPENROUTER_API_KEY: str | None = None
     ALBERT_KEY: str | None = None


### PR DESCRIPTION
## Summary
- lower the default SENTRY_SAMPLE_RATE from 1.0 to 0.1, matching the value recommended in the issue

Fixes #585

## Test plan
- [ ] confirm trace volume drops in the shared Sentry instance after deploy