### PR TITLE
fix(dataset): repair and document export workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,12 +121,17 @@ make models-maintenance    # Run model health checks
 
 ## Datasets
 
-**Prerequisites:** `COMPARIA_DB_URI`, `HF_PUSH_DATASET_KEY`, and `HF_PUSH_DATASET_PATH` environment variables configured.
+**Prerequisites:** Configure `COMPARIA_DB_URI` and `HF_PUSH_DATASET_PATH`. An
+`HF_PUSH_DATASET_KEY` with write access is also required for uploads.
 
 ```bash
 make dataset-export        # Export FR datasets to HuggingFace
 make dataset-export-da     # Export DA datasets to HuggingFace
 ```
+
+See [`utils/dataset/README.md`](utils/dataset/README.md) for setup, dry runs,
+exporting individual dataset variants, output files, filtering rules, and cache
+usage.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ dataset-export: ## Export FR datasets to HuggingFace (requires HF_PUSH_DATASET_K
 		echo "Error: HF_PUSH_DATASET_PATH is not defined"; \
 		exit 1; \
 	fi
-	$(UV) run python -m utils.dataset.run fr
+	DEFAULT_COUNTRY_PORTAL=fr $(UV) run --group data python -m utils.dataset.run
 
 dataset-export-da: ## Export DA datasets to HuggingFace (requires HF_PUSH_DATASET_KEY, HF_PUSH_DATASET_PATH and COMPARIA_DB_URI)
 	@echo "Exporting datasets..."
@@ -246,4 +246,4 @@ dataset-export-da: ## Export DA datasets to HuggingFace (requires HF_PUSH_DATASE
 		echo "Error: HF_PUSH_DATASET_PATH is not defined"; \
 		exit 1; \
 	fi
-	$(UV) run python -m utils.dataset.run da
+	DEFAULT_COUNTRY_PORTAL=da $(UV) run --group data python -m utils.dataset.run

--- a/tests/dataset/test_streaming_export.py
+++ b/tests/dataset/test_streaming_export.py
@@ -161,8 +161,8 @@ def check_reference_schema(failures):
                 voted_at=datetime(2024, 1, 1, 12, 0, 5),
             )
         ],
-        sys_a=fix.system_msg("s"),
-        sys_b=fix.system_msg("s"),
+        sys_a="s",
+        sys_b="s",
         mode="custom",
         custom_models_selection=["model-a", "model-b"],
         categories=["c"],

--- a/utils/dataset/README.md
+++ b/utils/dataset/README.md
@@ -1,0 +1,146 @@
+# Dataset export
+
+The dataset exporter reads arena comparisons from PostgreSQL, flattens each
+comparison into one row per turn, writes Parquet files and small sample
+previews, and optionally publishes them to Hugging Face.
+
+## Prerequisites
+
+- Python 3.13 or later and [`uv`](https://docs.astral.sh/uv/)
+- A migrated ComparIA PostgreSQL database containing comparison data
+- The data dependency group, installed with `uv sync --group data`
+- `COMPARIA_DB_URI`, for example
+  `postgresql://comparia:comparia@localhost:5432/comparia`
+- `HF_PUSH_DATASET_PATH` in the form `<organisation>/<repository-prefix>`
+
+`HF_PUSH_DATASET_PATH` is required for local exports too: the repository prefix
+is used to name output directories and files. `HF_PUSH_DATASET_KEY` is only
+required when uploading to Hugging Face.
+
+Settings can be added to the repository's `.env` file or exported in the
+current shell. To create and migrate the development database, follow the
+[database setup](../../CONTRIBUTING.md#database).
+
+## Export locally
+
+Run commands from the repository root. Use `--dry-run` to write files without
+authenticating to or uploading to Hugging Face:
+
+```bash
+uv run --group data python comparia-cli generate datasets --dry-run
+```
+
+The default exports both dataset variants. Export only one with `--dataset`:
+
+```bash
+uv run --group data python comparia-cli generate datasets \
+  --dataset normal \
+  --dry-run
+
+uv run --group data python comparia-cli generate datasets \
+  --dataset raw \
+  --dry-run
+```
+
+Use `--export-base-path` to write somewhere other than
+`utils/local_dataset/`:
+
+```bash
+uv run --group data python comparia-cli generate datasets \
+  --dry-run \
+  --export-base-path /tmp/comparia-datasets
+```
+
+Before a full export, row counts can be checked without writing files:
+
+```bash
+uv run --group data python comparia-cli generate datasets --count
+```
+
+## Dataset variants and output
+
+For `HF_PUSH_DATASET_PATH=example/comparia`, the default output is:
+
+```text
+utils/local_dataset/
+├── comparia/
+│   ├── comparia.parquet
+│   ├── comparia_samples.jsonl
+│   └── comparia_samples.tsv
+└── comparia-raw/
+    ├── comparia-raw.parquet
+    ├── comparia-raw_samples.jsonl
+    └── comparia-raw_samples.tsv
+```
+
+The sample files contain at most 1,000 rows. The exporter does not generate a
+full JSONL copy; Parquet is the canonical full export.
+
+The variants differ as follows:
+
+| Variant | Contents |
+| --- | --- |
+| `normal` | Public rows only. Comparisons are excluded when they are archived, not successfully analyzed, marked as PII or spam, associated with an excluded cohort, or contain an error. Internal `excluded` and `extra_metadata` columns are removed. |
+| `raw` | All successfully parsed rows, including the `excluded` flag and `extra_metadata`, so filtering decisions can be audited. |
+
+Both variants contain one row per conversation turn. Shared comparison fields
+and full conversation histories are repeated on each turn. Writes are streamed
+in bounded batches, so the full dataset is not accumulated in memory.
+
+## Reuse an existing raw export
+
+When the raw Parquet already exists under the selected export path, regenerate
+only the filtered normal dataset without reading PostgreSQL again:
+
+```bash
+uv run --group data python comparia-cli generate datasets \
+  --dataset normal \
+  --use-cache \
+  --dry-run
+```
+
+The raw file must be at the path derived from `HF_PUSH_DATASET_PATH`, such as
+`utils/local_dataset/comparia-raw/comparia-raw.parquet`. If it is missing, the
+command logs a warning and performs a full database export.
+
+## Publish to Hugging Face
+
+Set a token with write access, remove `--dry-run`, and choose the desired
+variant:
+
+```bash
+export HF_PUSH_DATASET_KEY=hf_...
+uv run --group data python comparia-cli generate datasets --dataset normal
+```
+
+With `HF_PUSH_DATASET_PATH=example/comparia`, `normal` is uploaded to
+`example/comparia` and `raw` to `example/comparia-raw`.
+
+## Verification
+
+The dataset regression tests do not connect to the database, although
+`COMPARIA_DB_URI` must be configured because the database engine is initialized
+during module imports:
+
+```bash
+uv run --group data python tests/dataset/test_comparison_to_turns.py
+uv run --group data python tests/dataset/test_streaming_export.py
+```
+
+After an export, inspect the Parquet schema and row count with DuckDB:
+
+```bash
+uv run --group data python - <<'PY'
+import duckdb
+
+path = "utils/local_dataset/comparia/comparia.parquet"
+print(duckdb.sql(f"DESCRIBE SELECT * FROM read_parquet('{path}')"))
+print(duckdb.sql(f"SELECT count(*) AS rows FROM read_parquet('{path}')"))
+PY
+```
+
+For command-line options, run:
+
+```bash
+uv run --group data python comparia-cli generate datasets --help
+```

--- a/utils/dataset/run.py
+++ b/utils/dataset/run.py
@@ -31,11 +31,13 @@ async def main(
     export_base_path: str
         Directory for local export (default: utils/local_dataset)
     dataset: str
-        Specific dataset to export (comparisons, comparisons_raw). Default: all
+        Dataset variant to export (normal, raw, or all). Default: all
     dry_run: bool
         Skip HuggingFace upload (only export to utils/local_dataset/)
     count: bool
         Display row counts for each dataset without exporting
+    use_cache: bool
+        Rebuild the normal dataset from an existing raw parquet without querying the database
     """
     datasets: list[Datasets] = ["normal", "raw"] if dataset == "all" else [dataset]
 


### PR DESCRIPTION
## Summary

Document the current dataset export workflow and repair stale commands and test fixtures that prevented it from running cleanly.

## Why this helps

Contributors can now run local exports, understand the public and raw dataset variants, reuse cached raw data, inspect generated files, and publish safely with the actual CLI options. The Make targets and documented regression checks also work with the current exporter API.

## Changes made

- add a dataset export guide covering prerequisites, dry runs, variants, output layout, filtering, cache reuse, publication, and verification
- link the guide from the contributor documentation and clarify when Hugging Face credentials are required
- update FR and DA Make targets to use the current option-based exporter entry point and data dependency group
- correct CLI help text for `normal`, `raw`, and cache behavior
- update the streaming export fixture for string-based system messages

## Testing

- `LOG_FORMAT=JSON COMPARIA_DB_URI=postgresql://comparia:comparia@localhost:5432/comparia make test-dataset`
- `uv run black --check utils/dataset/run.py tests/dataset/test_streaming_export.py`
- `LOG_FORMAT=JSON COMPARIA_DB_URI=postgresql://comparia:comparia@localhost:5432/comparia uv run --group data python comparia-cli generate datasets --help`
- `make -n dataset-export` and `make -n dataset-export-da` with required variables set
- `git diff --check`
- verified local Markdown links resolve

## Related issue

Closes #198