### PR TITLE
Fix: data fetching, error handling and auth handling

### DIFF
--- a/backend/auth/dependencies.py
+++ b/backend/auth/dependencies.py
@@ -4,6 +4,7 @@ from fastapi import Depends, HTTPException, Request, status
 
 from backend.auth.services import _hash, get_user_from_token
 from backend.config import ANONYMOUS_SESSION_COOKIE
+from backend.errors import AnonymousRequiredError, AuthRequiredError, RoleRequiredError
 from utils.database.models.auth import User, UserRole
 
 
@@ -22,12 +23,12 @@ async def optional_user(request: Request, role: UserRole | None = None) -> User 
 async def require_user(request: Request, role: UserRole | None = None) -> User:
     token = request.cookies.get("auth_session")
     if not token:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        raise AuthRequiredError()
     user = await get_user_from_token(token)
     if not user:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        raise AuthRequiredError()
     if role and user.role != role:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+        raise RoleRequiredError(role)
     return user
 
 
@@ -38,7 +39,7 @@ async def require_admin(request: Request) -> User:
 async def require_anonymous(request: Request) -> str:
     token = request.cookies.get(ANONYMOUS_SESSION_COOKIE)
     if not token:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+        raise AnonymousRequiredError()
     else:
         return _hash(token)
 

--- a/backend/auth/middleware.py
+++ b/backend/auth/middleware.py
@@ -2,17 +2,13 @@ import logging
 import secrets
 
 from fastapi import Request
-from fastapi.responses import JSONResponse
 
 from backend.auth.services import get_user_from_token
 from backend.config import ANONYMOUS_SESSION_COOKIE, settings
+from backend.errors import AUTH_REQUIRED_RESPONSE
 from utils.database.settings import get_app_settings
 
 logger = logging.getLogger("languia")
-
-_AUTH_REQUIRED_RESPONSE = JSONResponse(
-    {"detail": "Authentication required"}, status_code=401
-)
 
 
 async def auth_middleware(request: Request, call_next):
@@ -26,10 +22,10 @@ async def auth_middleware(request: Request, call_next):
     ):
         token = request.cookies.get("auth_session")
         if not token:
-            return _AUTH_REQUIRED_RESPONSE
+            return AUTH_REQUIRED_RESPONSE
         user = await get_user_from_token(token)
         if not user:
-            return _AUTH_REQUIRED_RESPONSE
+            return AUTH_REQUIRED_RESPONSE
 
     return await call_next(request)
 

--- a/backend/auth/middleware.py
+++ b/backend/auth/middleware.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 
 from backend.auth.services import get_user_from_token
 from backend.config import ANONYMOUS_SESSION_COOKIE, settings
+from utils.database.settings import get_app_settings
 
 logger = logging.getLogger("languia")
 
@@ -15,8 +16,10 @@ _AUTH_REQUIRED_RESPONSE = JSONResponse(
 
 
 async def auth_middleware(request: Request, call_next):
+    app_settings = await get_app_settings()
+
     if (
-        settings.AUTH_ACCESS_POLICY == "sign_in_required"
+        app_settings.auth_access_policy == "sign_in_required"
         and request.url.path.startswith("/arena")
         and request.url.path != "/arena/challenge"
         and settings.COMPARIA_DB_URI

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -1,3 +1,6 @@
+from fastapi import HTTPException, status
+from fastapi.responses import JSONResponse
+
 from utils.database.models import BotPos
 
 # from enum import StrEnum
@@ -40,3 +43,30 @@ class ChatError(RuntimeError):
 
     def __str__(self):
         return self.message
+
+
+class AnonymousRequiredError(HTTPException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="anonymous_required"
+        )
+
+
+class AuthRequiredError(HTTPException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="auth_required"
+        )
+
+
+# Used in middleware, can't raise HTTPException
+AUTH_REQUIRED_RESPONSE = JSONResponse(
+    {"detail": "auth_required"}, status_code=status.HTTP_401_UNAUTHORIZED
+)
+
+
+class RoleRequiredError(HTTPException):
+    def __init__(self, role: str = "admin") -> None:
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN, detail=f"{role}_required"
+        )

--- a/frontend/src/hooks.client.ts
+++ b/frontend/src/hooks.client.ts
@@ -1,4 +1,5 @@
 import { goto } from '$app/navigation'
+import { resolve } from '$app/paths'
 import { UnauthorizedError } from '$lib/fastapi-client'
 import type { HandleClientError } from '@sveltejs/kit'
 
@@ -7,7 +8,7 @@ import type { HandleClientError } from '@sveltejs/kit'
 // so we don't fall through to the generic error page.
 export const handleError: HandleClientError = ({ error }) => {
   if (error instanceof UnauthorizedError) {
-    goto('/login?redirect=' + encodeURIComponent(location.pathname))
+    goto(resolve(`/login?redirect=${encodeURIComponent(location.pathname)}`))
     return
   }
   console.error(error)

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,11 +1,12 @@
 import { env } from '$env/dynamic/private'
-import { api } from '$lib/fastapi-client'
+import { api, UnauthorizedError } from '$lib/fastapi-client'
 import { HOST_TO_LOCALE } from '$lib/global.svelte'
 import { defineCustomServerStrategy } from '$lib/i18n/runtime'
 import { paraglideMiddleware } from '$lib/i18n/server'
 import { logger } from '$lib/logger.server'
 import { httpRequestCounter, httpRequestDuration } from '$lib/metrics'
-import { redirect, type Handle } from '@sveltejs/kit'
+import type { Handle, HandleServerError } from '@sveltejs/kit'
+import { redirect } from '@sveltejs/kit'
 import { sequence } from '@sveltejs/kit/hooks'
 
 const MATOMO_ID = env.MATOMO_ID || ''
@@ -39,6 +40,13 @@ defineCustomServerStrategy('custom-url', {
     }
   }
 })
+
+export const handleError: HandleServerError = async ({ error, event }) => {
+  if (error instanceof UnauthorizedError) {
+    const path = event.url.pathname
+    redirect(302, `/login?redirect=${encodeURIComponent(path)}`)
+  }
+}
 
 // creating a handle to use the paraglide middleware
 const paraglideHandle: Handle = ({ event, resolve }) => {

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -6,6 +6,7 @@ import { paraglideMiddleware } from '$lib/i18n/server'
 import { logger } from '$lib/logger.server'
 import { httpRequestCounter, httpRequestDuration } from '$lib/metrics'
 import { redirect, type Handle } from '@sveltejs/kit'
+import { sequence } from '@sveltejs/kit/hooks'
 
 const MATOMO_ID = env.MATOMO_ID || ''
 const MATOMO_URL = env.MATOMO_URL || ''
@@ -141,15 +142,4 @@ const authWallHandle: Handle = ({ event, resolve }) => {
   return resolve(event)
 }
 
-// Compose handles: maintenance first, then auth wall, then metrics, then paraglide
-export const handle: Handle = async ({ event, resolve }) => {
-  return maintenanceHandle({
-    event,
-    resolve: (e) =>
-      authWallHandle({
-        event: e,
-        resolve: (e2) =>
-          metricsHandle({ event: e2, resolve: (e3) => paraglideHandle({ event: e3, resolve }) })
-      })
-  })
-}
+export const handle = sequence(maintenanceHandle, authWallHandle, metricsHandle, paraglideHandle)

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -87,7 +87,9 @@ const maintenanceHandle: Handle = async ({ event, resolve }) => {
   if (!maintenanceCache || now - maintenanceCache.checkedAt >= MAINTENANCE_CHECK_TTL_MS) {
     let enabled = maintenanceCache?.enabled ?? false
     try {
-      ;({ enabled } = await api.request<{ enabled: boolean }>('/maintenance/status'))
+      ;({ enabled } = await api.request<{ enabled: boolean }>('/maintenance/status', {
+        fetch: event.fetch
+      }))
     } catch (error) {
       // Fail open: don't take the whole site down if the status check itself fails
       logger.error('Maintenance status check failed', { error: `${error}` })

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -46,6 +46,7 @@ export const handleError: HandleServerError = async ({ error, event }) => {
     const path = event.url.pathname
     redirect(302, `/login?redirect=${encodeURIComponent(path)}`)
   }
+  console.error(error)
 }
 
 // creating a handle to use the paraglide middleware

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -1,6 +1,7 @@
-import { browser } from '$app/environment'
 import { goto } from '$app/navigation'
+import { resolve } from '$app/paths'
 import { api } from '$lib/fastapi-client'
+import { createContext } from 'svelte'
 
 export interface AuthUser {
   email: string
@@ -16,30 +17,15 @@ export interface AuthConfig {
   has_custom_logo: boolean
 }
 
-export const auth = $state<{ user: AuthUser | null; config: AuthConfig | null }>({
-  user: null,
-  config: null
-})
-
-export function isAdmin(): boolean {
-  return auth.user?.role === 'admin'
+type AuthCtx = {
+  user: AuthUser | null
+  config: AuthConfig
 }
+export const [getAuthContext, baseSetAuthContext] = createContext<AuthCtx>()
 
-export async function initAuth(): Promise<void> {
-  if (!browser) return
-
-  try {
-    auth.config = await api.request<AuthConfig>('/auth/config')
-  } catch {
-    // silently ignore
-  }
-
-  try {
-    const data = await api.request<{ user: AuthUser | null }>('/auth/me')
-    auth.user = data.user
-  } catch {
-    auth.user = null
-  }
+export function setAuthContext(data: AuthCtx) {
+  const auth = $state(data)
+  baseSetAuthContext(auth)
 }
 
 export function openSignInModal(): void {
@@ -50,13 +36,15 @@ export function openSignInModal(): void {
   }
 }
 
-export async function logout(): Promise<void> {
+export async function logout(auth: AuthCtx): Promise<void> {
   try {
     await api.request<void>('/auth/logout', { method: 'POST' })
   } finally {
     auth.user = null
     if (auth.config?.access_policy === 'sign_in_required') {
-      goto('/login')
+      goto(resolve('/login'))
+    } else {
+      goto(resolve('/arene'))
     }
   }
 }

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -28,6 +28,11 @@ export function setAuthContext(data: AuthCtx) {
   baseSetAuthContext(auth)
 }
 
+export function userAllowed(auth: AuthCtx, role?: AuthUser['role']) {
+  if (!role) return true
+  return auth.user?.role === role
+}
+
 export function openSignInModal(): void {
   const el = document.getElementById('fr-modal-signin')
   if (el) {

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -1,3 +1,5 @@
+import { goto } from '$app/navigation'
+import { resolve } from '$app/paths'
 import { CaptchaError, consumeAltchaToken } from '$lib/captcha.svelte'
 import { api, ValidationError } from '$lib/fastapi-client'
 import type {
@@ -245,11 +247,13 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
 
           if (event.type === 'add') {
             comparison.turns.push(parseAPITurn(event.turn))
+            goto(resolve(`/arene/${comparisonId_ as string}`))
           } else {
             if (!turn) throw new InternalError('No turn to update')
 
             if (event.type === 'update') {
               comparison.turns[comparison.turns.length - 1] = parseAPITurn(event.turn)
+              goto(resolve(`/arene/${comparisonId_ as string}`))
             } else if (event.type === 'error') {
               if (event.pos) {
                 turn[event.pos].status = 'error'

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -189,8 +189,8 @@ export function parseAPIRevealData(data: APIRevealData): RevealData {
   }
 }
 
-export async function queryComparisons() {
-  const data = await api.request<APIComparison[]>('/arena/comparison/list')
+export async function queryComparisons(_fetch: typeof fetch = fetch) {
+  const data = await api.request<APIComparison[]>('/arena/comparison/list', { fetch: _fetch })
   return data.map((c) => parseAPIComparison(c))
 }
 

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -277,7 +277,7 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
       }
     } catch (err) {
       if (err instanceof ValidationError) {
-        promptError = typeof err.errors === 'string' ? err.errors : err.errors[0].msg
+        promptError = err.errors ? err.errors[0].msg : err.message
       } else if (err instanceof CaptchaError) {
         promptError = 'Vérification anti-robot indisponible, veuillez réessayer.'
       } else {

--- a/frontend/src/lib/components/SignInForm.svelte
+++ b/frontend/src/lib/components/SignInForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Button, Checkbox, Input } from '$components/dsfr'
-  import { initAuth } from '$lib/auth.svelte'
+  import { getAuthContext, type AuthUser } from '$lib/auth.svelte'
   import { consumeAltchaToken } from '$lib/captcha.svelte'
   import { api } from '$lib/fastapi-client'
   import { useToast } from '$lib/helpers/useToast.svelte'
@@ -14,6 +14,7 @@
     onSuccess?: () => void
   } & SvelteHTMLElements['div'] = $props()
 
+  const auth = getAuthContext()
   let step = $state<'email' | 'code'>('email')
   let email = $state('')
   let code = $state('')
@@ -33,7 +34,6 @@
       })
       step = 'code'
     } catch (err) {
-      console.log('eeeerr', err)
       error = (err as Error).message
     } finally {
       loading = false
@@ -48,7 +48,8 @@
         method: 'POST',
         body: JSON.stringify({ email, code })
       })
-      await initAuth()
+      const data = await api.request<{ user: AuthUser | null }>('/auth/me')
+      auth.user = data.user
       onSuccess?.()
       useToast(m['auth.success'](), 4000)
     } catch {

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -20,7 +20,6 @@
   const { navLinks, isAdmin = false }: { navLinks: NavLink[]; isAdmin?: boolean } = $props()
 
   const auth = getAuthContext()
-  const isAdminUser = $derived(auth.user?.role === 'admin')
   let expanded = $state(true)
 </script>
 
@@ -131,19 +130,6 @@
 
       <LanguageSelector id="translate-{mode}" class={{ 'lg:hidden': !expanded }} />
     </div>
-
-    {#if isAdminUser}
-      {@render renderLink({
-        href: '/admin',
-        label: m['admin.panelLink'](),
-        icon: 'i-ri-admin-line',
-        isCurrent: () => page.url.pathname.startsWith('/admin'),
-        button: true,
-        size: 'sm',
-        variant: 'tertiary-no-outline',
-        class: 'text-sm! text-black! -ms-3'
-      })}
-    {/if}
 
     {#if auth.user}
       <div

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -125,7 +125,7 @@
         button: true,
         size: 'sm',
         variant: 'tertiary-no-outline',
-        class: 'text-sm! text-black! -ms-3'
+        class: 'text-sm! text-grey! -ms-3 pointer-events-none'
       })}
 
       <LanguageSelector id="translate-{mode}" class={{ 'lg:hidden': !expanded }} />

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -11,7 +11,7 @@
   import { page } from '$app/state'
   import { Button, Icon, Link } from '$components/dsfr'
   import type { LinkProps } from '$components/dsfr/Link.svelte'
-  import { auth, isAdmin as isAdminUser, logout } from '$lib/auth.svelte'
+  import { getAuthContext, logout } from '$lib/auth.svelte'
   import { api } from '$lib/fastapi-client'
   import { m } from '$lib/i18n/messages'
   import type { HTMLAnchorAttributes } from 'svelte/elements'
@@ -19,6 +19,8 @@
 
   const { navLinks, isAdmin = false }: { navLinks: NavLink[]; isAdmin?: boolean } = $props()
 
+  const auth = getAuthContext()
+  const isAdminUser = $derived(auth.user?.role === 'admin')
   let expanded = $state(true)
 </script>
 
@@ -130,7 +132,7 @@
       <LanguageSelector id="translate-{mode}" class={{ 'lg:hidden': !expanded }} />
     </div>
 
-    {#if isAdminUser()}
+    {#if isAdminUser}
       {@render renderLink({
         href: '/admin',
         label: m['admin.panelLink'](),
@@ -151,7 +153,7 @@
           variant="tertiary-no-outline"
           size="sm"
           class="text-black! -ms-3"
-          onclick={() => logout()}
+          onclick={() => logout(auth)}
         >
           <span class={['gap-2 flex items-center', { 'lg:w-full lg:justify-center': !expanded }]}>
             <Icon icon="i-ri-logout-box-r-line" block size={expanded ? 'sm' : 'md'} />

--- a/frontend/src/lib/fastapi-client.ts
+++ b/frontend/src/lib/fastapi-client.ts
@@ -73,11 +73,13 @@ export class InternalError extends Error {
 type PydanticValidationError = { loc: string[]; msg: string }
 
 export class ValidationError extends Error {
-  errors: PydanticValidationError[] | string
+  errors?: PydanticValidationError[]
 
   constructor(errors: PydanticValidationError[] | string) {
-    super('Error in form')
-    this.errors = errors
+    const simple = typeof errors === 'string'
+    const message = simple ? errors : 'Error in form'
+    super(message)
+    this.errors = simple ? undefined : errors
     this.name = 'ValidationError'
   }
 }

--- a/frontend/src/lib/fastapi-client.ts
+++ b/frontend/src/lib/fastapi-client.ts
@@ -139,11 +139,17 @@ export class FastAPIClient {
   /**
    * Make a single HTTP request (non-streaming)
    */
-  async request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  async request<T>(
+    path: string,
+    options: RequestInit & { fetch?: typeof fetch } = { fetch }
+  ): Promise<T> {
     const url = this.getUrl(path)
+    // Get svelte load function's fetch or use default
+    const _fetch = options.fetch ?? fetch
+    delete options.fetch
 
     try {
-      const response = await fetch(url, {
+      const response = await _fetch(url, {
         ...options,
         headers: options.headers ?? {
           'Content-Type': 'application/json'

--- a/frontend/src/lib/fastapi-client.ts
+++ b/frontend/src/lib/fastapi-client.ts
@@ -78,12 +78,13 @@ export class ValidationError extends Error {
   constructor(errors: PydanticValidationError[] | string) {
     super('Error in form')
     this.errors = errors
+    this.name = 'ValidationError'
   }
 }
 
 export class UnauthorizedError extends Error {
-  constructor() {
-    super('Unauthorized')
+  constructor(key: string) {
+    super(key)
     this.name = 'UnauthorizedError'
   }
 }
@@ -121,8 +122,9 @@ export class FastAPIClient {
     const content = await response.text()
     try {
       const detail = JSON.parse(content).detail
-
-      if (response.status === 422) {
+      if (response.status === 401 || response.status === 403) {
+        return new UnauthorizedError(detail)
+      } else if (response.status === 422) {
         return new ValidationError(detail)
       } else if (response.status === 429) {
         return new ValidationError(detail)
@@ -148,11 +150,6 @@ export class FastAPIClient {
         },
         credentials: 'include'
       })
-
-      if (response.status === 401) {
-        unauthorizedHandler?.()
-        throw new UnauthorizedError()
-      }
 
       if (!response.ok) {
         throw await this.parseErrorResponse(response, path, options.method)

--- a/frontend/src/lib/fastapi-client.ts
+++ b/frontend/src/lib/fastapi-client.ts
@@ -89,13 +89,6 @@ export class UnauthorizedError extends Error {
   }
 }
 
-type UnauthorizedHandler = () => void
-let unauthorizedHandler: UnauthorizedHandler | null = null
-
-export function setUnauthorizedHandler(handler: UnauthorizedHandler): void {
-  unauthorizedHandler = handler
-}
-
 /**
  * FastAPI client class
  */

--- a/frontend/src/lib/stores/form.svelte.ts
+++ b/frontend/src/lib/stores/form.svelte.ts
@@ -47,13 +47,13 @@ export function useForm<T extends Record<PropertyKey, any>, K extends keyof T>({
       onSuccess?.(updated)
     } catch (e) {
       if (e instanceof ValidationError) {
-        if (Array.isArray(e.errors)) {
+        if (e.errors) {
           e.errors.forEach((err) => {
             const [_body, ...rest] = err.loc
             errors[rest.join('-')] = err.msg
           })
         } else {
-          errors['unexpected'] = e.errors
+          errors['unexpected'] = e.message
         }
       }
     }

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -1,22 +1,9 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
   import { page } from '$app/state'
   import NavBar, { type NavLink } from '$components/header/NavBar.svelte'
-  import { initAuth, isAdmin } from '$lib/auth.svelte'
   import { m } from '$lib/i18n/messages'
-  import { onMount } from 'svelte'
 
   let { children } = $props()
-  let ready = $state(false)
-
-  onMount(async () => {
-    await initAuth()
-    if (!isAdmin()) {
-      goto('/')
-      return
-    }
-    ready = true
-  })
 
   const navLinks: NavLink[] = $derived([
     {
@@ -48,12 +35,10 @@
   ])
 </script>
 
-{#if ready}
-  <div class="lg:flex min-h-screen">
-    <NavBar {navLinks} isAdmin />
+<div class="lg:flex min-h-screen">
+  <NavBar {navLinks} isAdmin />
 
-    <main class="lg:max-h-screen lg:overflow-y-auto w-full">
-      {@render children()}
-    </main>
-  </div>
-{/if}
+  <main class="lg:max-h-screen lg:overflow-y-auto w-full">
+    {@render children()}
+  </main>
+</div>

--- a/frontend/src/routes/(admin)/+layout.ts
+++ b/frontend/src/routes/(admin)/+layout.ts
@@ -3,7 +3,7 @@ import { api } from '$lib/fastapi-client'
 import { redirect } from '@sveltejs/kit'
 import type { LayoutLoad } from './$types'
 
-export const load: LayoutLoad = async ({ url }) => {
+export const load: LayoutLoad = async ({ url, fetch }) => {
   // Requery auth in case of recent login, parent raw data may not be updated
   const auth = await api.request<{ user: AuthUser | null }>('/auth/me', { fetch })
 

--- a/frontend/src/routes/(admin)/+layout.ts
+++ b/frontend/src/routes/(admin)/+layout.ts
@@ -1,0 +1,13 @@
+import type { AuthUser } from '$lib/auth.svelte'
+import { api } from '$lib/fastapi-client'
+import { redirect } from '@sveltejs/kit'
+import type { LayoutLoad } from './$types'
+
+export const load: LayoutLoad = async ({ url }) => {
+  // Requery auth in case of recent login, parent raw data may not be updated
+  const auth = await api.request<{ user: AuthUser | null }>('/auth/me', { fetch })
+
+  if (!(auth.user?.role === 'admin')) {
+    redirect(302, `/login?redirect=${encodeURIComponent(url.pathname)}`)
+  }
+}

--- a/frontend/src/routes/(admin)/admin/llms/+layout.ts
+++ b/frontend/src/routes/(admin)/admin/llms/+layout.ts
@@ -3,21 +3,19 @@ import type { LLMData, LLMEndpoint, LLMLab, LLMLicense } from '$lib/generated/ad
 import type { JSONSchema } from '$lib/utils/form'
 import type { LayoutLoad } from './$types'
 
-export const ssr = false // auth error on server side
-
-export const load: LayoutLoad = async () => {
+export const load: LayoutLoad = async ({ fetch }) => {
   const data = await api.request<{
     endpoints: LLMEndpoint[]
     licenses: LLMLicense[]
     labs: LLMLab[]
     llms: LLMData[]
-  }>('/admin/llms/data')
+  }>('/admin/llms/data', { fetch })
   const schemas = await api.request<{
     endpoints: JSONSchema
     licenses: JSONSchema
     labs: JSONSchema
     llms: JSONSchema
-  }>('/admin/llms/schemas')
+  }>('/admin/llms/schemas', { fetch })
 
   const llmsSchemaProps = schemas.llms.properties!
 

--- a/frontend/src/routes/(admin)/admin/utilisateurs/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/utilisateurs/+page.svelte
@@ -1,19 +1,25 @@
 <script lang="ts">
-  import { Badge, Button, Icon, Table } from '$components/dsfr'
+  import { invalidate } from '$app/navigation'
   import ConfirmDeleteUserModal from '$components/ConfirmDeleteUserModal.svelte'
   import ConfirmPromoteAdminModal from '$components/ConfirmPromoteAdminModal.svelte'
+  import { Badge, Button, Icon, Table } from '$components/dsfr'
   import InviteUserModal from '$components/InviteUserModal.svelte'
   import PageLayout from '$components/PageLayout.svelte'
-  import { auth } from '$lib/auth.svelte'
+  import { getAuthContext } from '$lib/auth.svelte'
   import { api } from '$lib/fastapi-client'
-  import type { UserPublic } from '$lib/generated/admin'
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { getLocale } from '$lib/i18n/runtime'
   import type { OrderingMethod, TableCol } from '$lib/utils/data'
   import { sortRows, toRelativeTime, toSearchString } from '$lib/utils/data'
-  import { onMount } from 'svelte'
+  import type { PageProps } from './$types'
 
+  const { data }: PageProps = $props()
+  const refetch = () => invalidate('admin:users')
   const locale = getLocale()
+  const auth = getAuthContext()
+
+  const users = $derived(data.users.items)
+  const total = $derived(data.users.total)
 
   function sourceBadgeVariant(source: string) {
     switch (source) {
@@ -27,26 +33,6 @@
         return ''
     }
   }
-
-  let users = $state<UserPublic[]>([])
-  let total = $state(0)
-  let loading = $state(true)
-
-  async function fetchUsers() {
-    loading = true
-    try {
-      const params = new URLSearchParams({ page: '1', page_size: '50' })
-      const data = await api.request<{ items: UserPublic[]; total: number }>(
-        `/admin/users?${params}`
-      )
-      users = data.items
-      total = data.total
-    } finally {
-      loading = false
-    }
-  }
-
-  onMount(fetchUsers)
 
   let userToDelete = $state<{ id: string; email: string } | null>(null)
 
@@ -64,7 +50,7 @@
     try {
       await api.request(`/admin/users/${userToDelete.id}`, { method: 'DELETE' })
       useToast(`${userToDelete.email} deleted`, 4000)
-      await fetchUsers()
+      await refetch()
     } catch (err) {
       useToast((err as Error).message, 6000, 'error')
     }
@@ -89,7 +75,7 @@
         body: JSON.stringify({ role: 'admin' })
       })
       useToast(`${userToPromote.email} promoted to admin`, 4000)
-      await fetchUsers()
+      await refetch()
     } catch (err) {
       useToast((err as Error).message, 6000, 'error')
     }
@@ -99,7 +85,7 @@
     try {
       await api.request(`/admin/users/${row.id}/invite`, { method: 'DELETE' })
       useToast(`Invite for ${row.email} canceled, user removed`, 4000)
-      await fetchUsers()
+      await refetch()
     } catch (err) {
       useToast((err as Error).message, 6000, 'error')
     }
@@ -199,13 +185,11 @@
     {/snippet}
   </Table>
 
-  {#if !loading}
-    <p class="fr-text--sm mt-2! text-[--text-mention-grey]">
-      {total} user{total !== 1 ? 's' : ''}.
-    </p>
-  {/if}
+  <p class="fr-text--sm mt-2! text-[--text-mention-grey]">
+    {total} user{total !== 1 ? 's' : ''}.
+  </p>
 </PageLayout>
 
-<InviteUserModal onSuccess={fetchUsers} />
+<InviteUserModal onSuccess={refetch} />
 <ConfirmDeleteUserModal email={userToDelete?.email ?? null} onConfirm={confirmDelete} />
 <ConfirmPromoteAdminModal email={userToPromote?.email ?? null} onConfirm={confirmPromote} />

--- a/frontend/src/routes/(admin)/admin/utilisateurs/+page.ts
+++ b/frontend/src/routes/(admin)/admin/utilisateurs/+page.ts
@@ -1,0 +1,19 @@
+import { api } from '$lib/fastapi-client'
+import type { UserPublic } from '$lib/generated/admin'
+import type { PageLoad } from './$types'
+
+export const load: PageLoad = async ({ depends, url, fetch }) => {
+  const params = new URLSearchParams({
+    page: url.searchParams.get('page') ?? '1',
+    page_size: url.searchParams.get('page_size') ?? '50'
+  })
+  const data = await api.request<{ items: UserPublic[]; total: number }>(`/admin/users?${params}`, {
+    fetch
+  })
+
+  depends('admin:users')
+
+  return {
+    users: data
+  }
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -3,11 +3,10 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/state'
   import Toaster from '$components/Toaster.svelte'
-  import { auth, initAuth, openSignInModal } from '$lib/auth.svelte'
+  import { setAuthContext } from '$lib/auth.svelte'
   import { setI18nContext, setVotesContext } from '$lib/global.svelte'
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { setModelsContext } from '$lib/models'
-  import { setUnauthorizedHandler } from '$lib/fastapi-client'
   import { setCohortContext } from '$lib/stores/cohortStore.svelte'
   import { onMount } from 'svelte'
   import { SvelteURLSearchParams } from 'svelte/reactivity'
@@ -23,16 +22,6 @@
   let { children, data } = $props()
 
   onMount(() => {
-    void initAuth()
-
-    setUnauthorizedHandler(() => {
-      if (auth.config?.access_policy === 'sign_in_required') {
-        goto('/login?redirect=' + encodeURIComponent(location.pathname))
-      } else {
-        openSignInModal()
-      }
-    })
-
     // Remove locale param to avoid locale changes override problems
     const params = new SvelteURLSearchParams(page.url.searchParams)
     if (params.get('locale')) {
@@ -43,6 +32,7 @@
 
   setVotesContext(data.votes)
   setModelsContext(data.data)
+  setAuthContext(data.auth)
   setI18nContext()
   setCohortContext()
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { browser } from '$app/environment'
   import { goto } from '$app/navigation'
+  import { resolve } from '$app/paths'
   import { page } from '$app/state'
   import Toaster from '$components/Toaster.svelte'
   import { setAuthContext } from '$lib/auth.svelte'
+  import { UnauthorizedError } from '$lib/fastapi-client'
   import { setI18nContext, setVotesContext } from '$lib/global.svelte'
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { setModelsContext } from '$lib/models'
@@ -39,6 +41,9 @@
   function handleError(_event: PromiseRejectionEvent) {
     // FIXME display error page on some error? display custom text in toast?
     useToast('Unexpected error', 10000, 'error')
+    if (_event.reason instanceof UnauthorizedError) {
+      goto(resolve('/login'))
+    }
   }
 </script>
 

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -2,9 +2,9 @@ import { api } from '$lib/fastapi-client'
 import type { LLMList } from '$lib/generated/backend'
 import type { VotesData } from '$lib/global.svelte'
 
-export async function load() {
-  const votes = await api.request<VotesData>('/counter')
-  const data = await api.request<LLMList>('/models/')
+export async function load({ fetch }) {
+  const votes = await api.request<VotesData>('/counter', { fetch })
+  const data = await api.request<LLMList>('/models/', { fetch })
 
   return { data, votes }
 }

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,3 +1,4 @@
+import type { AuthConfig, AuthUser } from '$lib/auth.svelte'
 import { api } from '$lib/fastapi-client'
 import type { LLMList } from '$lib/generated/backend'
 import type { VotesData } from '$lib/global.svelte'
@@ -5,6 +6,8 @@ import type { VotesData } from '$lib/global.svelte'
 export async function load({ fetch }) {
   const votes = await api.request<VotesData>('/counter', { fetch })
   const data = await api.request<LLMList>('/models/', { fetch })
+  const authConfig = await api.request<AuthConfig>('/auth/config', { fetch })
+  const auth = await api.request<{ user: AuthUser | null }>('/auth/me', { fetch })
 
-  return { data, votes }
+  return { data, votes, auth: { user: auth.user, config: authConfig } }
 }

--- a/frontend/src/routes/arene/+layout.svelte
+++ b/frontend/src/routes/arene/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { NavBar } from '$components/header'
+  import { getAuthContext, userAllowed } from '$lib/auth.svelte.js'
   import { initComparisonsContext } from '$lib/chatService.svelte.js'
   import SignInModal from '$lib/components/SignInModal.svelte'
   import { m } from '$lib/i18n/messages'
@@ -7,13 +8,16 @@
   let { children, data } = $props()
 
   initComparisonsContext(data.comparisons)
+  const auth = getAuthContext()
 
-  const navLinks = [
-    { href: '/arene', label: m['header.chatbot.newDiscussion'](), icon: 'i-ri-chat-new-line' },
-    { href: '/arene/ranking', label: m['seo.titles.ranking'](), icon: 'i-ri-trophy-line' },
-    { href: '/arene/modeles', label: m['seo.titles.modeles'](), icon: 'i-ri-stack-line' }
-    // { href: '/dataviz', label: 'FIXME' },
-  ]
+  const navLinks = $derived(
+    [
+      { href: '/arene', label: m['header.chatbot.newDiscussion'](), icon: 'i-ri-chat-new-line' },
+      { href: '/arene/ranking', label: m['seo.titles.ranking'](), icon: 'i-ri-trophy-line' },
+      { href: '/arene/modeles', label: m['seo.titles.modeles'](), icon: 'i-ri-stack-line' },
+      { href: '/admin', role: 'admin', label: m['admin.panelLink'](), icon: 'i-ri-admin-line' }
+    ].filter((link) => userAllowed(auth, link.role))
+  )
 </script>
 
 <div class="lg:flex min-h-screen">

--- a/frontend/src/routes/arene/+layout.ts
+++ b/frontend/src/routes/arene/+layout.ts
@@ -1,12 +1,10 @@
 import { queryComparisons } from '$lib/chatService.svelte'
 import type { LayoutLoad } from './$types'
 
-export const ssr = false // auth error on server side
-
-export const load: LayoutLoad = async () => {
+export const load: LayoutLoad = async ({ fetch }) => {
   // Unauthorized errors are handled globally, see hooks.client.ts
 
   return {
-    comparisons: await queryComparisons()
+    comparisons: await queryComparisons(fetch)
   }
 }

--- a/frontend/src/routes/arene/[id]/+page.ts
+++ b/frontend/src/routes/arene/[id]/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -3,10 +3,9 @@
   import { page } from '$app/state'
   import SignInForm from '$components/SignInForm.svelte'
   import { env } from '$env/dynamic/public'
-  import { auth, initAuth } from '$lib/auth.svelte'
+  import { getAuthContext } from '$lib/auth.svelte'
   import { api } from '$lib/fastapi-client'
   import { m } from '$lib/i18n/messages'
-  import { onMount } from 'svelte'
 
   const redirectTo = $derived(page.url.searchParams.get('redirect') || '/arene')
 
@@ -15,10 +14,7 @@
     env.PUBLIC_AUTH_LOGIN_DESCRIPTION ||
     "Comparez les modèles d'IA conversationnelle en aveugle et contribuez à l'évaluation de l'IA en Europe."
 
-  onMount(() => {
-    if (auth.user) goto(redirectTo)
-    if (!auth.config) initAuth()
-  })
+  const auth = getAuthContext()
 </script>
 
 <svelte:head>


### PR DESCRIPTION
# Summary
- add more generic auth errors
- fix credential error when querying data from server side
- simplify auth data with context
- handle UnauthorizedError on server side too, also in on:unhandledrejection (errors in promises)
- handle admin role check on admin layout 
- fix validation error handling
- use load function for data fetching on admin/users
- go to /id after first prompt
- move admin link to side nav
- ~disable settings link 