### PR TITLE
fix(front): init comparisons context in admin layout

### DIFF
--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import { page } from '$app/state'
   import NavBar, { type NavLink } from '$components/header/NavBar.svelte'
+  import { initComparisonsContext } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
 
   let { children } = $props()
+
+  // NavBar's logout button needs a comparisons context; the admin area never
+  // displays the history itself (NavBar skips it when isAdmin).
+  initComparisonsContext([])
 
   const navLinks: NavLink[] = $derived([
     {


### PR DESCRIPTION
## Summary

- NavBar reads the comparisons context unconditionally (needed since logout() started clearing it), but the admin layout never initialized it
- This caused a missing_context crash on every /admin/* page (500 on direct load, silent failure on client-side navigation)

## Changes

- `frontend/src/routes/(admin)/+layout.svelte`: call `initComparisonsContext([])` before rendering NavBar, same as the arena layout does