### PR TITLE
feat(admin): enable/disable shipped locales from admin settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Instance configuration
-export DEFAULT_COUNTRY_PORTAL=fr
+export COMPARIA_INSTANCE_NAME=fr
 
 # Currency used to display model prices and conversation costs (ISO 4217).
 # Rates are refreshed daily from the open-source Frankfurter API.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # Instance configuration
 export DEFAULT_COUNTRY_PORTAL=fr
-export DEFAULT_LOCALE=fr
 
 # Currency used to display model prices and conversation costs (ISO 4217).
 # Rates are refreshed daily from the open-source Frankfurter API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Copy the example env file and fill in the required values:
 cp .env.example .env
 ```
 
-Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_COUNTRY_PORTAL=da` and point `COMPARIA_DB_URI` to the DA database.
+Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `COMPARIA_INSTANCE_NAME=da` and point `COMPARIA_DB_URI` to the DA database.
 
 Start Postgres and Redis, then run:
 
@@ -39,7 +39,7 @@ source .env
 make dev      # backend on :8008, frontend on :5173
 ```
 
-For the DA instance, copy `.env.example` and set `DEFAULT_COUNTRY_PORTAL=da` and `COMPARIA_DB_URI` to the DA database before sourcing.
+For the DA instance, copy `.env.example` and set `COMPARIA_INSTANCE_NAME=da` and `COMPARIA_DB_URI` to the DA database before sourcing.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Copy the example env file and fill in the required values:
 cp .env.example .env
 ```
 
-Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_COUNTRY_PORTAL=da`, `DEFAULT_LOCALE=da`, and point `COMPARIA_DB_URI` to the DA database.
+Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_COUNTRY_PORTAL=da` and point `COMPARIA_DB_URI` to the DA database.
 
 Start Postgres and Redis, then run:
 
@@ -39,7 +39,7 @@ source .env
 make dev      # backend on :8008, frontend on :5173
 ```
 
-For the DA instance, copy `.env.example` and set `DEFAULT_COUNTRY_PORTAL=da`, `DEFAULT_LOCALE=da`, and `COMPARIA_DB_URI` to the DA database before sourcing.
+For the DA instance, copy `.env.example` and set `DEFAULT_COUNTRY_PORTAL=da` and `COMPARIA_DB_URI` to the DA database before sourcing.
 
 ---
 

--- a/backend/admin/router.py
+++ b/backend/admin/router.py
@@ -324,6 +324,7 @@ def _to_app_settings_public(row: AppSettings) -> AppSettingsPublic:
         secondary_color_dark=row.secondary_color_dark,
         homepage_url=row.homepage_url,
         has_custom_logo=row.logo is not None,
+        enabled_locales=row.enabled_locales,
         updated_at=row.updated_at.isoformat(),
         updated_by=row.updated_by,
     )
@@ -340,6 +341,14 @@ async def patch_settings(
     body: AppSettingsPatch,
     current_user: RequiredAdmin,
 ) -> AppSettingsPublic:
+    if (
+        body.enabled_locales is not None
+        and settings.DEFAULT_COUNTRY_PORTAL not in body.enabled_locales
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot disable the instance's default locale",
+        )
     row = await update_app_settings(
         body.model_dump(exclude_unset=True), updated_by=current_user.id
     )

--- a/backend/admin/router.py
+++ b/backend/admin/router.py
@@ -325,6 +325,7 @@ def _to_app_settings_public(row: AppSettings) -> AppSettingsPublic:
         homepage_url=row.homepage_url,
         has_custom_logo=row.logo is not None,
         enabled_locales=row.enabled_locales,
+        default_locale=row.default_locale,
         updated_at=row.updated_at.isoformat(),
         updated_by=row.updated_by,
     )
@@ -341,14 +342,23 @@ async def patch_settings(
     body: AppSettingsPatch,
     current_user: RequiredAdmin,
 ) -> AppSettingsPublic:
-    if (
-        body.enabled_locales is not None
-        and settings.DEFAULT_COUNTRY_PORTAL not in body.enabled_locales
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot disable the instance's default locale",
+    if body.enabled_locales is not None or body.default_locale is not None:
+        current = await get_app_settings()
+        effective_locales = (
+            body.enabled_locales
+            if body.enabled_locales is not None
+            else current.enabled_locales
         )
+        effective_default = (
+            body.default_locale
+            if body.default_locale is not None
+            else current.default_locale
+        )
+        if effective_default not in effective_locales:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Default locale must be part of the enabled locales",
+            )
     row = await update_app_settings(
         body.model_dump(exclude_unset=True), updated_by=current_user.id
     )

--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -61,6 +61,7 @@ class AuthConfig(BaseModel):
     platform_url: str
     has_custom_logo: bool
     enabled_locales: list[str]
+    default_locale: str
 
 
 class EmailRequestBody(BaseModel):
@@ -149,6 +150,7 @@ async def get_config() -> AuthConfig:
         platform_url=settings.COMPARIA_APP_URL,
         has_custom_logo=app_settings.logo is not None,
         enabled_locales=app_settings.enabled_locales,
+        default_locale=app_settings.default_locale,
     )
 
 

--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -60,6 +60,7 @@ class AuthConfig(BaseModel):
     homepage_url: str | None
     platform_url: str
     has_custom_logo: bool
+    enabled_locales: list[str]
 
 
 class EmailRequestBody(BaseModel):
@@ -147,6 +148,7 @@ async def get_config() -> AuthConfig:
         homepage_url=app_settings.homepage_url,
         platform_url=settings.COMPARIA_APP_URL,
         has_custom_logo=app_settings.logo is not None,
+        enabled_locales=app_settings.enabled_locales,
     )
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -33,7 +33,12 @@ class Settings(BaseSettings):
     HF_PUSH_DATASET_KEY: str = ""
     HF_PUSH_DATASET_PATH: str = ""
 
-    DEFAULT_COUNTRY_PORTAL: str = "fr"
+    # Names the deployment (fr, da, a museum one-off, ...). Used as the Redis key
+    # namespace and to seed the default locale. Renamed from DEFAULT_COUNTRY_PORTAL,
+    # which described a country portal the project outgrew; the deployment manifests
+    # have to carry the new name, since nothing falls back to the old one. The
+    # values themselves are unchanged, so Redis keys stay put.
+    COMPARIA_INSTANCE_NAME: str = "fr"
 
     # Display currency. Model prices are stored in euros and converted for the UI.
     DISPLAY_CURRENCY: str = "EUR"

--- a/controller.py
+++ b/controller.py
@@ -8,7 +8,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
-from backend.config import DEFAULT_COUNTRY_PORTAL
+from backend.config import settings
 from backend.llms.data import get_llms_data
 
 templates = Jinja2Templates(directory="templates")
@@ -56,7 +56,7 @@ def get_models_errors() -> list[str]:  # Return type hint
     response_class=HTMLResponse,
 )
 def index(request: Request) -> HTMLResponse:
-    models = get_llms_data(DEFAULT_COUNTRY_PORTAL)
+    models = get_llms_data(settings.COMPARIA_INSTANCE_NAME)
 
     error_count = dict.fromkeys(models.enabled, 0)
     for model_id, _date, _details in models_errors:

--- a/devops/instances/da/.env.da.example
+++ b/devops/instances/da/.env.da.example
@@ -1,4 +1,4 @@
-DEFAULT_COUNTRY_PORTAL=da
+COMPARIA_INSTANCE_NAME=da
 
 COMPARIA_DB_URI="postgres://user:pass@host:5432/comparia_da?sslmode=require"
 COMPARIA_REDIS_HOST=localhost

--- a/devops/instances/da/app.compose.da.yml
+++ b/devops/instances/da/app.compose.da.yml
@@ -6,7 +6,6 @@ services:
     depends_on:
       - backend-da
     environment:
-      DEFAULT_LOCALE: da
       PUBLIC_LANGUIA_DEBUG: "true"
       PUBLIC_API_LOCAL_URL: "http://backend-da:80"
       PUBLIC_API_URL: "${PUBLIC_API_URL:-http://localhost:8002}"

--- a/devops/instances/da/app.compose.da.yml
+++ b/devops/instances/da/app.compose.da.yml
@@ -19,7 +19,7 @@ services:
     environment:
       LOGDIR: /data
       LANGUIA_DEBUG: "true"
-      DEFAULT_COUNTRY_PORTAL: da
+      COMPARIA_INSTANCE_NAME: da
       COMPARIA_DB_URI: "${COMPARIA_DB_URI_DA:-postgresql://comparia:comparia@postgres:5432/comparia_da}"
       COMPARIA_REDIS_HOST: redis
       OPENROUTER_API_KEY:

--- a/devops/instances/fr/.env.fr.example
+++ b/devops/instances/fr/.env.fr.example
@@ -1,4 +1,4 @@
-DEFAULT_COUNTRY_PORTAL=fr
+COMPARIA_INSTANCE_NAME=fr
 
 COMPARIA_DB_URI="postgres://user:pass@host:5432/comparia_fr?sslmode=require"
 COMPARIA_REDIS_HOST=localhost

--- a/devops/instances/fr/app.compose.fr.yml
+++ b/devops/instances/fr/app.compose.fr.yml
@@ -6,7 +6,6 @@ services:
     depends_on:
       - backend-fr
     environment:
-      DEFAULT_LOCALE: fr
       PUBLIC_LANGUIA_DEBUG: "true"
       PUBLIC_API_LOCAL_URL: "http://backend-fr:80"
       PUBLIC_API_URL: "${PUBLIC_API_URL:-http://localhost:8001}"

--- a/devops/instances/fr/app.compose.fr.yml
+++ b/devops/instances/fr/app.compose.fr.yml
@@ -19,7 +19,7 @@ services:
     environment:
       LOGDIR: /data
       LANGUIA_DEBUG: "true"
-      DEFAULT_COUNTRY_PORTAL: fr
+      COMPARIA_INSTANCE_NAME: fr
       COMPARIA_DB_URI: "${COMPARIA_DB_URI_FR:-postgresql://comparia:comparia@postgres:5432/comparia}"
       COMPARIA_REDIS_HOST: redis
       OPENROUTER_API_KEY:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,9 +10,6 @@ PUBLIC_API_URL=http://localhost:8001
 # In development: http://localhost:8001
 PUBLIC_API_LOCAL_URL=http://localhost:8001
 
-# Disabled locales (comma-separated if multiple)
-PUBLIC_DISABLED_LOCALES=
-
 # Debug mode for frontend logger (true = debug level, false = info level)
 PUBLIC_LANGUIA_DEBUG=false
 

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -45,6 +45,9 @@
                 "locales": {
                     "label": "Aktiverede sprog"
                 },
+                "defaultLocale": {
+                    "label": "Standardsprog"
+                },
                 "logo": {
                     "label": "Logo",
                     "chooseFile": "Vælg en fil",

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -30,6 +30,7 @@
             "users": "Brugere",
             "llms": "LLMs",
             "customization": "Tilpasning",
+            "locales": "Sprog",
             "authentification": "Autentificering"
         },
         "panelLink": "Administration",
@@ -39,15 +40,17 @@
             "save": "Gem",
             "saving": "Gemmer...",
             "saved": "Indstillinger opdateret",
+            "locales": {
+                "enabled": {
+                    "label": "Aktiverede sprog"
+                },
+                "default": {
+                    "label": "Standardsprog"
+                }
+            },
             "customization": {
                 "platformName": "Platformens navn",
                 "votesObjective": "Stemmemål",
-                "locales": {
-                    "label": "Aktiverede sprog"
-                },
-                "defaultLocale": {
-                    "label": "Standardsprog"
-                },
                 "logo": {
                     "label": "Logo",
                     "chooseFile": "Vælg en fil",

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -42,6 +42,9 @@
             "customization": {
                 "platformName": "Platformens navn",
                 "votesObjective": "Stemmemål",
+                "locales": {
+                    "label": "Aktiverede sprog"
+                },
                 "logo": {
                     "label": "Logo",
                     "chooseFile": "Vælg en fil",

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -42,7 +42,8 @@
             "saved": "Indstillinger opdateret",
             "locales": {
                 "enabled": {
-                    "label": "Aktiverede sprog"
+                    "label": "Aktiverede sprog",
+                    "hint": "Fjernes markeringen for et sprog, forsvinder det straks fra menuen. Besøgende, der allerede læser på det sprog, skifter til standardsproget ved næste sideindlæsning."
                 },
                 "default": {
                     "label": "Standardsprog"

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -41,7 +41,8 @@
             "saved": "Settings updated",
             "locales": {
                 "enabled": {
-                    "label": "Enabled languages"
+                    "label": "Enabled languages",
+                    "hint": "Unchecking a language removes it from the menu immediately. Visitors already reading in it switch to the default language on their next page load."
                 },
                 "default": {
                     "label": "Default language"

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -44,6 +44,9 @@
                 "locales": {
                     "label": "Enabled languages"
                 },
+                "defaultLocale": {
+                    "label": "Default language"
+                },
                 "logo": {
                     "label": "Logo",
                     "chooseFile": "Choose a file",

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -29,6 +29,7 @@
             "users": "Users",
             "llms": "LLMs",
             "customization": "Customization",
+            "locales": "Languages",
             "authentification": "Authentication"
         },
         "panelLink": "Admin panel",
@@ -38,15 +39,17 @@
             "save": "Save",
             "saving": "Saving...",
             "saved": "Settings updated",
+            "locales": {
+                "enabled": {
+                    "label": "Enabled languages"
+                },
+                "default": {
+                    "label": "Default language"
+                }
+            },
             "customization": {
                 "platformName": "Platform name",
                 "votesObjective": "Votes objective",
-                "locales": {
-                    "label": "Enabled languages"
-                },
-                "defaultLocale": {
-                    "label": "Default language"
-                },
                 "logo": {
                     "label": "Logo",
                     "chooseFile": "Choose a file",

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -41,6 +41,9 @@
             "customization": {
                 "platformName": "Platform name",
                 "votesObjective": "Votes objective",
+                "locales": {
+                    "label": "Enabled languages"
+                },
                 "logo": {
                     "label": "Logo",
                     "chooseFile": "Choose a file",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -122,6 +122,7 @@
             "customization": "Personnalisation",
             "legal": "Documents juridiques",
             "llms": "LLMs",
+            "locales": "Langues",
             "suggestions": "Suggestions",
             "users": "Utilisateurs"
         },
@@ -232,16 +233,10 @@
                     "secondaryLight": "Couleur secondaire (thème clair)",
                     "secondaryDark": "Couleur secondaire (thème sombre)"
                 },
-                "defaultLocale": {
-                    "label": "Langue par défaut"
-                },
                 "homepageUrl": {
                     "label": "URL de la page d’accueil",
                     "hint": "Cette adresse est ouverte lorsqu’une personne sélectionne le logo ou le nom de la plateforme. Laissez vide pour utiliser l’accueil local.",
                     "invalid": "Saisissez une URL HTTPS complète."
-                },
-                "locales": {
-                    "label": "Langues activées"
                 },
                 "logo": {
                     "chooseFile": "Choisir un fichier",
@@ -255,6 +250,14 @@
                 "votesObjective": "Objectif de votes"
             },
             "loading": "Chargement...",
+            "locales": {
+                "default": {
+                    "label": "Langue par défaut"
+                },
+                "enabled": {
+                    "label": "Langues activées"
+                }
+            },
             "save": "Enregistrer",
             "saved": "Paramètres mis à jour",
             "saving": "Enregistrement...",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -232,6 +232,9 @@
                     "secondaryLight": "Couleur secondaire (thème clair)",
                     "secondaryDark": "Couleur secondaire (thème sombre)"
                 },
+                "defaultLocale": {
+                    "label": "Langue par défaut"
+                },
                 "homepageUrl": {
                     "label": "URL de la page d’accueil",
                     "hint": "Cette adresse est ouverte lorsqu’une personne sélectionne le logo ou le nom de la plateforme. Laissez vide pour utiliser l’accueil local.",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -255,7 +255,8 @@
                     "label": "Langue par défaut"
                 },
                 "enabled": {
-                    "label": "Langues activées"
+                    "label": "Langues activées",
+                    "hint": "Décocher une langue la retire immédiatement du menu. Les personnes qui la lisaient basculent vers la langue par défaut au prochain chargement."
                 }
             },
             "save": "Enregistrer",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -237,6 +237,9 @@
                     "hint": "Cette adresse est ouverte lorsqu’une personne sélectionne le logo ou le nom de la plateforme. Laissez vide pour utiliser l’accueil local.",
                     "invalid": "Saisissez une URL HTTPS complète."
                 },
+                "locales": {
+                    "label": "Langues activées"
+                },
                 "logo": {
                     "chooseFile": "Choisir un fichier",
                     "hint": "PNG, JPEG, SVG ou WebP, 2 Mo maximum.",

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -12,10 +12,30 @@ import { sequence } from '@sveltejs/kit/hooks'
 const MATOMO_ID = env.MATOMO_ID || ''
 const MATOMO_URL = env.MATOMO_URL || ''
 
-const DEFAULT_LOCALE = env.DEFAULT_LOCALE || ''
+const DEFAULT_LOCALE_CHECK_TTL_MS = 20_000
+
+// Cached per Node process (same rationale as maintenanceCache below): the
+// admin-editable default locale doesn't need to be read from the backend on
+// every single request.
+let defaultLocaleCache: { value: string; checkedAt: number } | null = null
+
+async function getDefaultLocale(): Promise<string> {
+  const now = Date.now()
+  if (!defaultLocaleCache || now - defaultLocaleCache.checkedAt >= DEFAULT_LOCALE_CHECK_TTL_MS) {
+    let value = defaultLocaleCache?.value ?? ''
+    try {
+      ;({ default_locale: value } = await api.request<{ default_locale: string }>('/auth/config'))
+    } catch (error) {
+      // Fail open: fall back to Paraglide's own strategies if the check fails
+      logger.error('Default locale check failed', { error: `${error}` })
+    }
+    defaultLocaleCache = { value, checkedAt: now }
+  }
+  return defaultLocaleCache.value
+}
 
 defineCustomServerStrategy('custom-url', {
-  getLocale: (request) => {
+  getLocale: async (request) => {
     if (!request) return
     const url = new URL(request.url)
     const locale = url.searchParams.get('locale')
@@ -24,18 +44,19 @@ defineCustomServerStrategy('custom-url', {
       return HOST_TO_LOCALE[url.host as keyof typeof HOST_TO_LOCALE]
     } else if (locale) {
       return locale
-    } else if (DEFAULT_LOCALE) {
-      // Only apply DEFAULT_LOCALE if no user cookie is already set.
+    } else {
+      // Only apply the default locale if no user cookie is already set.
       // Paraglide runs custom strategies before built-in ones (including cookie),
-      // so without this check DEFAULT_LOCALE would silently override the user's
-      // locale preference stored in PARAGLIDE_LOCALE.
+      // so without this check it would silently override the user's locale
+      // preference stored in PARAGLIDE_LOCALE.
       const cookieLocale = request.headers
         .get('cookie')
         ?.split('; ')
         .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
         ?.split('=')[1]
       if (!cookieLocale) {
-        return DEFAULT_LOCALE
+        const defaultLocale = await getDefaultLocale()
+        if (defaultLocale) return defaultLocale
       }
     }
   }

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,6 +1,5 @@
 import { env } from '$env/dynamic/private'
 import { api, UnauthorizedError } from '$lib/fastapi-client'
-import { HOST_TO_LOCALE } from '$lib/global.svelte'
 import { defineCustomServerStrategy } from '$lib/i18n/runtime'
 import { paraglideMiddleware } from '$lib/i18n/server'
 import { logger } from '$lib/logger.server'
@@ -12,53 +11,67 @@ import { sequence } from '@sveltejs/kit/hooks'
 const MATOMO_ID = env.MATOMO_ID || ''
 const MATOMO_URL = env.MATOMO_URL || ''
 
-const DEFAULT_LOCALE_CHECK_TTL_MS = 20_000
+const LOCALE_SETTINGS_TTL_MS = 20_000
 
-// Cached per Node process (same rationale as maintenanceCache below): the
-// admin-editable default locale doesn't need to be read from the backend on
-// every single request.
-let defaultLocaleCache: { value: string; checkedAt: number } | null = null
+type LocaleSettings = { enabled_locales: string[]; default_locale: string }
 
-async function getDefaultLocale(): Promise<string> {
+// Cached per Node process (same rationale as maintenanceCache below). The
+// in-flight promise is cached rather than its result, so a cold process fires
+// one request instead of one per concurrent render.
+let localeSettingsCache: { promise: Promise<LocaleSettings>; checkedAt: number } | null = null
+let lastLocaleSettings: LocaleSettings = { enabled_locales: [], default_locale: '' }
+
+function getLocaleSettings(): Promise<LocaleSettings> {
   const now = Date.now()
-  if (!defaultLocaleCache || now - defaultLocaleCache.checkedAt >= DEFAULT_LOCALE_CHECK_TTL_MS) {
-    let value = defaultLocaleCache?.value ?? ''
-    try {
-      ;({ default_locale: value } = await api.request<{ default_locale: string }>('/auth/config'))
-    } catch (error) {
-      // Fail open: fall back to Paraglide's own strategies if the check fails
-      logger.error('Default locale check failed', { error: `${error}` })
+  if (!localeSettingsCache || now - localeSettingsCache.checkedAt >= LOCALE_SETTINGS_TTL_MS) {
+    localeSettingsCache = {
+      checkedAt: now,
+      promise: api
+        .request<Partial<LocaleSettings>>('/auth/config')
+        .then((config) => {
+          lastLocaleSettings = {
+            enabled_locales: config.enabled_locales ?? [],
+            default_locale: config.default_locale ?? ''
+          }
+          return lastLocaleSettings
+        })
+        .catch((error) => {
+          // Fail open: keep serving the last known settings, and let Paraglide's
+          // own strategies decide if we never managed to read any.
+          logger.error('Locale settings fetch failed', { error: `${error}` })
+          return lastLocaleSettings
+        })
     }
-    defaultLocaleCache = { value, checkedAt: now }
   }
-  return defaultLocaleCache.value
+  return localeSettingsCache.promise
 }
 
 defineCustomServerStrategy('custom-url', {
+  // Paraglide runs custom strategies before every built-in one, so this is the
+  // only place that sees all the locale sources at once, and the only place that
+  // can turn one down. It reads PARAGLIDE_LOCALE itself instead of leaving it to
+  // the built-in cookie strategy, because a cookie holding a locale the admin
+  // has since disabled has to be overridden rather than honoured.
+  //
+  // Returning undefined hands over to those built-in strategies, which is what
+  // we want when the backend is unreachable and we have nothing to enforce.
   getLocale: async (request) => {
     if (!request) return
-    const url = new URL(request.url)
-    const locale = url.searchParams.get('locale')
+    const { enabled_locales, default_locale } = await getLocaleSettings()
+    if (!enabled_locales.length) return
 
-    if (url.host in HOST_TO_LOCALE) {
-      return HOST_TO_LOCALE[url.host as keyof typeof HOST_TO_LOCALE]
-    } else if (locale) {
-      return locale
-    } else {
-      // Only apply the default locale if no user cookie is already set.
-      // Paraglide runs custom strategies before built-in ones (including cookie),
-      // so without this check it would silently override the user's locale
-      // preference stored in PARAGLIDE_LOCALE.
-      const cookieLocale = request.headers
-        .get('cookie')
-        ?.split('; ')
-        .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
-        ?.split('=')[1]
-      if (!cookieLocale) {
-        const defaultLocale = await getDefaultLocale()
-        if (defaultLocale) return defaultLocale
-      }
+    const cookieLocale = request.headers
+      .get('cookie')
+      ?.split('; ')
+      .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
+      ?.split('=')[1]
+
+    const requested = new URL(request.url).searchParams.get('locale')
+    for (const candidate of [requested, cookieLocale]) {
+      if (candidate && enabled_locales.includes(candidate)) return candidate
     }
+
+    return default_locale || undefined
   }
 })
 

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -23,6 +23,7 @@ export interface AuthConfig {
   secondary_color_light: string
   secondary_color_dark: string
   homepage_url: string | null
+  enabled_locales: string[]
 }
 
 type AuthCtx = {

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -24,6 +24,7 @@ export interface AuthConfig {
   secondary_color_dark: string
   homepage_url: string | null
   enabled_locales: string[]
+  default_locale: string
 }
 
 type AuthCtx = {

--- a/frontend/src/lib/components/header/LanguageSelector.svelte
+++ b/frontend/src/lib/components/header/LanguageSelector.svelte
@@ -1,29 +1,16 @@
 <script lang="ts">
-  import { page } from '$app/state'
   import { getAuthContext } from '$lib/auth.svelte'
   import Dropdown from '$components/Dropdown.svelte'
-  import { getLocales, type LocaleOption } from '$lib/global.svelte'
+  import { getLocales } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale, setLocale } from '$lib/i18n/runtime'
   import type { SvelteHTMLElements } from 'svelte/elements'
-  import { SvelteURL } from 'svelte/reactivity'
 
   let { id, ...props }: { id: string } & SvelteHTMLElements['nav'] = $props()
 
   const auth = getAuthContext()
   const locales = $derived(getLocales(auth.config.enabled_locales))
   const currentLocale = getLocale()
-
-  function onLocaleSelect(locale: LocaleOption) {
-    if (page.url.host !== locale.host) {
-      const url = new SvelteURL(window.location.href)
-      url.host = locale.host
-      url.search = `locale=${locale.code}`
-      window.location.href = url.href
-    } else {
-      setLocale(locale.code)
-    }
-  }
 </script>
 
 <nav {...props} class={['language-selector fr-translate fr-nav whitespace-nowrap', props.class]}>
@@ -42,7 +29,7 @@
             class="fr-sidemenu__link py-2! font-normal! font-sm!"
             lang={locale.code}
             aria-current={locale.code == currentLocale}
-            onclick={() => onLocaleSelect(locale)}
+            onclick={() => setLocale(locale.code)}
           >
             {locale.long}
           </button>

--- a/frontend/src/lib/components/header/LanguageSelector.svelte
+++ b/frontend/src/lib/components/header/LanguageSelector.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { page } from '$app/state'
+  import { getAuthContext } from '$lib/auth.svelte'
   import Dropdown from '$components/Dropdown.svelte'
-  import { LOCALES, type LocaleOption } from '$lib/global.svelte'
+  import { getLocales, type LocaleOption } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale, setLocale } from '$lib/i18n/runtime'
   import type { SvelteHTMLElements } from 'svelte/elements'
@@ -9,6 +10,8 @@
 
   let { id, ...props }: { id: string } & SvelteHTMLElements['nav'] = $props()
 
+  const auth = getAuthContext()
+  const locales = $derived(getLocales(auth.config.enabled_locales))
   const currentLocale = getLocale()
 
   function onLocaleSelect(locale: LocaleOption) {
@@ -26,13 +29,14 @@
 <nav {...props} class={['language-selector fr-translate fr-nav whitespace-nowrap', props.class]}>
   <Dropdown
     id="dropdown-{id}"
-    label={LOCALES.find((locale) => locale.code === currentLocale)!.short}
+    label={locales.find((locale) => locale.code === currentLocale)?.short ??
+      currentLocale.toUpperCase()}
     title={m['actions.selectLanguage']()}
     buttonClass="fr-translate__btn rounded-sm!"
     closeOnSelect
   >
     <ul class="fr-sidemenu__list">
-      {#each LOCALES as locale (locale.code)}
+      {#each locales as locale (locale.code)}
         <li class="fr-sidemenu__item">
           <button
             class="fr-sidemenu__link py-2! font-normal! font-sm!"

--- a/frontend/src/lib/generated/admin.ts
+++ b/frontend/src/lib/generated/admin.ts
@@ -48,6 +48,7 @@ export interface AppSettingsPatch {
   secondary_color_light?: string | null;
   secondary_color_dark?: string | null;
   homepage_url?: string | null;
+  enabled_locales?: string[] | null;
 }
 export interface AppSettingsPublic {
   auth_access_policy: "anonymous_first" | "sign_in_required";
@@ -60,6 +61,7 @@ export interface AppSettingsPublic {
   secondary_color_dark: string;
   homepage_url: string | null;
   has_custom_logo: boolean;
+  enabled_locales: string[];
   updated_at: string;
   updated_by?: string | null;
 }

--- a/frontend/src/lib/generated/admin.ts
+++ b/frontend/src/lib/generated/admin.ts
@@ -49,6 +49,7 @@ export interface AppSettingsPatch {
   secondary_color_dark?: string | null;
   homepage_url?: string | null;
   enabled_locales?: string[] | null;
+  default_locale?: string | null;
 }
 export interface AppSettingsPublic {
   auth_access_policy: "anonymous_first" | "sign_in_required";
@@ -62,6 +63,7 @@ export interface AppSettingsPublic {
   homepage_url: string | null;
   has_custom_logo: boolean;
   enabled_locales: string[];
+  default_locale: string;
   updated_at: string;
   updated_by?: string | null;
 }

--- a/frontend/src/lib/global.svelte.ts
+++ b/frontend/src/lib/global.svelte.ts
@@ -1,29 +1,23 @@
-import { dev } from '$app/environment'
 import { getLocale, type Locale } from '$lib/i18n/runtime'
 import { getContext, setContext } from 'svelte'
 
-export type LocaleOption = { code: Locale; short: string; long: string; host: string }
+export type LocaleOption = { code: Locale; short: string; long: string }
 
-const DEFAULT_HOST = dev ? 'localhost:5173' : 'comparia.beta.gouv.fr'
-export const HOST_TO_LOCALE = dev
-  ? {
-      '127.0.0.1:8080': 'da'
-    }
-  : {
-      'ai-arenaen.dk': 'da',
-      'aiarenaen.dk': 'da'
-    }
+// Every locale the bundle ships with. Which of them an instance offers is an
+// admin setting (AppSettings.enabled_locales), not a property of the domain:
+// picking a language never moves you to another instance.
 export const ALL_LOCALES = [
-  { code: 'da', short: 'DA', long: 'DA - Dansk', host: dev ? '127.0.0.1:8080' : 'ai-arenaen.dk' },
-  { code: 'fr', short: 'FR', long: 'FR - Français', host: DEFAULT_HOST },
-  { code: 'en', short: 'EN', long: 'EN - English', host: DEFAULT_HOST },
-  { code: 'lt', short: 'LT', long: 'LT - Lietuvių', host: DEFAULT_HOST },
-  { code: 'sv', short: 'SV', long: 'SV - Svensk', host: DEFAULT_HOST }
+  { code: 'da', short: 'DA', long: 'DA - Dansk' },
+  { code: 'fr', short: 'FR', long: 'FR - Français' },
+  { code: 'en', short: 'EN', long: 'EN - English' },
+  { code: 'lt', short: 'LT', long: 'LT - Lietuvių' },
+  { code: 'sv', short: 'SV', long: 'SV - Svensk' }
 ] satisfies LocaleOption[]
 
-// enabledLocales comes from AppSettings (admin-editable, see auth.config),
-// replacing the old build-time PUBLIC_DISABLED_LOCALES env var.
-export function getLocales(enabledLocales: string[]): LocaleOption[] {
+// Falls back to the full list so a frontend deployed ahead of its backend still
+// renders a language menu instead of throwing on a missing field.
+export function getLocales(enabledLocales: string[] | undefined): LocaleOption[] {
+  if (!enabledLocales?.length) return ALL_LOCALES
   return ALL_LOCALES.filter((locale) => enabledLocales.includes(locale.code))
 }
 

--- a/frontend/src/lib/global.svelte.ts
+++ b/frontend/src/lib/global.svelte.ts
@@ -1,11 +1,6 @@
 import { dev } from '$app/environment'
-import { env } from '$env/dynamic/public'
 import { getLocale, type Locale } from '$lib/i18n/runtime'
 import { getContext, setContext } from 'svelte'
-
-const disabledLocaleCodes = env.PUBLIC_DISABLED_LOCALES
-  ? env.PUBLIC_DISABLED_LOCALES.split(',').map((code) => code.trim())
-  : null
 
 export type LocaleOption = { code: Locale; short: string; long: string; host: string }
 
@@ -18,7 +13,7 @@ export const HOST_TO_LOCALE = dev
       'ai-arenaen.dk': 'da',
       'aiarenaen.dk': 'da'
     }
-const ALL_LOCALES = [
+export const ALL_LOCALES = [
   { code: 'da', short: 'DA', long: 'DA - Dansk', host: dev ? '127.0.0.1:8080' : 'ai-arenaen.dk' },
   { code: 'fr', short: 'FR', long: 'FR - Français', host: DEFAULT_HOST },
   { code: 'en', short: 'EN', long: 'EN - English', host: DEFAULT_HOST },
@@ -26,9 +21,11 @@ const ALL_LOCALES = [
   { code: 'sv', short: 'SV', long: 'SV - Svensk', host: DEFAULT_HOST }
 ] satisfies LocaleOption[]
 
-export const LOCALES = ALL_LOCALES.filter((locale) => {
-  return !disabledLocaleCodes?.includes(locale.code)
-})
+// enabledLocales comes from AppSettings (admin-editable, see auth.config),
+// replacing the old build-time PUBLIC_DISABLED_LOCALES env var.
+export function getLocales(enabledLocales: string[]): LocaleOption[] {
+  return ALL_LOCALES.filter((locale) => enabledLocales.includes(locale.code))
+}
 
 export type VotesData = { count: number; objective: number }
 

--- a/frontend/src/routes/(admin)/+layout.svelte
+++ b/frontend/src/routes/(admin)/+layout.svelte
@@ -17,6 +17,11 @@
       icon: 'i-ri-palette-line'
     },
     {
+      label: m['admin.nav.locales'](),
+      href: '/admin/locales',
+      icon: 'i-ri-translate-2'
+    },
+    {
       label: m['admin.nav.authentification'](),
       href: '/admin/authentification',
       icon: 'i-ri-fingerprint-line'

--- a/frontend/src/routes/(admin)/admin/customization/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/customization/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, Checkbox, Input } from '$components/dsfr'
+  import { Button, Checkbox, Input, Select } from '$components/dsfr'
   import ColorInput from '$components/form/ColorInput.svelte'
   import PageLayout from '$components/PageLayout.svelte'
   import { getAuthContext } from '$lib/auth.svelte'
@@ -25,6 +25,7 @@
   let secondaryColorDark = $state('')
   let homepageUrl = $state('')
   let enabledLocales = $state<Record<string, boolean>>({})
+  let defaultLocale = $state('')
   let loadedValues = $state({
     votesObjective: '',
     platformName: '',
@@ -40,6 +41,19 @@
     hasCustomLogo ? `${api.getUrl('/auth/config/logo')}?v=${logoVersion}` : '/orgs/comparia.png'
   )
   const auth = getAuthContext()
+  const defaultLocaleOptions = $derived(
+    ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map((locale) => ({
+      value: locale.code,
+      label: locale.long
+    }))
+  )
+
+  $effect(() => {
+    // Keep the selection valid if the admin unchecks the current default locale
+    if (defaultLocaleOptions.length && !defaultLocaleOptions.some((o) => o.value === defaultLocale)) {
+      defaultLocale = defaultLocaleOptions[0].value
+    }
+  })
 
   async function load() {
     loading = true
@@ -56,6 +70,7 @@
       enabledLocales = Object.fromEntries(
         ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales.includes(locale.code)])
       )
+      defaultLocale = data.default_locale
       loadedValues = { ...currentValues(), votesObjective, platformName }
     } finally {
       loading = false
@@ -132,7 +147,8 @@
         homepage_url: homepageUrl || null,
         enabled_locales: ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map(
           (locale) => locale.code
-        )
+        ),
+        default_locale: defaultLocale
       }
       const saved = await api.request<AppSettingsPublic>('/admin/settings', {
         method: 'PATCH',
@@ -317,6 +333,14 @@
           />
         {/each}
       </div>
+
+      <Select
+        id="settings-default-locale"
+        label={m['admin.settings.customization.defaultLocale.label']()}
+        bind:selected={defaultLocale}
+        options={defaultLocaleOptions}
+        groupClass="mt-4! max-w-[240px]"
+      />
 
       <div class="gap-3 mt-4! flex flex-wrap">
         <Button

--- a/frontend/src/routes/(admin)/admin/customization/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/customization/+page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { Button, Checkbox, Input, Select } from '$components/dsfr'
+  import { Button, Input } from '$components/dsfr'
   import ColorInput from '$components/form/ColorInput.svelte'
   import PageLayout from '$components/PageLayout.svelte'
   import { getAuthContext } from '$lib/auth.svelte'
   import { api } from '$lib/fastapi-client'
   import type { AppSettingsPatch, AppSettingsPublic } from '$lib/generated/admin'
-  import { ALL_LOCALES } from '$lib/global.svelte'
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { m } from '$lib/i18n/messages'
   import { contrastRatio, isHexColor } from '$lib/theme'
@@ -24,8 +23,6 @@
   let secondaryColorLight = $state('')
   let secondaryColorDark = $state('')
   let homepageUrl = $state('')
-  let enabledLocales = $state<Record<string, boolean>>({})
-  let defaultLocale = $state('')
   let loadedValues = $state({
     votesObjective: '',
     platformName: '',
@@ -41,19 +38,6 @@
     hasCustomLogo ? `${api.getUrl('/auth/config/logo')}?v=${logoVersion}` : '/orgs/comparia.png'
   )
   const auth = getAuthContext()
-  const defaultLocaleOptions = $derived(
-    ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map((locale) => ({
-      value: locale.code,
-      label: locale.long
-    }))
-  )
-
-  $effect(() => {
-    // Keep the selection valid if the admin unchecks the current default locale
-    if (defaultLocaleOptions.length && !defaultLocaleOptions.some((o) => o.value === defaultLocale)) {
-      defaultLocale = defaultLocaleOptions[0].value
-    }
-  })
 
   async function load() {
     loading = true
@@ -67,10 +51,6 @@
       secondaryColorLight = data.secondary_color_light
       secondaryColorDark = data.secondary_color_dark
       homepageUrl = data.homepage_url ?? ''
-      enabledLocales = Object.fromEntries(
-        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales.includes(locale.code)])
-      )
-      defaultLocale = data.default_locale
       loadedValues = { ...currentValues(), votesObjective, platformName }
     } finally {
       loading = false
@@ -144,11 +124,7 @@
         primary_color_dark: primaryColorDark.toUpperCase(),
         secondary_color_light: secondaryColorLight.toUpperCase(),
         secondary_color_dark: secondaryColorDark.toUpperCase(),
-        homepage_url: homepageUrl || null,
-        enabled_locales: ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map(
-          (locale) => locale.code
-        ),
-        default_locale: defaultLocale
+        homepage_url: homepageUrl || null
       }
       const saved = await api.request<AppSettingsPublic>('/admin/settings', {
         method: 'PATCH',
@@ -323,25 +299,6 @@
         bind:value={votesObjective}
         groupClass="mt-4!"
       />
-      <div class="mt-4!">
-        <p class="fr-label mb-2!">{m['admin.settings.customization.locales.label']()}</p>
-        {#each ALL_LOCALES as locale (locale.code)}
-          <Checkbox
-            id="settings-locale-{locale.code}"
-            label={locale.long}
-            bind:checked={enabledLocales[locale.code]}
-          />
-        {/each}
-      </div>
-
-      <Select
-        id="settings-default-locale"
-        label={m['admin.settings.customization.defaultLocale.label']()}
-        bind:selected={defaultLocale}
-        options={defaultLocaleOptions}
-        groupClass="mt-4! max-w-[240px]"
-      />
-
       <div class="gap-3 mt-4! flex flex-wrap">
         <Button
           type="submit"

--- a/frontend/src/routes/(admin)/admin/customization/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/customization/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { Button, Input } from '$components/dsfr'
+  import { Button, Checkbox, Input } from '$components/dsfr'
   import ColorInput from '$components/form/ColorInput.svelte'
   import PageLayout from '$components/PageLayout.svelte'
   import { getAuthContext } from '$lib/auth.svelte'
   import { api } from '$lib/fastapi-client'
   import type { AppSettingsPatch, AppSettingsPublic } from '$lib/generated/admin'
+  import { ALL_LOCALES } from '$lib/global.svelte'
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { m } from '$lib/i18n/messages'
   import { contrastRatio, isHexColor } from '$lib/theme'
@@ -23,6 +24,7 @@
   let secondaryColorLight = $state('')
   let secondaryColorDark = $state('')
   let homepageUrl = $state('')
+  let enabledLocales = $state<Record<string, boolean>>({})
   let loadedValues = $state({
     votesObjective: '',
     platformName: '',
@@ -51,6 +53,9 @@
       secondaryColorLight = data.secondary_color_light
       secondaryColorDark = data.secondary_color_dark
       homepageUrl = data.homepage_url ?? ''
+      enabledLocales = Object.fromEntries(
+        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales.includes(locale.code)])
+      )
       loadedValues = { ...currentValues(), votesObjective, platformName }
     } finally {
       loading = false
@@ -124,7 +129,10 @@
         primary_color_dark: primaryColorDark.toUpperCase(),
         secondary_color_light: secondaryColorLight.toUpperCase(),
         secondary_color_dark: secondaryColorDark.toUpperCase(),
-        homepage_url: homepageUrl || null
+        homepage_url: homepageUrl || null,
+        enabled_locales: ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map(
+          (locale) => locale.code
+        )
       }
       const saved = await api.request<AppSettingsPublic>('/admin/settings', {
         method: 'PATCH',
@@ -299,6 +307,17 @@
         bind:value={votesObjective}
         groupClass="mt-4!"
       />
+      <div class="mt-4!">
+        <p class="fr-label mb-2!">{m['admin.settings.customization.locales.label']()}</p>
+        {#each ALL_LOCALES as locale (locale.code)}
+          <Checkbox
+            id="settings-locale-{locale.code}"
+            label={locale.long}
+            bind:checked={enabledLocales[locale.code]}
+          />
+        {/each}
+      </div>
+
       <div class="gap-3 mt-4! flex flex-wrap">
         <Button
           type="submit"

--- a/frontend/src/routes/(admin)/admin/locales/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/locales/+page.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { Button, Checkbox, Select } from '$components/dsfr'
+  import PageLayout from '$components/PageLayout.svelte'
+  import { api } from '$lib/fastapi-client'
+  import type { AppSettingsPatch, AppSettingsPublic } from '$lib/generated/admin'
+  import { ALL_LOCALES } from '$lib/global.svelte'
+  import { useToast } from '$lib/helpers/useToast.svelte'
+  import { m } from '$lib/i18n/messages'
+  import { onMount } from 'svelte'
+
+  let loading = $state(true)
+  let saving = $state(false)
+
+  let enabledLocales = $state<Record<string, boolean>>({})
+  let defaultLocale = $state('')
+
+  const defaultLocaleOptions = $derived(
+    ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map((locale) => ({
+      value: locale.code,
+      label: locale.long
+    }))
+  )
+
+  $effect(() => {
+    // Keep the selection valid if the admin unchecks the current default locale
+    if (
+      defaultLocaleOptions.length &&
+      !defaultLocaleOptions.some((o) => o.value === defaultLocale)
+    ) {
+      defaultLocale = defaultLocaleOptions[0].value
+    }
+  })
+
+  async function load() {
+    loading = true
+    try {
+      const data = await api.request<AppSettingsPublic>('/admin/settings')
+      enabledLocales = Object.fromEntries(
+        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales.includes(locale.code)])
+      )
+      defaultLocale = data.default_locale
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(load)
+
+  async function save(e: SubmitEvent) {
+    e.preventDefault()
+    saving = true
+    try {
+      const patch: AppSettingsPatch = {
+        enabled_locales: ALL_LOCALES.filter((locale) => enabledLocales[locale.code]).map(
+          (locale) => locale.code
+        ),
+        default_locale: defaultLocale
+      }
+      await api.request('/admin/settings', { method: 'PATCH', body: JSON.stringify(patch) })
+      useToast(m['admin.settings.saved'](), 4000)
+    } catch (err) {
+      useToast((err as Error).message, 6000, 'error')
+    } finally {
+      saving = false
+    }
+  }
+</script>
+
+<PageLayout
+  seoTitle={m['admin.nav.locales']()}
+  title={m['admin.nav.locales']()}
+  subtitle={m['admin.settings.subtitle']()}
+>
+  {#if loading}
+    <p class="fr-text--sm text-[--text-mention-grey]">{m['admin.settings.loading']()}</p>
+  {:else}
+    <form onsubmit={save} class="max-w-[480px]">
+      <div>
+        <p class="fr-label mb-2!">{m['admin.settings.locales.enabled.label']()}</p>
+        {#each ALL_LOCALES as locale (locale.code)}
+          <Checkbox
+            id="settings-locale-{locale.code}"
+            label={locale.long}
+            bind:checked={enabledLocales[locale.code]}
+          />
+        {/each}
+      </div>
+
+      <Select
+        id="settings-default-locale"
+        label={m['admin.settings.locales.default.label']()}
+        bind:selected={defaultLocale}
+        options={defaultLocaleOptions}
+        groupClass="mt-4! max-w-[240px]"
+      />
+
+      <Button
+        type="submit"
+        text={saving ? m['admin.settings.saving']() : m['admin.settings.save']()}
+        disabled={saving}
+        class="mt-4!"
+      />
+    </form>
+  {/if}
+</PageLayout>

--- a/frontend/src/routes/(admin)/admin/locales/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/locales/+page.svelte
@@ -35,8 +35,6 @@
     loading = true
     try {
       const data = await api.request<AppSettingsPublic>('/admin/settings')
-      // Unchecking a locale takes it away from visitors already reading in it:
-      // the next request rewrites their PARAGLIDE_LOCALE cookie to the default.
       enabledLocales = Object.fromEntries(
         ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales?.includes(locale.code)])
       )
@@ -79,6 +77,7 @@
     <form onsubmit={save} class="max-w-[480px]">
       <div>
         <p class="fr-label mb-2!">{m['admin.settings.locales.enabled.label']()}</p>
+        <p class="fr-hint-text mt-0! mb-2!">{m['admin.settings.locales.enabled.hint']()}</p>
         {#each ALL_LOCALES as locale (locale.code)}
           <Checkbox
             id="settings-locale-{locale.code}"

--- a/frontend/src/routes/(admin)/admin/locales/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/locales/+page.svelte
@@ -35,8 +35,10 @@
     loading = true
     try {
       const data = await api.request<AppSettingsPublic>('/admin/settings')
+      // Unchecking a locale takes it away from visitors already reading in it:
+      // the next request rewrites their PARAGLIDE_LOCALE cookie to the default.
       enabledLocales = Object.fromEntries(
-        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales.includes(locale.code)])
+        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales?.includes(locale.code)])
       )
       defaultLocale = data.default_locale
     } finally {

--- a/tests/auth/test_account.py
+++ b/tests/auth/test_account.py
@@ -157,6 +157,8 @@ def test_public_config_carries_the_deployment_url():
             secondary_color_dark="#CACAFB",
             homepage_url=None,
             logo=None,
+            enabled_locales=["fr"],
+            default_locale="fr",
         )
 
     with patched(auth_router, get_app_settings=get_app_settings):

--- a/tests/database/test_app_settings_locales.py
+++ b/tests/database/test_app_settings_locales.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
+os.environ["LOG_FORMAT"] = "JSON"
+
+from utils.database.models.app_settings import (
+    SUPPORTED_LOCALES,
+    AppSettings,
+    AppSettingsPatch,
+)
+
+
+def test_a_fresh_instance_enables_every_shipped_locale() -> None:
+    assert AppSettings().enabled_locales == list(SUPPORTED_LOCALES)
+
+
+def test_defaults_are_not_shared_between_instances() -> None:
+    first = AppSettings()
+    first.enabled_locales.append("xx")
+
+    assert AppSettings().enabled_locales == list(SUPPORTED_LOCALES)
+
+
+@pytest.mark.parametrize("locales", [["fr"], ["da", "en"], list(SUPPORTED_LOCALES)])
+def test_supported_locales_are_accepted(locales: list[str]) -> None:
+    assert AppSettingsPatch(enabled_locales=locales).enabled_locales == locales
+
+
+def test_unsupported_locales_are_refused() -> None:
+    with pytest.raises(ValidationError, match="Unsupported locales: de, xx"):
+        AppSettingsPatch(enabled_locales=["fr", "xx", "de"])
+
+
+def test_enabling_no_locale_is_refused() -> None:
+    # An empty list would leave the language menu empty and every visitor stuck
+    # on whatever Paraglide falls back to.
+    with pytest.raises(ValidationError, match="At least one locale"):
+        AppSettingsPatch(enabled_locales=[])
+
+
+def test_unsupported_default_locale_is_refused() -> None:
+    with pytest.raises(ValidationError, match="Unsupported locale: xx"):
+        AppSettingsPatch(default_locale="xx")
+
+
+def test_locales_are_left_alone_when_the_patch_omits_them() -> None:
+    patch = AppSettingsPatch(platform_name="Whatever")
+
+    assert patch.enabled_locales is None
+    assert patch.default_locale is None
+    assert patch.model_dump(exclude_unset=True) == {"platform_name": "Whatever"}

--- a/tests/database/test_app_settings_locales.py
+++ b/tests/database/test_app_settings_locales.py
@@ -10,21 +10,33 @@ os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
 os.environ["LOG_FORMAT"] = "JSON"
 
 from utils.database.models.app_settings import (
+    DEFAULT_ENABLED_LOCALES,
     SUPPORTED_LOCALES,
     AppSettings,
     AppSettingsPatch,
 )
 
 
-def test_a_fresh_instance_enables_every_shipped_locale() -> None:
-    assert AppSettings().enabled_locales == list(SUPPORTED_LOCALES)
+def test_a_fresh_instance_only_enables_the_well_translated_locales() -> None:
+    assert AppSettings().enabled_locales == list(DEFAULT_ENABLED_LOCALES)
+
+
+def test_the_thinly_translated_locales_stay_off_until_an_admin_asks() -> None:
+    # They remain patchable, they just aren't served to anyone by default.
+    off_by_default = set(SUPPORTED_LOCALES) - set(DEFAULT_ENABLED_LOCALES)
+
+    assert off_by_default == {"lt", "sv"}
+    assert AppSettingsPatch(enabled_locales=["fr", "lt"]).enabled_locales == [
+        "fr",
+        "lt",
+    ]
 
 
 def test_defaults_are_not_shared_between_instances() -> None:
     first = AppSettings()
     first.enabled_locales.append("xx")
 
-    assert AppSettings().enabled_locales == list(SUPPORTED_LOCALES)
+    assert AppSettings().enabled_locales == list(DEFAULT_ENABLED_LOCALES)
 
 
 @pytest.mark.parametrize("locales", [["fr"], ["da", "en"], list(SUPPORTED_LOCALES)])

--- a/utils/database/alembic/versions/e3a7c5f19b04_add_enabled_locales.py
+++ b/utils/database/alembic/versions/e3a7c5f19b04_add_enabled_locales.py
@@ -18,6 +18,14 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+# Frozen copy of DEFAULT_ENABLED_LOCALES at the time of this revision. Migrations
+# don't import app code, so this stays right even after the model's list moves on.
+# lt and sv are left out on purpose: this reproduces the PUBLIC_DISABLED_LOCALES
+# ="lt,sv" both instances were deployed with, so nobody gains a half-translated
+# language on upgrade.
+_DEFAULT_ENABLED_LOCALES = '["da", "en", "fr"]'
+
+
 def upgrade() -> None:
     op.add_column(
         'app_settings',
@@ -25,7 +33,7 @@ def upgrade() -> None:
             'enabled_locales',
             postgresql.JSONB(astext_type=sa.Text()),
             nullable=False,
-            server_default='["da", "en", "fr", "lt", "sv"]',
+            server_default=_DEFAULT_ENABLED_LOCALES,
         ),
     )
     op.alter_column('app_settings', 'enabled_locales', server_default=None)

--- a/utils/database/alembic/versions/e3a7c5f19b04_add_enabled_locales.py
+++ b/utils/database/alembic/versions/e3a7c5f19b04_add_enabled_locales.py
@@ -1,7 +1,7 @@
 """add_enabled_locales
 
 Revision ID: e3a7c5f19b04
-Revises: c6a1f3e8d2b7
+Revises: d4f9a1c7e2b8
 Create Date: 2026-07-21 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = 'e3a7c5f19b04'
-down_revision: Union[str, Sequence[str], None] = 'c6a1f3e8d2b7'
+down_revision: Union[str, Sequence[str], None] = 'd4f9a1c7e2b8'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/utils/database/alembic/versions/e3a7c5f19b04_add_enabled_locales.py
+++ b/utils/database/alembic/versions/e3a7c5f19b04_add_enabled_locales.py
@@ -1,0 +1,35 @@
+"""add_enabled_locales
+
+Revision ID: e3a7c5f19b04
+Revises: c6a1f3e8d2b7
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'e3a7c5f19b04'
+down_revision: Union[str, Sequence[str], None] = 'c6a1f3e8d2b7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'app_settings',
+        sa.Column(
+            'enabled_locales',
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default='["da", "en", "fr", "lt", "sv"]',
+        ),
+    )
+    op.alter_column('app_settings', 'enabled_locales', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('app_settings', 'enabled_locales')

--- a/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
+++ b/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
@@ -29,7 +29,18 @@ def _instance_locale() -> str:
     # The da instance used to get its locale from the frontend's DEFAULT_LOCALE
     # env var, which this column replaces. Seed from the backend's own instance
     # name so ai-arenaen.dk doesn't come back up in French after the upgrade.
-    portal = os.environ.get('DEFAULT_COUNTRY_PORTAL', 'fr')
+    #
+    # Refuse to guess when the variable is absent: defaulting to fr here is
+    # exactly how the da database would quietly end up in French. Raising rolls
+    # the whole upgrade back, since env.py wraps the run in one transaction.
+    portal = os.environ.get('DEFAULT_COUNTRY_PORTAL', '').strip()
+    if not portal:
+        raise RuntimeError(
+            'DEFAULT_COUNTRY_PORTAL must be set to run this migration, so the '
+            "instance's own locale is seeded rather than guessed."
+        )
+    # A portal that isn't a locale code (a museum or private instance) is a
+    # deliberate case rather than a mistake: those run in French.
     return portal if portal in _DEFAULT_ENABLED_LOCALES else 'fr'
 
 

--- a/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
+++ b/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
@@ -33,10 +33,10 @@ def _instance_locale() -> str:
     # Refuse to guess when the variable is absent: defaulting to fr here is
     # exactly how the da database would quietly end up in French. Raising rolls
     # the whole upgrade back, since env.py wraps the run in one transaction.
-    portal = os.environ.get('DEFAULT_COUNTRY_PORTAL', '').strip()
+    portal = os.environ.get('COMPARIA_INSTANCE_NAME', '').strip()
     if not portal:
         raise RuntimeError(
-            'DEFAULT_COUNTRY_PORTAL must be set to run this migration, so the '
+            'COMPARIA_INSTANCE_NAME must be set to run this migration, so the '
             "instance's own locale is seeded rather than guessed."
         )
     # A portal that isn't a locale code (a museum or private instance) is a

--- a/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
+++ b/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
@@ -5,6 +5,7 @@ Revises: e3a7c5f19b04
 Create Date: 2026-07-21 00:00:00.000000
 
 """
+import os
 from typing import Sequence, Union
 
 from alembic import op
@@ -17,6 +18,18 @@ down_revision: Union[str, Sequence[str], None] = 'e3a7c5f19b04'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+# Frozen copy of SUPPORTED_LOCALES at the time of this revision. Migrations don't
+# import app code, so this list stays right even after the model's list moves on.
+_SUPPORTED_LOCALES = ('da', 'en', 'fr', 'lt', 'sv')
+
+
+def _instance_locale() -> str:
+    # The da instance used to get its locale from the frontend's DEFAULT_LOCALE
+    # env var, which this column replaces. Seed from the backend's own instance
+    # name so ai-arenaen.dk doesn't come back up in French after the upgrade.
+    portal = os.environ.get('DEFAULT_COUNTRY_PORTAL', 'fr')
+    return portal if portal in _SUPPORTED_LOCALES else 'fr'
+
 
 def upgrade() -> None:
     op.add_column(
@@ -25,7 +38,7 @@ def upgrade() -> None:
             'default_locale',
             sqlmodel.sql.sqltypes.AutoString(),
             nullable=False,
-            server_default='fr',
+            server_default=_instance_locale(),
         ),
     )
     op.alter_column('app_settings', 'default_locale', server_default=None)

--- a/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
+++ b/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
@@ -18,9 +18,11 @@ down_revision: Union[str, Sequence[str], None] = 'e3a7c5f19b04'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
-# Frozen copy of SUPPORTED_LOCALES at the time of this revision. Migrations don't
-# import app code, so this list stays right even after the model's list moves on.
-_SUPPORTED_LOCALES = ('da', 'en', 'fr', 'lt', 'sv')
+# Frozen copy of DEFAULT_ENABLED_LOCALES at the time of this revision. Migrations
+# don't import app code, so this stays right even after the model's list moves on.
+# It is the enabled set rather than the supported one, so the value seeded here is
+# always part of the enabled_locales the previous revision wrote.
+_DEFAULT_ENABLED_LOCALES = ('da', 'en', 'fr')
 
 
 def _instance_locale() -> str:
@@ -28,7 +30,7 @@ def _instance_locale() -> str:
     # env var, which this column replaces. Seed from the backend's own instance
     # name so ai-arenaen.dk doesn't come back up in French after the upgrade.
     portal = os.environ.get('DEFAULT_COUNTRY_PORTAL', 'fr')
-    return portal if portal in _SUPPORTED_LOCALES else 'fr'
+    return portal if portal in _DEFAULT_ENABLED_LOCALES else 'fr'
 
 
 def upgrade() -> None:

--- a/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
+++ b/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
@@ -1,0 +1,35 @@
+"""add_default_locale
+
+Revision ID: f8c2b6a41d70
+Revises: e3a7c5f19b04
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+# revision identifiers, used by Alembic.
+revision: str = 'f8c2b6a41d70'
+down_revision: Union[str, Sequence[str], None] = 'e3a7c5f19b04'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'app_settings',
+        sa.Column(
+            'default_locale',
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            server_default='fr',
+        ),
+    )
+    op.alter_column('app_settings', 'default_locale', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('app_settings', 'default_locale')

--- a/utils/database/models/app_settings.py
+++ b/utils/database/models/app_settings.py
@@ -94,6 +94,13 @@ class AppSettings(SQLModel, table=True):
     homepage_url: str | None = Field(default=None, max_length=_HOMEPAGE_URL_MAX_LENGTH)
     logo: Annotated[bytes | None, Field(sa_type=LargeBinary)] = None
     logo_content_type: str | None = None
+    enabled_locales: Annotated[list[str], Field(sa_type=JSONB)] = [
+        "da",
+        "en",
+        "fr",
+        "lt",
+        "sv",
+    ]
     updated_at: AutoDatetime
     updated_by: uuid.UUID | None = Field(default=None, foreign_key="auth_user.id")
 
@@ -109,6 +116,7 @@ class AppSettingsPublic(SQLModel):
     secondary_color_dark: str
     homepage_url: str | None
     has_custom_logo: bool
+    enabled_locales: list[str]
     updated_at: str
     updated_by: uuid.UUID | None = None
 
@@ -123,6 +131,7 @@ class AppSettingsPatch(SQLModel):
     secondary_color_light: str | None = None
     secondary_color_dark: str | None = None
     homepage_url: str | None = Field(default=None, max_length=_HOMEPAGE_URL_MAX_LENGTH)
+    enabled_locales: list[str] | None = None
 
     @field_validator(
         "primary_color_light",

--- a/utils/database/models/app_settings.py
+++ b/utils/database/models/app_settings.py
@@ -72,6 +72,22 @@ def _normalize_homepage_url(value: object) -> str | None:
     return url
 
 
+# Locales compiled into the frontend bundle, see frontend/comparia.inlang/settings.json.
+# An instance enables a subset of these. Anything outside the tuple is refused
+# rather than stored, because the frontend has no messages for it and would fall
+# back to the base locale without telling anyone.
+SUPPORTED_LOCALES = ("da", "en", "fr", "lt", "sv")
+
+
+def _check_enabled_locales(value: list[str]) -> list[str]:
+    if not value:
+        raise ValueError("At least one locale must be enabled")
+    unknown = sorted(set(value) - set(SUPPORTED_LOCALES))
+    if unknown:
+        raise ValueError(f"Unsupported locales: {', '.join(unknown)}")
+    return value
+
+
 class AppSettings(SQLModel, table=True):
     """Singleton row (id=1) holding product settings editable from the admin panel."""
 
@@ -94,13 +110,9 @@ class AppSettings(SQLModel, table=True):
     homepage_url: str | None = Field(default=None, max_length=_HOMEPAGE_URL_MAX_LENGTH)
     logo: Annotated[bytes | None, Field(sa_type=LargeBinary)] = None
     logo_content_type: str | None = None
-    enabled_locales: Annotated[list[str], Field(sa_type=JSONB)] = [
-        "da",
-        "en",
-        "fr",
-        "lt",
-        "sv",
-    ]
+    enabled_locales: Annotated[list[str], Field(sa_type=JSONB)] = list(
+        SUPPORTED_LOCALES
+    )
     default_locale: str = Field(default="fr")
     updated_at: AutoDatetime
     updated_by: uuid.UUID | None = Field(default=None, foreign_key="auth_user.id")
@@ -165,3 +177,15 @@ class AppSettingsPatch(SQLModel):
     @classmethod
     def normalize_homepage_url(cls, value: object) -> str | None:
         return _normalize_homepage_url(value)
+
+    @field_validator("enabled_locales")
+    @classmethod
+    def validate_enabled_locales(cls, value: list[str] | None) -> list[str] | None:
+        return value if value is None else _check_enabled_locales(value)
+
+    @field_validator("default_locale")
+    @classmethod
+    def validate_default_locale(cls, value: str | None) -> str | None:
+        if value is not None and value not in SUPPORTED_LOCALES:
+            raise ValueError(f"Unsupported locale: {value}")
+        return value

--- a/utils/database/models/app_settings.py
+++ b/utils/database/models/app_settings.py
@@ -101,6 +101,7 @@ class AppSettings(SQLModel, table=True):
         "lt",
         "sv",
     ]
+    default_locale: str = Field(default="fr")
     updated_at: AutoDatetime
     updated_by: uuid.UUID | None = Field(default=None, foreign_key="auth_user.id")
 
@@ -117,6 +118,7 @@ class AppSettingsPublic(SQLModel):
     homepage_url: str | None
     has_custom_logo: bool
     enabled_locales: list[str]
+    default_locale: str
     updated_at: str
     updated_by: uuid.UUID | None = None
 
@@ -132,6 +134,7 @@ class AppSettingsPatch(SQLModel):
     secondary_color_dark: str | None = None
     homepage_url: str | None = Field(default=None, max_length=_HOMEPAGE_URL_MAX_LENGTH)
     enabled_locales: list[str] | None = None
+    default_locale: str | None = None
 
     @field_validator(
         "primary_color_light",

--- a/utils/database/models/app_settings.py
+++ b/utils/database/models/app_settings.py
@@ -78,6 +78,13 @@ def _normalize_homepage_url(value: object) -> str | None:
 # back to the base locale without telling anyone.
 SUPPORTED_LOCALES = ("da", "en", "fr", "lt", "sv")
 
+# What a new instance starts with, and what the migration backfills onto the
+# existing ones. Narrower than SUPPORTED_LOCALES: lt and sv ship far too few
+# translated messages to be offered unasked, which is why prod carried
+# PUBLIC_DISABLED_LOCALES="lt,sv". An admin can still turn them on from
+# /admin/locales, which is the point of the setting.
+DEFAULT_ENABLED_LOCALES = ("da", "en", "fr")
+
 
 def _check_enabled_locales(value: list[str]) -> list[str]:
     if not value:
@@ -111,7 +118,7 @@ class AppSettings(SQLModel, table=True):
     logo: Annotated[bytes | None, Field(sa_type=LargeBinary)] = None
     logo_content_type: str | None = None
     enabled_locales: Annotated[list[str], Field(sa_type=JSONB)] = list(
-        SUPPORTED_LOCALES
+        DEFAULT_ENABLED_LOCALES
     )
     default_locale: str = Field(default="fr")
     updated_at: AutoDatetime

--- a/utils/database/settings.py
+++ b/utils/database/settings.py
@@ -6,14 +6,14 @@ from utils.database.models.app_settings import DEFAULT_ENABLED_LOCALES, AppSetti
 from utils.database.session import get_session
 from utils.storage.redis import REDIS_APP_SETTINGS_KEY, invalidate_cache, redis_cache
 
-# DEFAULT_COUNTRY_PORTAL names the instance and happens to be a locale code on
-# the fr and da instances. One-off instances name themselves something else, so
-# fall back to fr rather than seeding a locale the frontend can't render.
+# The instance name happens to be a locale code on fr and da. One-off instances
+# name themselves something else, so fall back to fr rather than seeding a
+# locale the frontend can't render.
 # Matched against the enabled set, not the supported one, to keep the default
 # locale inside enabled_locales the way PATCH /admin/settings demands.
 _INSTANCE_LOCALE = (
-    settings.DEFAULT_COUNTRY_PORTAL
-    if settings.DEFAULT_COUNTRY_PORTAL in DEFAULT_ENABLED_LOCALES
+    settings.COMPARIA_INSTANCE_NAME
+    if settings.COMPARIA_INSTANCE_NAME in DEFAULT_ENABLED_LOCALES
     else "fr"
 )
 

--- a/utils/database/settings.py
+++ b/utils/database/settings.py
@@ -10,6 +10,7 @@ _DEFAULTS = AppSettings(
     auth_access_policy=settings.AUTH_ACCESS_POLICY,
     auth_domain_allowlist=settings.AUTH_DOMAIN_ALLOWLIST,
     votes_objective=settings.VOTES_OBJECTIVE,
+    enabled_locales=["da", "en", "fr", "lt", "sv"],
 )
 
 

--- a/utils/database/settings.py
+++ b/utils/database/settings.py
@@ -2,16 +2,18 @@ import uuid
 from datetime import datetime
 
 from backend.config import settings
-from utils.database.models.app_settings import SUPPORTED_LOCALES, AppSettings
+from utils.database.models.app_settings import DEFAULT_ENABLED_LOCALES, AppSettings
 from utils.database.session import get_session
 from utils.storage.redis import REDIS_APP_SETTINGS_KEY, invalidate_cache, redis_cache
 
 # DEFAULT_COUNTRY_PORTAL names the instance and happens to be a locale code on
 # the fr and da instances. One-off instances name themselves something else, so
 # fall back to fr rather than seeding a locale the frontend can't render.
+# Matched against the enabled set, not the supported one, to keep the default
+# locale inside enabled_locales the way PATCH /admin/settings demands.
 _INSTANCE_LOCALE = (
     settings.DEFAULT_COUNTRY_PORTAL
-    if settings.DEFAULT_COUNTRY_PORTAL in SUPPORTED_LOCALES
+    if settings.DEFAULT_COUNTRY_PORTAL in DEFAULT_ENABLED_LOCALES
     else "fr"
 )
 

--- a/utils/database/settings.py
+++ b/utils/database/settings.py
@@ -2,15 +2,24 @@ import uuid
 from datetime import datetime
 
 from backend.config import settings
-from utils.database.models.app_settings import AppSettings
+from utils.database.models.app_settings import SUPPORTED_LOCALES, AppSettings
 from utils.database.session import get_session
 from utils.storage.redis import REDIS_APP_SETTINGS_KEY, invalidate_cache, redis_cache
+
+# DEFAULT_COUNTRY_PORTAL names the instance and happens to be a locale code on
+# the fr and da instances. One-off instances name themselves something else, so
+# fall back to fr rather than seeding a locale the frontend can't render.
+_INSTANCE_LOCALE = (
+    settings.DEFAULT_COUNTRY_PORTAL
+    if settings.DEFAULT_COUNTRY_PORTAL in SUPPORTED_LOCALES
+    else "fr"
+)
 
 _DEFAULTS = AppSettings(
     auth_access_policy=settings.AUTH_ACCESS_POLICY,
     auth_domain_allowlist=settings.AUTH_DOMAIN_ALLOWLIST,
     votes_objective=settings.VOTES_OBJECTIVE,
-    enabled_locales=["da", "en", "fr", "lt", "sv"],
+    default_locale=_INSTANCE_LOCALE,
 )
 
 

--- a/utils/ranking/run.py
+++ b/utils/ranking/run.py
@@ -38,7 +38,7 @@ def store_to_redis(data: RankingResult) -> None:
             value=json.dumps(data),
         )
         logger.info(
-            f"[SESSION] Stored ranking data for {settings.DEFAULT_COUNTRY_PORTAL}"
+            f"[SESSION] Stored ranking data for {settings.COMPARIA_INSTANCE_NAME}"
         )
     except Exception as e:
         logger.error(f"[SESSION] Error storing ranking data: {e}")

--- a/utils/storage/redis.py
+++ b/utils/storage/redis.py
@@ -14,12 +14,11 @@ logger = logging.getLogger("languia")
 P = ParamSpec("P")
 RT = TypeVar("RT")
 
-# TODO drop DEFAULT_COUNTRY_PORTAL env var + add REDIS_INSTANCE_PREFIX?
 REDIS_INSTANCE_PREFIX: Final[str] = (
-    f"{settings.DEFAULT_COUNTRY_PORTAL}:" if settings.DEFAULT_COUNTRY_PORTAL else ""
+    f"{settings.COMPARIA_INSTANCE_NAME}:" if settings.COMPARIA_INSTANCE_NAME else ""
 )
 
-# Redis keys (all namespaced by instance portal prefix)
+# Redis keys (all namespaced by the instance prefix)
 REDIS_COMPARISON_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}comparison:{{id}}"
 REDIS_USER_CHAR_COUNT: Final[str] = f"{REDIS_INSTANCE_PREFIX}pricey_chars:{{key}}"
 REDIS_BLOCKED_COUNT_KEY: Final[str] = f"{REDIS_INSTANCE_PREFIX}guardrail_blocked:{{ip}}"
@@ -76,7 +75,7 @@ def get_maintenance_mode() -> bool:
 
 def maintenance_key_for_instance(instance: str) -> str:
     """Build the maintenance mode key for an arbitrary instance (fr, da, ...),
-    regardless of the current process' own DEFAULT_COUNTRY_PORTAL."""
+    regardless of the current process' own COMPARIA_INSTANCE_NAME."""
     return f"{instance}:maintenance_mode"
 
 


### PR DESCRIPTION
## Summary

- Add `enabled_locales` and `default_locale` to the `app_settings` singleton (admin-editable), replacing the build-time `PUBLIC_DISABLED_LOCALES` and frontend `DEFAULT_LOCALE` env vars
- Expose both publicly via `/auth/config`
- Language selector now reads the enabled locale list from context instead of a static build-time constant
- `hooks.server.ts`'s locale resolution is now async and fetches `default_locale` from the backend (short TTL cache, same pattern as the existing maintenance check)
- New dedicated `/admin/locales` admin page: checkboxes for enabled locales + a default-locale dropdown (limited to currently-enabled locales)
- Server-side guard: `PATCH /admin/settings` rejects a `default_locale` that isn't part of `enabled_locales`

See `ignored_files/admin_locales_plan.md` (local, not committed) for the full design notes and open questions (scope limited to the 5 locales already wired in `comparia.inlang/settings.json`; the extra Weblate-only translation files are not covered here).

## Changes

- `utils/database/models/app_settings.py`, two new Alembic migrations, `utils/database/settings.py`: `enabled_locales` and `default_locale` fields
- `backend/admin/router.py`: `PATCH /admin/settings` validation (default_locale must be in enabled_locales) + response fields
- `backend/auth/router.py`: `AuthConfig.enabled_locales` / `AuthConfig.default_locale`
- `frontend/src/lib/auth.svelte.ts`: `AuthConfig` type
- `frontend/src/lib/global.svelte.ts`, `frontend/src/lib/components/header/LanguageSelector.svelte`: dynamic locale list from context
- `frontend/src/hooks.server.ts`: async `getLocale`, backend-fetched `default_locale` with a 20s cache
- `frontend/src/routes/(admin)/admin/locales/+page.svelte`: new admin page (locale checkboxes + default locale select)
- `frontend/src/routes/(admin)/+layout.svelte`: nav entry for the new page
- `frontend/locales/messages/{fr,en,da}.json`: new i18n keys

## Test plan

- [x] Toggle a locale off in admin settings, confirm it disappears from the language selector
- [x] Confirm the server rejects a default_locale outside enabled_locales (400) — verified via curl
- [x] Confirm the default locale dropdown only offers currently-enabled locales, and snaps to a valid one if the current default gets unchecked
- [x] Confirm a fresh visitor (no cookie) gets the configured default_locale
- [x] Confirm existing locale switching (including DA host redirect) still works