### PR TITLE
Feat: anon history

### DIFF
--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -13,6 +13,7 @@ from backend.arena.services import (
     add_comparison_turn,
     create_comparison,
     get_user_comparisons,
+    merge_anonymous_comparisons,
     read_comparison,
     set_comparison_revealed,
     update_comparison_error,
@@ -35,7 +36,7 @@ from backend.arena.streaming import (
     stream_comparison_messages,
 )
 from backend.arena.web_search import search_web
-from backend.auth.dependencies import OptionalUser, RequiredAnomymous
+from backend.auth.dependencies import OptionalUser, RequiredAnomymous, RequiredUser
 from backend.llms.data import get_llms_data, pick_replacement_model
 from backend.utils.user import get_ip, get_matomo_tracker_from_cookies
 from utils.database.models import (
@@ -526,3 +527,12 @@ async def get_comparisons(
     comparisons = await get_user_comparisons(user_id, anonymous_user_hash)
 
     return comparisons
+
+
+@router.post("/comparison/merge")
+async def merge_comparisons(
+    user: RequiredUser,
+    anonymous_user_hash: RequiredAnomymous,
+    request: Request,
+) -> None:
+    await merge_anonymous_comparisons(user.id, anonymous_user_hash)

--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -509,6 +509,7 @@ async def reveal(
 @router.get("/comparison/list")
 async def get_comparisons(
     user: OptionalUser,
+    anonymous_user_hash: RequiredAnomymous,
     request: Request,
 ) -> list[ComparisonPublic]:
     """
@@ -521,9 +522,7 @@ async def get_comparisons(
     Returns:
         list: list of user's Comparison if logged in.
     """
-    if not user:
-        return []
-
-    comparisons = await get_user_comparisons(user.id)
+    user_id = user.id if user else None
+    comparisons = await get_user_comparisons(user_id, anonymous_user_hash)
 
     return comparisons

--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -206,7 +206,7 @@ async def add_first_text(
     comparison = await create_comparison(
         ComparisonCreate(
             ip=get_ip(request),
-            anonymous_user_hash=anonymous_user_hash,
+            anonymous_user_hash=anonymous_user_hash if not user else None,
             user_id=user.id if user else None,
             visitor_id=get_matomo_tracker_from_cookies(request.cookies),
             cohorts=args.cohorts,

--- a/backend/arena/services.py
+++ b/backend/arena/services.py
@@ -1,10 +1,11 @@
+import logging
 import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, TypeVar
 
 from fastapi import HTTPException, status
 from linkup import LinkupSearchTextResult
-from sqlmodel import col, select
+from sqlmodel import and_, col, select, update
 
 from backend.llms.data import get_llms_data
 from utils.database.models import (
@@ -29,6 +30,7 @@ from utils.database.session import get_session
 if TYPE_CHECKING:
     from sqlmodel.ext.asyncio.session import AsyncSession
 
+logger = logging.getLogger("languia")
 
 T = TypeVar("T", bound=Comparison | Turn)
 
@@ -222,3 +224,24 @@ async def get_user_comparisons(
             )
             for comparison in db_comparisons
         ]
+
+
+async def merge_anonymous_comparisons(user_id: uuid.UUID, anonymous_user_hash: str):
+    async with get_session() as session:
+        query = (
+            update(Comparison)
+            .where(
+                and_(
+                    Comparison.anonymous_user_hash == anonymous_user_hash,
+                    Comparison.user_id == None,
+                )
+            )
+            .values({"user_id": user_id, "anonymous_user_hash": None})
+        )
+
+        results = await session.exec(query)
+        await session.commit()
+
+        logger.info(
+            f"Merged {results.rowcount} Comparisons from anonymous '{anonymous_user_hash}' to user {user_id}"
+        )

--- a/backend/arena/services.py
+++ b/backend/arena/services.py
@@ -199,11 +199,18 @@ async def update_turn_vote(
         await session.commit()
 
 
-async def get_user_comparisons(user_id: uuid.UUID) -> list[ComparisonPublic]:
+async def get_user_comparisons(
+    user_id: uuid.UUID | None,
+    anonymous_user_hash: str,
+) -> list[ComparisonPublic]:
     async with get_session() as session:
         query = (
             select(Comparison)
-            .where(Comparison.user_id == user_id)
+            .where(
+                Comparison.user_id == user_id
+                if user_id
+                else Comparison.anonymous_user_hash == anonymous_user_hash
+            )
             .order_by(col(Comparison.updated_at).desc())
         )
         db_comparisons = (await session.exec(query)).all()

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -102,7 +102,6 @@
     },
     "auth": {
         "discussions": {
-            "prompt": "Connectez-vous pour accéder à votre historique de discussion",
             "signIn": "Se connecter",
             "title": "Discussions"
         },

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -133,7 +133,8 @@
                 "neverOther": "tout autre élément permettant de vous identifier",
                 "neverPersonal": "des informations médicales, financières ou juridiques personnelles",
                 "neverPhone": "des numéros de téléphone"
-            }
+            },
+            "merge": "Fusionner les conversations existantes avec votre compte"
         },
         "settings": {
             "logout": "Se déconnecter",

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -1,5 +1,6 @@
 import { goto } from '$app/navigation'
 import { resolve } from '$app/paths'
+import { updateComparisonsContext, type ComparisonsCtx } from '$lib/chatService.svelte'
 import { api } from '$lib/fastapi-client'
 import { createContext } from 'svelte'
 
@@ -41,9 +42,10 @@ export function openSignInModal(): void {
   }
 }
 
-export async function logout(auth: AuthCtx): Promise<void> {
+export async function logout(auth: AuthCtx, comparisons: ComparisonsCtx): Promise<void> {
   try {
     await api.request<void>('/auth/logout', { method: 'POST' })
+    await updateComparisonsContext(comparisons)
   } finally {
     auth.user = null
     if (auth.config?.access_policy === 'sign_in_required') {

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -203,6 +203,7 @@ export function initComparisonsContext(data: ComparisonsCtx) {
 
 export async function updateComparisonsContext(comparisons: ComparisonsCtx) {
   const data = await queryComparisons()
+  comparisons.length = 0
   comparisons.push(...data)
 }
 

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -146,7 +146,7 @@ export const modeInfos: ModeInfos[] = (
 
 // COMPARISON LOGIC
 
-type ComparisonsCtx = Comparison[]
+export type ComparisonsCtx = Comparison[]
 export const [getComparisonsContext, setComparisonsContext] = createContext<ComparisonsCtx>()
 
 function parseAPITurn(turn: APIComparisonTurn): ComparisonTurn {

--- a/frontend/src/lib/components/SignInForm.svelte
+++ b/frontend/src/lib/components/SignInForm.svelte
@@ -19,6 +19,7 @@
   let email = $state('')
   let code = $state('')
   let consented = $state(false)
+  let mergeComparisons = $state(false)
   let loading = $state(false)
   let error = $state<string>()
 
@@ -50,6 +51,9 @@
       })
       const data = await api.request<{ user: AuthUser | null }>('/auth/me')
       auth.user = data.user
+      if (mergeComparisons) {
+        await api.request('/arena/comparison/merge', { method: 'POST' })
+      }
       onSuccess?.()
       useToast(m['auth.success'](), 4000)
     } catch {
@@ -90,6 +94,14 @@
       autocomplete="email"
       required
       class="mb-4!"
+    />
+
+    <Checkbox
+      id="login-merge"
+      class="text-xs!"
+      bind:checked={mergeComparisons}
+      disabled={step === 'code'}
+      label={m['auth.modal.merge']()}
     />
 
     <Checkbox

--- a/frontend/src/lib/components/header/History.svelte
+++ b/frontend/src/lib/components/header/History.svelte
@@ -4,11 +4,15 @@
   import AILogo from '$components/AILogo.svelte'
   import { Link } from '$components/dsfr'
   import { getComparisonsContext } from '$lib/chatService.svelte'
+  import { m } from '$lib/i18n/messages'
   import { getModelsContext } from '$lib/models'
   import type { SvelteHTMLElements } from 'svelte/elements'
 
-  const { mode = 'desktop', ...props }: { mode: 'desktop' | 'mobile' } & SvelteHTMLElements['nav'] =
-    $props()
+  const {
+    mode = 'desktop',
+    expanded,
+    ...props
+  }: { mode?: 'desktop' | 'mobile'; expanded: boolean } & SvelteHTMLElements['nav'] = $props()
 
   const comparisons = getComparisonsContext()
   const { models } = getModelsContext()
@@ -32,30 +36,37 @@
 {/snippet}
 
 {#if comparisons.length}
-  <nav {...props} class={['comparison-history', props.class]}>
-    <ul class="fr-sidemenu__list">
-      {#each comparisons as comp (comp.id)}
-        {@const href = resolve(`/arene/${comp.id}`)}
-        {@const current = page.url.pathname === href ? 'page' : undefined}
-        <li class={['fr-sidemenu__item', { 'before:content-none!': mode === 'mobile' }]}>
-          <Link
-            {href}
-            aria-current={current}
-            class="fr-sidemenu__link py-1! font-normal! text-sm!"
-            aria-controls={mode === 'mobile' ? 'fr-modal-menu' : undefined}
-          >
-            <span class="max-w-[145px] shrink truncate">{comp.turns[0]?.user_msg.content}</span>
-            <span class="gap-1 ms-auto flex items-center">
-              {@render logo(
-                comp.reveal_data?.a.llm_id,
-                comp.reveal_data?.chosen_llm === 'a'
-              )}/{@render logo(comp.reveal_data?.b.llm_id, comp.reveal_data?.chosen_llm === 'b')}
-            </span>
-          </Link>
-        </li>
-      {/each}
-    </ul>
-  </nav>
+  <div class={['gap-2 lg:min-h-0 flex flex-col', { 'lg:hidden': !expanded }]}>
+    <div class="px-4">
+      <p class="text-sm! mb-0! text-black font-bold">
+        {m['auth.discussions.title']()}
+      </p>
+    </div>
+    <nav {...props} class={['comparison-history lg:overflow-y-auto', props.class]}>
+      <ul class="fr-sidemenu__list">
+        {#each comparisons as comp (comp.id)}
+          {@const href = resolve(`/arene/${comp.id}`)}
+          {@const current = page.url.pathname === href ? 'page' : undefined}
+          <li class={['fr-sidemenu__item', { 'before:content-none!': mode === 'mobile' }]}>
+            <Link
+              {href}
+              aria-current={current}
+              class="fr-sidemenu__link py-1! font-normal! text-sm!"
+              aria-controls={mode === 'mobile' ? 'fr-modal-menu' : undefined}
+            >
+              <span class="max-w-[145px] shrink truncate">{comp.turns[0]?.user_msg.content}</span>
+              <span class="gap-1 ms-auto flex items-center">
+                {@render logo(
+                  comp.reveal_data?.a.llm_id,
+                  comp.reveal_data?.chosen_llm === 'a'
+                )}/{@render logo(comp.reveal_data?.b.llm_id, comp.reveal_data?.chosen_llm === 'b')}
+              </span>
+            </Link>
+          </li>
+        {/each}
+      </ul>
+    </nav>
+  </div>
 {/if}
 
 <style lang="postcss">

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -103,19 +103,6 @@
   </div>
 {/snippet}
 
-{#snippet discussions(mode: 'desktop' | 'mobile' = 'desktop')}
-  {#if !isAdmin}
-    <div class={['gap-2 lg:min-h-0 flex flex-col', { 'lg:hidden': !expanded }]}>
-      <div class="px-4">
-        <p class="text-sm! mb-0! text-black font-bold">
-          {m['auth.discussions.title']()}
-        </p>
-      </div>
-      <History {mode} class="lg:overflow-y-auto" />
-    </div>
-  {/if}
-{/snippet}
-
 {#snippet footer(mode: 'desktop' | 'mobile' = 'desktop')}
   <div class="gap-2 flex flex-col">
     <div class="flex items-center justify-between">
@@ -220,7 +207,9 @@
       </ul>
     </nav>
 
-    {@render discussions()}
+    {#if !isAdmin}
+      <History {expanded} />
+    {/if}
 
     <div class="b-t-[--grey-925-125] b-t-1 px-4 py-5 mt-auto">
       {@render footer()}
@@ -259,7 +248,9 @@
         </ul>
       </nav>
 
-      {@render discussions('mobile')}
+      {#if !isAdmin}
+        <History mode="mobile" expanded={true} />
+      {/if}
 
       <div class="bottom-0 pb-5 p-4 bg-white sticky mt-auto border-t border-[--grey-925-125]">
         {@render footer('mobile')}

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -12,6 +12,7 @@
   import { Button, Icon, Link } from '$components/dsfr'
   import type { LinkProps } from '$components/dsfr/Link.svelte'
   import { getAuthContext, logout } from '$lib/auth.svelte'
+  import { getComparisonsContext } from '$lib/chatService.svelte'
   import { api } from '$lib/fastapi-client'
   import { m } from '$lib/i18n/messages'
   import type { HTMLAnchorAttributes } from 'svelte/elements'
@@ -20,6 +21,7 @@
   const { navLinks, isAdmin = false }: { navLinks: NavLink[]; isAdmin?: boolean } = $props()
 
   const auth = getAuthContext()
+  const comparisons = getComparisonsContext()
   let expanded = $state(true)
 
   const connectionBtnProps = $derived(
@@ -27,7 +29,7 @@
       ? {
           text: m['auth.settings.logout'](),
           icon: 'i-ri-logout-box-r-line',
-          onclick: () => logout(auth)
+          onclick: () => logout(auth, comparisons)
         }
       : {
           text: m['auth.discussions.signIn'](),

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -21,6 +21,21 @@
 
   const auth = getAuthContext()
   let expanded = $state(true)
+
+  const connectionBtnProps = $derived(
+    auth.user
+      ? {
+          text: m['auth.settings.logout'](),
+          icon: 'i-ri-logout-box-r-line',
+          onclick: () => logout(auth)
+        }
+      : {
+          text: m['auth.discussions.signIn'](),
+          icon: 'i-ri-login-box-line',
+          'aria-controls': 'fr-modal-signin',
+          'data-fr-opened': 'false'
+        }
+  )
 </script>
 
 {#snippet helpLink()}
@@ -93,24 +108,8 @@
         <p class="text-sm! mb-0! text-black font-bold">
           {m['auth.discussions.title']()}
         </p>
-        {#if !auth.user}
-          <p class="text-sm mb-0! text-black">
-            {m['auth.discussions.prompt']()}
-          </p>
-          <Button
-            variant="tertiary"
-            text={m['auth.discussions.signIn']()}
-            icon="user-line"
-            size="sm"
-            aria-controls="fr-modal-signin"
-            data-fr-opened="false"
-            class="mt-2! block w-full!"
-          />
-        {/if}
       </div>
-      {#if auth.user}
-        <History {mode} class="lg:overflow-y-auto" />
-      {/if}
+      <History {mode} class="lg:overflow-y-auto" />
     </div>
   {/if}
 {/snippet}
@@ -131,22 +130,24 @@
       <LanguageSelector id="translate-{mode}" class={{ 'lg:hidden': !expanded }} />
     </div>
 
-    {#if auth.user}
-      <div
-        class="md:flex-row gap-1 lg:flex-col md:items-center lg:items-start -mt-1 md:justify-between flex flex-col"
+    <div
+      class="md:flex-row gap-1 lg:flex-col md:items-center lg:items-start md:justify-between flex flex-col"
+    >
+      <Button
+        variant="tertiary"
+        size="sm"
+        {...connectionBtnProps}
+        icon={undefined}
+        text={undefined}
+        class={['w-full!', { '-ms-[2px]': !expanded }]}
       >
-        <Button
-          variant="tertiary-no-outline"
-          size="sm"
-          class="text-black! -ms-3"
-          onclick={() => logout(auth)}
-        >
-          <span class={['gap-2 flex items-center', { 'lg:w-full lg:justify-center': !expanded }]}>
-            <Icon icon="i-ri-logout-box-r-line" block size={expanded ? 'sm' : 'md'} />
-            <span class={{ 'lg:sr-only': !expanded }}>{m['auth.settings.logout']()}</span>
-          </span>
-        </Button>
+        <span class={['gap-2 flex items-center', { 'lg:w-full lg:justify-center': !expanded }]}>
+          <Icon icon={connectionBtnProps.icon} block size={expanded ? 'sm' : 'md'} />
+          <span class={{ 'lg:sr-only': !expanded }}>{connectionBtnProps.text}</span>
+        </span>
+      </Button>
 
+      {#if auth.user}
         <p
           class={[
             'text-sm mb-0! text-grey min-w-0 max-w-full [overflow-wrap:anywhere]',
@@ -155,8 +156,8 @@
         >
           {auth.user.email}
         </p>
-      </div>
-    {/if}
+      {/if}
+    </div>
 
     <!-- {@render helpLink()} -->
 

--- a/frontend/src/routes/arene/components/ViewChat.svelte
+++ b/frontend/src/routes/arene/components/ViewChat.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
+  import { goto } from '$app/navigation'
+  import { resolve } from '$app/paths'
   import { Button, Icon, Tooltip } from '$components/dsfr'
   import TextPrompt from '$components/TextPrompt.svelte'
   import { getComparison, modeInfos } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
-  import { GroupedMessages, RevealArea, VoteModal } from '.'
   import { onDestroy } from 'svelte'
+  import { GroupedMessages, RevealArea, VoteModal } from '.'
 
   let { comparisonId }: { comparisonId: string } = $props()
 
   const comparator = $derived(getComparison(comparisonId))
+
+  $effect(() => {
+    if (!comparator.comparison) {
+      goto(resolve('/arene'))
+    }
+  })
 
   let prompt = $state('')
   let voteReminder = $state(false)


### PR DESCRIPTION
## Summary

- move login btn to logout
- display anonymous comparisons history list
- add checkbox in login form and back logic to merge existing anonymous comparisons to account comparisons
- do not save anonymous_user_hash in Comparison if user logged in
- do not display history list block if no comparions