### PR TITLE
Improve account settings and legal access

### DIFF
--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -18,6 +18,7 @@ from backend.auth.email import send_login_code
 from backend.auth.services import (
     _hash,
     accept_invite,
+    erase_user_account,
     get_anonymous_consent_status,
     get_consent_status,
     get_invite_token_info,
@@ -52,6 +53,7 @@ class AuthConfig(BaseModel):
     smtp_configured: bool
     domain_allowlist: list[str]
     platform_name: str
+    platform_url: str
     has_custom_logo: bool
 
 
@@ -129,6 +131,7 @@ async def get_config() -> AuthConfig:
         smtp_configured=bool(settings.SMTP_HOST),
         domain_allowlist=app_settings.auth_domain_allowlist,
         platform_name=app_settings.platform_name,
+        platform_url=settings.COMPARIA_APP_URL,
         has_custom_logo=app_settings.logo is not None,
     )
 
@@ -378,6 +381,25 @@ async def accept_authenticated_consent(
 @router.get("/consent")
 async def consent_status(user: RequiredUser) -> dict:
     return await get_consent_status(user.id)
+
+
+class AccountEraseBody(BaseModel):
+    email: EmailStr
+
+
+@router.delete("/me", status_code=status.HTTP_204_NO_CONTENT)
+async def erase_account(
+    body: AccountEraseBody,
+    user: RequiredUser,
+    response: Response,
+) -> None:
+    if body.email.lower() != user.email.lower():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email confirmation does not match the signed-in account.",
+        )
+    await erase_user_account(user.id)
+    response.delete_cookie("auth_session")
 
 
 class AnonymousConsentBody(BaseModel):

--- a/backend/auth/services.py
+++ b/backend/auth/services.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Protocol
 
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import update as sa_update
 from sqlmodel import select
 
@@ -521,3 +522,45 @@ async def has_current_terms_acceptance(
         )
         is not None
     )
+
+
+async def erase_user_account(user_id: uuid.UUID) -> None:
+    now = datetime.now()
+    async with get_session() as session:
+        user = await session.get(User, user_id)
+        if not user or user.deleted_at is not None:
+            return
+
+        await session.execute(
+            sa_update(AuthSession)
+            .where(AuthSession.user_id == user_id)
+            .values(revoked_at=now, ip="erased", user_agent=None)
+        )
+        await session.execute(
+            sa_update(ConsentLog)
+            .where(ConsentLog.user_id == user_id)
+            .values(ip="erased")
+        )
+        await session.execute(
+            sa_update(ConsentLog)
+            .where(
+                ConsentLog.user_id == user_id,
+                ConsentLog.purpose == "research_data_sharing",
+                ConsentLog.withdrawn_at.is_(None),
+            )
+            .values(withdrawn_at=now)
+        )
+        await session.execute(
+            sa_update(Comparison)
+            .where(Comparison.user_id == user_id)
+            .values(user_id=None)
+        )
+        await session.execute(sa_delete(LoginCode).where(LoginCode.user_id == user_id))
+        await session.execute(
+            sa_delete(InviteToken).where(InviteToken.user_id == user_id)
+        )
+
+        user.email = f"deleted-{user.id}@deleted.invalid"
+        user.deleted_at = now
+        session.add(user)
+        await session.commit()

--- a/frontend/src/lib/auth.svelte.ts
+++ b/frontend/src/lib/auth.svelte.ts
@@ -15,6 +15,7 @@ export interface AuthConfig {
   smtp_configured: boolean
   domain_allowlist: string[]
   platform_name: string
+  platform_url: string
   has_custom_logo: boolean
 }
 
@@ -42,15 +43,15 @@ export function openSignInModal(): void {
   }
 }
 
-export async function logout(auth: AuthCtx, comparisons: ComparisonsCtx): Promise<void> {
+export async function logout(auth: AuthCtx, comparisons?: ComparisonsCtx): Promise<void> {
   try {
     await api.request<void>('/auth/logout', { method: 'POST' })
-    try {
-      await updateComparisonsContext(comparisons)
-    } catch {
-      // Session is already cleared server-side; querying again can fail
-      // (eg. sign_in_required policy blocks /arena/* without a session).
-      comparisons.length = 0
+    if (comparisons) {
+      try {
+        await updateComparisonsContext(comparisons)
+      } catch {
+        comparisons.length = 0
+      }
     }
   } finally {
     auth.user = null

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -149,6 +149,12 @@ export const modeInfos: ModeInfos[] = (
 export type ComparisonsCtx = Comparison[]
 export const [getComparisonsContext, setComparisonsContext] = createContext<ComparisonsCtx>()
 
+function copyKeywordAnnotations(
+  annotations: APIComparisonTurn['keyword_annotations_a']
+): ComparisonTurnSide['keyword_annotations'] {
+  return [...annotations] as ComparisonTurnSide['keyword_annotations']
+}
+
 function parseAPITurn(turn: APIComparisonTurn): ComparisonTurn {
   const status = !turn.llm_msg_a && !turn.llm_msg_b ? 'pending' : 'complete'
   return {
@@ -159,14 +165,14 @@ function parseAPITurn(turn: APIComparisonTurn): ComparisonTurn {
     a: {
       status: !turn.llm_msg_a ? 'pending' : 'complete',
       llm_msg: turn.llm_msg_a,
-      custom_annotation: '',
-      keyword_annotations: []
+      custom_annotation: turn.custom_annotation_a ?? '',
+      keyword_annotations: copyKeywordAnnotations(turn.keyword_annotations_a)
     },
     b: {
       status: !turn.llm_msg_b ? 'pending' : 'complete',
       llm_msg: turn.llm_msg_b,
-      custom_annotation: '',
-      keyword_annotations: []
+      custom_annotation: turn.custom_annotation_b ?? '',
+      keyword_annotations: copyKeywordAnnotations(turn.keyword_annotations_b)
     }
   }
 }

--- a/frontend/src/lib/components/AccessibilityPage.svelte.test.ts
+++ b/frontend/src/lib/components/AccessibilityPage.svelte.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import { render } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import AccessibilityPage from '../../routes/arene/accessibilite/+page.svelte'
+
+const auth = {
+  config: { platform_url: 'https://arena.example.test', platform_name: 'Plateforme de test' }
+}
+
+vi.mock('$lib/auth.svelte', () => ({ getAuthContext: () => auth }))
+
+describe('Accessibility declaration', () => {
+  it('uses the canonical deployment domain in the declaration', () => {
+    const { container } = render(AccessibilityPage)
+
+    expect(container.textContent).toContain('arena.example.test')
+    expect(container.textContent).not.toContain('comparia.beta.gouv.fr')
+  })
+
+  it('falls back to the platform name when its URL is invalid', () => {
+    auth.config.platform_url = '://invalid'
+    const { container } = render(AccessibilityPage)
+
+    expect(container.textContent).toContain('Plateforme de test')
+    auth.config.platform_url = 'https://arena.example.test'
+  })
+})

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -13,8 +13,6 @@
       { href: '/mentions-legales', labelKey: 'legal' },
       { href: '/modalites', labelKey: 'tos' },
       { href: '/donnees-personnelles', labelKey: 'privacy' },
-      { href: '/accessibilite', labelKey: 'accessibility' },
-      { href: '/ecoconception', labelKey: 'rgesn' },
       { href: 'https://github.com/betagouv/languia', labelKey: 'sources' }
     ] as const
   ).map(({ href, labelKey }) => {

--- a/frontend/src/lib/components/SettingsPage.svelte.test.ts
+++ b/frontend/src/lib/components/SettingsPage.svelte.test.ts
@@ -1,0 +1,46 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import Page from '../../routes/arene/parametres/+page.svelte'
+
+vi.mock('$lib/auth.svelte', () => ({
+  getAuthContext: () => ({ user: { email: 'utilisateur@example.test' } }),
+  logout: vi.fn()
+}))
+
+vi.mock('$lib/chatService.svelte', () => ({
+  getComparisonsContext: () => []
+}))
+
+vi.mock('$lib/fastapi-client', () => ({
+  api: { request: vi.fn() }
+}))
+
+vi.mock('$lib/consent', () => ({
+  withdrawLocalConsent: vi.fn()
+}))
+
+describe('Settings page', () => {
+  it('groups account actions and legal information into two tabs', async () => {
+    const { getByRole, getByLabelText, queryByRole } = render(Page)
+
+    expect(getByRole('heading', { level: 1, name: 'Paramètres' })).toBeTruthy()
+    expect(getByRole('tab', { name: 'Compte', selected: true })).toBeTruthy()
+    expect(getByLabelText('Adresse électronique')).toBeDisabled()
+    expect(getByRole('button', { name: 'Se déconnecter' })).toBeTruthy()
+    expect(getByRole('button', { name: 'Exporter mes données' })).toBeTruthy()
+
+    await fireEvent.click(getByRole('tab', { name: 'À propos' }))
+
+    expect(getByRole('heading', { name: 'Liens utiles' })).toBeTruthy()
+    expect(getByRole('link', { name: 'Conditions générales d’utilisation' })).toHaveAttribute(
+      'href',
+      '/arene/modalites'
+    )
+    expect(getByRole('link', { name: 'Politique de confidentialité' })).toHaveAttribute(
+      'href',
+      '/arene/donnees-personnelles'
+    )
+    expect(queryByRole('link', { name: 'Mentions légales' })).toBeNull()
+    expect(queryByRole('heading', { name: 'Profil' })).toBeNull()
+  })
+})

--- a/frontend/src/lib/components/ThemeSelector.svelte
+++ b/frontend/src/lib/components/ThemeSelector.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import lightPictoSrc from '@gouvfr/dsfr/dist/artwork/pictograms/environment/sun.svg?no-inline'
   import darkPictoSrc from '@gouvfr/dsfr/dist/artwork/pictograms/environment/moon.svg?no-inline'
   import systemPictoSrc from '@gouvfr/dsfr/dist/artwork/pictograms/system/system.svg?no-inline'
+  import { Select } from '$components/dsfr'
   import { m } from '$lib/i18n/messages'
+
+  type Theme = 'light' | 'dark' | 'system'
+
+  let { variant = 'button' }: { variant?: 'button' | 'select' } = $props()
+  let selectedTheme = $state<Theme>('system')
 
   const options = [
     { value: 'light', label: m['components.theme.options.light'](), imgSrc: lightPictoSrc },
@@ -13,95 +20,125 @@
       subLabel: m['components.theme.options.systemSub'](),
       imgSrc: systemPictoSrc
     }
-  ]
+  ] satisfies { value: Theme; label: string; subLabel?: string; imgSrc: string }[]
+
+  onMount(() => {
+    const currentTheme = document.documentElement.getAttribute('data-fr-scheme')
+    if (currentTheme === 'light' || currentTheme === 'dark' || currentTheme === 'system') {
+      selectedTheme = currentTheme
+    }
+  })
+
+  function selectTheme(event: Event) {
+    const value = (event.currentTarget as HTMLSelectElement).value
+    if (value !== 'light' && value !== 'dark' && value !== 'system') return
+
+    selectedTheme = value
+    const dsfr = (
+      window as typeof window & {
+        dsfr: (element: HTMLElement) => { scheme: { scheme: Theme } }
+      }
+    ).dsfr
+    dsfr(document.documentElement).scheme.scheme = value
+  }
 </script>
 
-<button
-  aria-controls="footer-display"
-  data-fr-opened="false"
-  class="fr-icon-theme-fill fr-btn--icon-left fr-footer__bottom-link"
->
-  {m['components.theme.title']()}
-</button>
+{#if variant === 'select'}
+  <Select
+    id="display-theme"
+    label={m['components.theme.title']()}
+    {options}
+    selected={selectedTheme}
+    onchange={selectTheme}
+  />
+{:else}
+  <button
+    aria-controls="footer-display"
+    data-fr-opened="false"
+    class="fr-icon-theme-fill fr-btn--icon-left fr-footer__bottom-link"
+  >
+    {m['components.theme.title']()}
+  </button>
 
-<dialog id="footer-display" aria-labelledby="footer-display-title" class="fr-modal">
-  <div class="fr-container fr-container--fluid fr-container-md">
-    <div class="fr-grid-row fr-grid-row--center">
-      <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-        <div class="fr-modal__body">
-          <div class="fr-modal__header">
-            <button
-              aria-controls="footer-display"
-              title={m['closeModal']()}
-              type="button"
-              id="button-14"
-              class="fr-btn--close fr-btn"
-            >
-              {m['words.close']()}
-            </button>
-          </div>
-          <div class="fr-modal__content">
-            <h2 id="footer-display-title" class="fr-modal__title">
-              {m['components.theme.title']()}
-            </h2>
-            <div id="fr-display" class="fr-display">
-              <fieldset
-                class="fr-fieldset"
-                id="display-fieldset"
-                aria-labelledby="display-fieldset-legend display-fieldset-messages"
+  <dialog id="footer-display" aria-labelledby="footer-display-title" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+      <div class="fr-grid-row fr-grid-row--center">
+        <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
+          <div class="fr-modal__body">
+            <div class="fr-modal__header">
+              <button
+                aria-controls="footer-display"
+                title={m['closeModal']()}
+                type="button"
+                id="button-14"
+                class="fr-btn--close fr-btn"
               >
-                <legend
-                  class="fr-fieldset__legend--regular fr-fieldset__legend"
-                  id="display-fieldset-legend"
+                {m['words.close']()}
+              </button>
+            </div>
+            <div class="fr-modal__content">
+              <h2 id="footer-display-title" class="fr-modal__title">
+                {m['components.theme.title']()}
+              </h2>
+              <div id="fr-display" class="fr-display">
+                <fieldset
+                  class="fr-fieldset"
+                  id="display-fieldset"
+                  aria-labelledby="display-fieldset-legend display-fieldset-messages"
                 >
-                  {m['components.theme.legend']()}
-                </legend>
+                  <legend
+                    class="fr-fieldset__legend--regular fr-fieldset__legend"
+                    id="display-fieldset-legend"
+                  >
+                    {m['components.theme.legend']()}
+                  </legend>
 
-                {#each options as option (option.value)}
-                  <div class="fr-fieldset__element">
-                    <div class="fr-radio-group fr-radio-rich">
-                      <input
-                        value={option.value}
-                        type="radio"
-                        id="fr-radios-theme-{option.value}"
-                        name="fr-radios-theme"
-                      />
-                      <label class="fr-label" for="fr-radios-theme-{option.value}">
-                        {option.label}
-                        {#if option.subLabel}
-                          <span class="fr-hint-text">{option.subLabel}</span>
-                        {/if}
-                      </label>
-                      <div class="fr-radio-rich__pictogram">
-                        <svg
-                          aria-hidden="true"
-                          class="fr-artwork"
-                          viewBox="0 0 80 80"
-                          width="80px"
-                          height="80px"
-                        >
-                          <use
-                            class="fr-artwork-decorative"
-                            href={option.imgSrc + '#artwork-decorative'}
-                          />
-                          <use class="fr-artwork-minor" href={option.imgSrc + '#artwork-minor'} />
-                          <use class="fr-artwork-major" href={option.imgSrc + '#artwork-major'} />
-                        </svg>
+                  {#each options as option (option.value)}
+                    <div class="fr-fieldset__element">
+                      <div class="fr-radio-group fr-radio-rich">
+                        <input
+                          value={option.value}
+                          type="radio"
+                          id="fr-radios-theme-{option.value}"
+                          name="fr-radios-theme"
+                        />
+                        <label class="fr-label" for="fr-radios-theme-{option.value}">
+                          {option.label}
+                          {#if option.subLabel}
+                            <span class="fr-hint-text">{option.subLabel}</span>
+                          {/if}
+                        </label>
+                        <div class="fr-radio-rich__pictogram">
+                          <svg
+                            aria-hidden="true"
+                            class="fr-artwork"
+                            viewBox="0 0 80 80"
+                            width="80px"
+                            height="80px"
+                          >
+                            <use
+                              class="fr-artwork-decorative"
+                              href={option.imgSrc + '#artwork-decorative'}
+                            />
+                            <use class="fr-artwork-minor" href={option.imgSrc + '#artwork-minor'} />
+                            <use class="fr-artwork-major" href={option.imgSrc + '#artwork-major'} />
+                          </svg>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                {/each}
+                  {/each}
 
-                <div
-                  class="fr-messages-group"
-                  id="display-fieldset-messages"
-                  aria-live="polite"
-                ></div>
-              </fieldset>
+                  <div
+                    class="fr-messages-group"
+                    id="display-fieldset-messages"
+                    aria-live="polite"
+                  ></div>
+                </fieldset>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</dialog>
+  </dialog>
+{/if}

--- a/frontend/src/lib/components/ThemeSelector.svelte.test.ts
+++ b/frontend/src/lib/components/ThemeSelector.svelte.test.ts
@@ -1,0 +1,44 @@
+import { fireEvent, render, waitFor } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ThemeSelector from './ThemeSelector.svelte'
+
+describe('ThemeSelector', () => {
+  const scheme = { scheme: 'system' }
+  const dsfr = vi.fn(() => ({ scheme }))
+
+  beforeEach(() => {
+    scheme.scheme = 'system'
+    dsfr.mockClear()
+    vi.stubGlobal('dsfr', dsfr)
+  })
+
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-fr-scheme')
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a directly accessible theme select', () => {
+    const { getByRole, queryByRole } = render(ThemeSelector, { variant: 'select' })
+
+    const select = getByRole('combobox', { name: "Paramètres d'affichage" })
+    expect(select).toBeTruthy()
+    expect(select.textContent).toContain('Thème clair')
+    expect(select.textContent).toContain('Thème sombre')
+    expect(select.textContent).toContain('Système')
+    expect(queryByRole('dialog')).toBeNull()
+  })
+
+  it('uses the current scheme and applies a selected theme', async () => {
+    document.documentElement.setAttribute('data-fr-scheme', 'dark')
+    const { getByRole } = render(ThemeSelector, { variant: 'select' })
+    const select = getByRole('combobox', {
+      name: "Paramètres d'affichage"
+    }) as HTMLSelectElement
+
+    await waitFor(() => expect(select.value).toBe('dark'))
+    await fireEvent.change(select, { target: { value: 'light' } })
+
+    expect(dsfr).toHaveBeenCalledWith(document.documentElement)
+    expect(scheme.scheme).toBe('light')
+  })
+})

--- a/frontend/src/lib/components/dsfr/Tabs.svelte
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte
@@ -25,18 +25,39 @@
     tab?: Snippet<[T]>
   } & SvelteHTMLElements['div'] = $props()
 
-  let currentTabId = $state(initialId)
+  const getInitialId = () => initialId
+  let currentTabId = $state(getInitialId())
+
+  function selectTab(index: number) {
+    const tab = tabs[index]
+    if (!tab) return
+    currentTabId = tab.id
+    queueMicrotask(() => document.getElementById(`tab-${tab.id}`)?.focus())
+  }
+
+  function handleKeydown(event: KeyboardEvent, index: number) {
+    let nextIndex: number | undefined
+    if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length
+    if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length
+    if (event.key === 'Home') nextIndex = 0
+    if (event.key === 'End') nextIndex = tabs.length - 1
+    if (nextIndex === undefined) return
+
+    event.preventDefault()
+    selectTab(nextIndex)
+  }
 
   const items = $derived.by(() =>
-    tabs.map((tab) => ({
+    tabs.map((tab, index) => ({
       props: {
         id: `tab-${tab.id}`,
-        tabindex: tab.id === initialId ? 0 : -1,
+        tabindex: tab.id === currentTabId ? 0 : -1,
         role: 'tab',
-        'aria-selected': tab.id === initialId ? true : false,
+        'aria-selected': tab.id === currentTabId ? true : false,
         'aria-controls': `tab-${tab.id}-panel`,
         class: kind === 'tab' ? 'fr-tabs__tab' : 'fr-nav__link',
-        onclick: () => (currentTabId = tab.id)
+        onclickcapture: () => (currentTabId = tab.id),
+        onkeydowncapture: (event: KeyboardEvent) => handleKeydown(event, index)
       },
       ...tab
     }))
@@ -67,23 +88,22 @@
     {/each}
   </ul>
   {#each tabs as item, i (i)}
-    <div
-      id={`tab-${item.id}-panel`}
-      role="tabpanel"
-      aria-labelledby={`tab-${item.id}`}
-      tabindex="0"
-      class={[
-        'fr-tabs__panel',
-        {
-          'fr-tabs__panel--selected': item.id === initialId,
-          'px-0! py-5!': noBorders,
-          'visibility-none! transition-none!': item.href && item.id !== currentTabId
-        },
-        panelClass
-      ]}
-    >
-      {#if item.content}{item.content}{:else}{@render tab?.(item)}{/if}
-    </div>
+    {#if item.id === currentTabId}
+      <div
+        id={`tab-${item.id}-panel`}
+        role="tabpanel"
+        aria-labelledby={`tab-${item.id}`}
+        tabindex="0"
+        class={[
+          'fr-tabs__panel',
+          'fr-tabs__panel--selected',
+          { 'px-0! py-5!': noBorders },
+          panelClass
+        ]}
+      >
+        {#if item.content}{item.content}{:else}{@render tab?.(item)}{/if}
+      </div>
+    {/if}
   {/each}
 </div>
 

--- a/frontend/src/lib/components/dsfr/Tabs.svelte.test.ts
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte.test.ts
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import Tabs from './Tabs.svelte'
+
+describe('Tabs', () => {
+  it('hides the inactive panel immediately when switching tabs', async () => {
+    const { container, getByRole } = render(Tabs, {
+      tabs: [
+        { id: 'account', label: 'Compte', content: 'Contenu du compte' },
+        { id: 'about', label: 'À propos', content: 'Contenu à propos' }
+      ],
+      label: 'Rubriques'
+    })
+
+    expect(container.querySelector('#tab-account-panel')).toBeInTheDocument()
+    expect(container.querySelector('#tab-about-panel')).not.toBeInTheDocument()
+
+    await fireEvent.click(getByRole('tab', { name: 'À propos' }))
+
+    expect(container.querySelector('#tab-account-panel')).not.toBeInTheDocument()
+    expect(container.querySelector('#tab-about-panel')).toBeInTheDocument()
+  })
+
+  it('switches and focuses tabs with the keyboard', async () => {
+    const { container, getByRole } = render(Tabs, {
+      tabs: [
+        { id: 'account', label: 'Compte', content: 'Contenu du compte' },
+        { id: 'about', label: 'À propos', content: 'Contenu à propos' },
+        { id: 'privacy', label: 'Confidentialité', content: 'Contenu confidentialité' }
+      ],
+      label: 'Rubriques'
+    })
+
+    const accountTab = getByRole('tab', { name: 'Compte' })
+    const aboutTab = getByRole('tab', { name: 'À propos' })
+    const privacyTab = getByRole('tab', { name: 'Confidentialité' })
+
+    accountTab.focus()
+    await fireEvent.keyDown(accountTab, { key: 'ArrowRight' })
+    await Promise.resolve()
+    expect(document.activeElement).toBe(aboutTab)
+    expect(container.querySelector('#tab-about-panel')).toBeInTheDocument()
+
+    await fireEvent.keyDown(aboutTab, { key: 'End' })
+    await Promise.resolve()
+    expect(document.activeElement).toBe(privacyTab)
+
+    await fireEvent.keyDown(privacyTab, { key: 'Home' })
+    await Promise.resolve()
+    expect(document.activeElement).toBe(accountTab)
+
+    await fireEvent.keyDown(accountTab, { key: 'ArrowLeft' })
+    await Promise.resolve()
+    expect(document.activeElement).toBe(privacyTab)
+  })
+})

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -21,8 +21,16 @@
   const { navLinks, isAdmin = false }: { navLinks: NavLink[]; isAdmin?: boolean } = $props()
 
   const auth = getAuthContext()
-  const comparisons = getComparisonsContext()
+  // svelte-ignore state_referenced_locally
+  const comparisons = isAdmin ? undefined : getComparisonsContext()
   let expanded = $state(true)
+  let legalMenuOpen = $state(false)
+
+  function handleLegalMenuKeydown(event: KeyboardEvent, mode: 'desktop' | 'mobile') {
+    if (event.key !== 'Escape') return
+    legalMenuOpen = false
+    document.getElementById(`legal-menu-trigger-${mode}`)?.focus()
+  }
 
   const connectionBtnProps = $derived(
     auth.user
@@ -103,54 +111,133 @@
   </div>
 {/snippet}
 
+{#snippet legalMenu(mode: 'desktop' | 'mobile')}
+  <div class="relative">
+    <button
+      id="legal-menu-trigger-{mode}"
+      type="button"
+      aria-label="Informations légales"
+      aria-expanded={legalMenuOpen}
+      aria-controls="legal-menu-{mode}"
+      onclick={() => (legalMenuOpen = !legalMenuOpen)}
+      class={[
+        'text-grey! px-0 py-2 rounded gap-1 flex cursor-pointer items-center text-[13px]! whitespace-nowrap hover:bg-[--background-contrast-grey]',
+        { 'lg:h-6 lg:w-6 lg:justify-center lg:py-0': !expanded }
+      ]}
+    >
+      <Icon icon="i-ri-scales-3-line" block size="sm" />
+      <span class={{ 'lg:sr-only': !expanded }}>Légal</span>
+      <Icon
+        icon="i-ri-arrow-up-s-line"
+        block
+        size="xs"
+        class={['transition-transform', { 'rotate-180': legalMenuOpen, 'lg:hidden': !expanded }]}
+      />
+    </button>
+
+    <nav
+      id="legal-menu-{mode}"
+      aria-label="Informations légales"
+      hidden={!legalMenuOpen}
+      class="lg:absolute lg:bottom-full lg:left-0 lg:w-[290px] lg:mb-2 p-3 bg-white rounded shadow-lg z-100 border border-[--border-default-grey]"
+    >
+      <p class="fr-text--sm font-bold mb-2!">Informations légales</p>
+      <ul class="fr-raw-list gap-2 flex flex-col items-start">
+        <li>
+          <Link
+            href={resolve('/arene/donnees-personnelles')}
+            text="Données personnelles et confidentialité"
+            size="sm"
+            onclick={() => (legalMenuOpen = false)}
+            onkeydown={(event) => handleLegalMenuKeydown(event, mode)}
+          />
+        </li>
+        <li>
+          <Link
+            href={resolve('/arene/modalites')}
+            text="Conditions générales d’utilisation"
+            size="sm"
+            onclick={() => (legalMenuOpen = false)}
+            onkeydown={(event) => handleLegalMenuKeydown(event, mode)}
+          />
+        </li>
+        <li>
+          <Link
+            href={resolve('/arene/accessibilite')}
+            text="Accessibilité : non conforme"
+            size="sm"
+            onclick={() => (legalMenuOpen = false)}
+            onkeydown={(event) => handleLegalMenuKeydown(event, mode)}
+          />
+        </li>
+        <li>
+          <Link
+            href={resolve('/arene/ecoconception')}
+            text="Écoconception"
+            size="sm"
+            onclick={() => (legalMenuOpen = false)}
+            onkeydown={(event) => handleLegalMenuKeydown(event, mode)}
+          />
+        </li>
+      </ul>
+    </nav>
+  </div>
+{/snippet}
+
 {#snippet footer(mode: 'desktop' | 'mobile' = 'desktop')}
   <div class="gap-2 flex flex-col">
-    <div class="flex items-center justify-between">
-      {@render renderLink({
-        href: '/arena/settings',
-        label: m['seo.titles.settings'](),
-        icon: 'i-ri-settings-4-line',
-        button: true,
-        size: 'sm',
-        variant: 'tertiary-no-outline',
-        class: 'text-sm! text-grey! -ms-3 pointer-events-none'
-      })}
-
-      <LanguageSelector id="translate-{mode}" class={{ 'lg:hidden': !expanded }} />
-    </div>
-
     <div
-      class="md:flex-row gap-1 lg:flex-col md:items-center lg:items-start md:justify-between flex flex-col"
+      class={[
+        'gap-2 flex items-center justify-between',
+        { 'lg:flex-col lg:justify-center': !expanded }
+      ]}
     >
-      <Button
-        variant="tertiary"
-        size="sm"
-        {...connectionBtnProps}
-        icon={undefined}
-        text={undefined}
-        class={['w-full!', { '-ms-[2px]': !expanded }]}
-      >
-        <span class={['gap-2 flex items-center', { 'lg:w-full lg:justify-center': !expanded }]}>
-          <Icon icon={connectionBtnProps.icon} block size={expanded ? 'sm' : 'md'} />
-          <span class={{ 'lg:sr-only': !expanded }}>{connectionBtnProps.text}</span>
-        </span>
-      </Button>
+      <span class={['text-sm text-grey', { 'lg:sr-only': !expanded }]}>Mon compte</span>
 
-      {#if auth.user}
-        <p
-          class={[
-            'text-sm mb-0! text-grey min-w-0 max-w-full [overflow-wrap:anywhere]',
-            { 'lg:hidden': !expanded }
-          ]}
+      <div class={['gap-1 flex items-center', { 'lg:gap-2 lg:flex-col': !expanded }]}>
+        <Link
+          href={resolve('/arene/parametres')}
+          button
+          iconOnly
+          size="xs"
+          variant="tertiary-no-outline"
+          aria-label="Paramètres"
+          title="Paramètres"
+          class="px-0! w-[1.5rem]! min-w-[1.5rem]! justify-center"
         >
-          {auth.user.email}
-        </p>
-      {/if}
+          <Icon icon="i-ri-settings-4-line" block size="sm" />
+        </Link>
+
+        <Button
+          variant="tertiary-no-outline"
+          size="xs"
+          iconOnly
+          {...connectionBtnProps}
+          icon={undefined}
+          text={undefined}
+          aria-label={connectionBtnProps.text}
+          title={connectionBtnProps.text}
+          class="px-0! w-[1.5rem]! min-w-[1.5rem]! justify-center"
+        >
+          <Icon icon={connectionBtnProps.icon} block size="sm" />
+        </Button>
+      </div>
     </div>
 
     <!-- {@render helpLink()} -->
 
     <VoteGauge id="vote-gauge" class={{ 'lg:hidden': !expanded }} />
+
+    <div class={['gap-1 flex items-center justify-between', { 'lg:justify-center': !expanded }]}>
+      {@render legalMenu(mode)}
+      <LanguageSelector
+        id="translate-{mode}"
+        class={[
+          'text-grey! [&_.fr-translate__btn]:text-grey! [&_.fr-translate__btn]:text-[13px]!',
+          { 'lg:hidden': !expanded }
+        ]}
+      />
+    </div>
   </div>
 {/snippet}
 

--- a/frontend/src/lib/components/header/NavBar.svelte.test.ts
+++ b/frontend/src/lib/components/header/NavBar.svelte.test.ts
@@ -1,0 +1,59 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import NavBar from './NavBar.svelte'
+
+const mocks = vi.hoisted(() => ({
+  getComparisonsContext: vi.fn(() => {
+    throw new Error('Comparison context is unavailable outside the arena')
+  })
+}))
+
+vi.mock('$lib/auth.svelte', () => ({
+  getAuthContext: () => ({
+    user: { email: 'admin@example.test', role: 'admin' },
+    config: {
+      access_policy: 'anonymous_first',
+      has_custom_logo: false,
+      platform_name: 'Plateforme de test',
+      platform_url: 'https://example.test'
+    }
+  }),
+  logout: vi.fn()
+}))
+
+vi.mock('$lib/chatService.svelte', () => ({
+  getComparisonsContext: mocks.getComparisonsContext
+}))
+
+vi.mock('$lib/fastapi-client', () => ({
+  api: { getUrl: (path: string) => path }
+}))
+
+vi.mock('$lib/global.svelte', () => ({
+  LOCALES: [{ code: 'fr', short: 'FR', long: 'FR - Français', host: 'localhost:5173' }],
+  getVotesContext: () => ({ count: 0, objective: 100 })
+}))
+
+describe('NavBar admin', () => {
+  it('renders the global legal menu without requiring the arena comparison context', async () => {
+    const { container, getByRole, queryByRole } = render(NavBar, { navLinks: [], isAdmin: true })
+
+    expect(container.textContent).not.toContain('admin@example.test')
+    expect(getByRole('link', { name: 'Paramètres' })).toBeTruthy()
+    expect(getByRole('button', { name: 'Se déconnecter' })).toBeTruthy()
+    const legalMenuButton = getByRole('button', { name: 'Informations légales' })
+    expect(legalMenuButton).toHaveTextContent('Légal')
+    await fireEvent.click(legalMenuButton)
+
+    expect(getByRole('link', { name: 'Données personnelles et confidentialité' })).toBeTruthy()
+    expect(getByRole('link', { name: 'Conditions générales d’utilisation' })).toBeTruthy()
+    expect(getByRole('link', { name: 'Accessibilité : non conforme' }).getAttribute('href')).toBe(
+      '/arene/accessibilite'
+    )
+    expect(getByRole('link', { name: 'Écoconception' }).getAttribute('href')).toBe(
+      '/arene/ecoconception'
+    )
+    expect(queryByRole('link', { name: 'Mentions légales' })).toBeNull()
+    expect(mocks.getComparisonsContext).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/userDataExport.test.ts
+++ b/frontend/src/lib/userDataExport.test.ts
@@ -1,0 +1,204 @@
+import { queryComparisons, type Comparison } from '$lib/chatService.svelte'
+import { describe, expect, it } from 'vitest'
+import { buildUserDataExport } from './userDataExport'
+
+const comparison = {
+  id: 'comparison-1',
+  mode: 'random',
+  custom_models_selection: null,
+  revealed: true,
+  llm_id_a: 'model-a',
+  llm_id_b: 'model-b',
+  system_msg_a: 'System prompt A',
+  system_msg_b: 'System prompt B',
+  reveal_data: {
+    b64: 'internal-reveal-payload',
+    chosen_llm: 'a',
+    a: { llm_id: 'model-a', conso: { tokens: 42 } },
+    b: { llm_id: 'model-b', conso: { tokens: 84 } }
+  },
+  error: 'Internal error details',
+  turns: [
+    {
+      id: 'turn-1',
+      status: 'complete',
+      choice: 'a_better',
+      user_msg: {
+        id: 'user-message-1',
+        created_at: '2026-07-21T08:00:00.000Z',
+        content: 'Prompt enriched for the models',
+        user_content: 'My original prompt',
+        web_search_results: [
+          {
+            type: 'text',
+            name: 'Useful source',
+            url: 'https://example.test/source',
+            content: 'Search result content',
+            favicon: 'https://example.test/favicon.ico',
+            internal_rank: 1
+          }
+        ],
+        turn_id: 'turn-1'
+      },
+      a: {
+        status: 'complete',
+        llm_msg: {
+          id: 'assistant-message-a',
+          content: 'Response A',
+          created_at: '2026-07-21T08:00:01.000Z',
+          generation_id: 'generation-a',
+          reasoning_content: 'Private reasoning A',
+          tokens: 123,
+          is_cached: false
+        },
+        keyword_annotations: ['useful', 'complete'],
+        custom_annotation: 'Clear and useful'
+      },
+      b: {
+        status: 'complete',
+        llm_msg: {
+          id: 'assistant-message-b',
+          content: 'Response B',
+          generation_id: 'generation-b',
+          reasoning_content: 'Private reasoning B',
+          tokens: 456,
+          is_cached: true
+        },
+        keyword_annotations: ['superficial'],
+        custom_annotation: ''
+      }
+    }
+  ]
+} as unknown as Comparison
+
+describe('buildUserDataExport', () => {
+  it('builds a stable, versioned export containing useful conversation data', () => {
+    const result = buildUserDataExport(
+      'personne@example.fr',
+      [comparison],
+      new Date('2026-07-21T09:30:00.000Z')
+    )
+
+    expect(result).toEqual({
+      schema_version: 1,
+      exported_at: '2026-07-21T09:30:00.000Z',
+      account: { email: 'personne@example.fr' },
+      conversations: [
+        {
+          id: 'comparison-1',
+          mode: 'random',
+          revealed: true,
+          system_prompts: { a: 'System prompt A', b: 'System prompt B' },
+          models: { a: 'model-a', b: 'model-b' },
+          turns: [
+            {
+              id: 'turn-1',
+              created_at: '2026-07-21T08:00:00.000Z',
+              prompt: {
+                content: 'My original prompt',
+                web_search_results: [
+                  {
+                    name: 'Useful source',
+                    url: 'https://example.test/source',
+                    content: 'Search result content'
+                  }
+                ]
+              },
+              responses: {
+                a: { content: 'Response A', created_at: '2026-07-21T08:00:01.000Z' },
+                b: { content: 'Response B', created_at: null }
+              },
+              vote: {
+                choice: 'a_better',
+                annotations: {
+                  a: { keywords: ['useful', 'complete'], comment: 'Clear and useful' },
+                  b: { keywords: ['superficial'], comment: null }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('excludes technical metadata and internal errors', () => {
+    const serialized = JSON.stringify(buildUserDataExport('personne@example.fr', [comparison]))
+
+    expect(serialized).not.toContain('reasoning_content')
+    expect(serialized).not.toContain('Private reasoning')
+    expect(serialized).not.toContain('generation_id')
+    expect(serialized).not.toContain('generation-a')
+    expect(serialized).not.toContain('tokens')
+    expect(serialized).not.toContain('is_cached')
+    expect(serialized).not.toContain('internal-reveal-payload')
+    expect(serialized).not.toContain('Internal error details')
+    expect(serialized).not.toContain('favicon')
+    expect(serialized).not.toContain('internal_rank')
+  })
+
+  it('does not reveal model identities before the comparison is revealed', () => {
+    const hiddenComparison = {
+      ...comparison,
+      revealed: false,
+      llm_id_a: 'hidden-model-a',
+      llm_id_b: 'hidden-model-b'
+    }
+
+    const result = buildUserDataExport('personne@example.fr', [hiddenComparison])
+
+    expect(result.conversations[0].models).toBeNull()
+    expect(JSON.stringify(result)).not.toContain('hidden-model')
+  })
+
+  it('exports persisted annotations after comparisons are reloaded from the API', async () => {
+    const apiComparison = {
+      id: 'comparison-reloaded',
+      mode: 'random',
+      custom_models_selection: null,
+      error: null,
+      revealed: false,
+      llm_id_a: 'hidden-model-a',
+      llm_id_b: 'hidden-model-b',
+      turns: [
+        {
+          id: 'turn-reloaded',
+          choice: 'b_better',
+          user_msg: {
+            id: 'user-message-reloaded',
+            content: 'Reloaded prompt',
+            user_content: 'Reloaded prompt'
+          },
+          llm_msg_a: {
+            generation_id: 'generation-a',
+            content: 'Reloaded response A'
+          },
+          keyword_annotations_a: ['incorrect'],
+          custom_annotation_a: 'Contains an error',
+          llm_msg_b: {
+            generation_id: 'generation-b',
+            content: 'Reloaded response B'
+          },
+          keyword_annotations_b: ['useful', 'complete'],
+          custom_annotation_b: null
+        }
+      ]
+    }
+    const reloadedComparisons = await queryComparisons(
+      async () =>
+        new Response(JSON.stringify([apiComparison]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+    )
+
+    const result = buildUserDataExport('personne@example.fr', reloadedComparisons)
+
+    expect(result.conversations[0].turns[0].vote.annotations).toEqual({
+      a: { keywords: ['incorrect'], comment: 'Contains an error' },
+      b: { keywords: ['useful', 'complete'], comment: null }
+    })
+    expect(result.conversations[0].models).toBeNull()
+    expect(JSON.stringify(result)).not.toContain('hidden-model')
+  })
+})

--- a/frontend/src/lib/userDataExport.ts
+++ b/frontend/src/lib/userDataExport.ts
@@ -1,0 +1,133 @@
+import type { Comparison, TurnChoice, WebSearchResults } from '$lib/chatService.svelte'
+
+export const USER_DATA_EXPORT_SCHEMA_VERSION = 1 as const
+
+interface ExportedSearchResult {
+  name: string
+  url: string
+  content: string
+}
+
+interface ExportedMessage {
+  content: string
+  created_at: string | null
+}
+
+interface ExportedVoteAnnotations {
+  keywords: string[]
+  comment: string | null
+}
+
+interface ExportedTurn {
+  id: string
+  created_at: string | null
+  prompt: {
+    content: string
+    web_search_results: ExportedSearchResult[]
+  }
+  responses: {
+    a: ExportedMessage | null
+    b: ExportedMessage | null
+  }
+  vote: {
+    choice: TurnChoice | null
+    annotations: {
+      a: ExportedVoteAnnotations
+      b: ExportedVoteAnnotations
+    }
+  }
+}
+
+interface ExportedConversation {
+  id: string
+  mode: Comparison['mode']
+  revealed: boolean
+  system_prompts: {
+    a: string | null
+    b: string | null
+  }
+  models: {
+    a: string | null
+    b: string | null
+  } | null
+  turns: ExportedTurn[]
+}
+
+export interface UserDataExport {
+  schema_version: typeof USER_DATA_EXPORT_SCHEMA_VERSION
+  exported_at: string
+  account: {
+    email: string
+  }
+  conversations: ExportedConversation[]
+}
+
+function exportSearchResults(
+  results: WebSearchResults[] | null | undefined
+): ExportedSearchResult[] {
+  return (results ?? []).map(({ name, url, content }) => ({ name, url, content }))
+}
+
+function exportMessage(
+  message: Comparison['turns'][number]['a']['llm_msg']
+): ExportedMessage | null {
+  if (!message) return null
+
+  return {
+    content: message.content,
+    created_at: message.created_at ?? null
+  }
+}
+
+function exportAnnotations(side: Comparison['turns'][number]['a']): ExportedVoteAnnotations {
+  return {
+    keywords: [...side.keyword_annotations],
+    comment: side.custom_annotation || null
+  }
+}
+
+export function buildUserDataExport(
+  email: string,
+  comparisons: Comparison[],
+  exportedAt: Date = new Date()
+): UserDataExport {
+  return {
+    schema_version: USER_DATA_EXPORT_SCHEMA_VERSION,
+    exported_at: exportedAt.toISOString(),
+    account: { email },
+    conversations: comparisons.map((comparison) => ({
+      id: comparison.id,
+      mode: comparison.mode,
+      revealed: comparison.revealed,
+      system_prompts: {
+        a: comparison.system_msg_a ?? null,
+        b: comparison.system_msg_b ?? null
+      },
+      models: comparison.revealed
+        ? {
+            a: comparison.llm_id_a,
+            b: comparison.llm_id_b
+          }
+        : null,
+      turns: comparison.turns.map((turn) => ({
+        id: turn.id,
+        created_at: turn.user_msg.created_at ?? null,
+        prompt: {
+          content: turn.user_msg.user_content || turn.user_msg.content,
+          web_search_results: exportSearchResults(turn.user_msg.web_search_results)
+        },
+        responses: {
+          a: exportMessage(turn.a.llm_msg),
+          b: exportMessage(turn.b.llm_msg)
+        },
+        vote: {
+          choice: turn.choice,
+          annotations: {
+            a: exportAnnotations(turn.a),
+            b: exportAnnotations(turn.b)
+          }
+        }
+      }))
+    }))
+  }
+}

--- a/frontend/src/routes/(pages)/(general)/accessibilite/+page.server.ts
+++ b/frontend/src/routes/(pages)/(general)/accessibilite/+page.server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit'
+
+export function load() {
+  redirect(308, '/arene/accessibilite')
+}

--- a/frontend/src/routes/(pages)/(general)/ecoconception/+page.server.ts
+++ b/frontend/src/routes/(pages)/(general)/ecoconception/+page.server.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit'
+
+export function load() {
+  redirect(308, '/arene/ecoconception')
+}

--- a/frontend/src/routes/arene/accessibilite/+page.svelte
+++ b/frontend/src/routes/arene/accessibilite/+page.svelte
@@ -1,13 +1,30 @@
-<script>
+<script lang="ts">
   import SeoHead from '$components/SEOHead.svelte'
+  import { getAuthContext } from '$lib/auth.svelte'
   import { m } from '$lib/i18n/messages'
   import { externalLinkProps, sanitize } from '$lib/utils/commons'
+
+  const auth = getAuthContext()
+
+  function getPlatformDomain(value: string) {
+    try {
+      return new URL(value).host
+    } catch {
+      try {
+        return new URL(`https://${value}`).host
+      } catch {
+        return auth.config.platform_name || 'cette plateforme'
+      }
+    }
+  }
+
+  const platformDomain = $derived(getPlatformDomain(auth.config.platform_url))
 </script>
 
 <SeoHead title={m['seo.titles.accessibilite']()} />
 
-<main class="py-10 lg:py-15">
-  <div class="fr-container">
+<section class="py-10 lg:py-15" aria-labelledby="declaration-daccessibilite">
+  <div class="fr-container max-w-[900px]">
     <p>{@html sanitize(m['general.a11y.disclaimer']())}</p>
 
     <!-- <p>À cette fin, beta.gouv.fr met en œuvre la stratégie et les actions suivantes :</p>
@@ -19,10 +36,10 @@
 
     <h1 id="declaration-daccessibilite">{m['general.a11y.title']()}</h1>
     <!-- <p><em>Établie le 24 avril 2024.</em></p> -->
-    <p>{@html sanitize(m['general.a11y.desc']())}</p>
+    <p>{@html sanitize(m['general.a11y.desc']({ domain: platformDomain }))}</p>
 
     <h2 id="etat-de-conformite">{m['general.a11y.stateTitle']()}</h2>
-    <p>{@html sanitize(m['general.a11y.stateDesc']())}</p>
+    <p>{@html sanitize(m['general.a11y.stateDesc']({ domain: platformDomain }))}</p>
     <ul>
       <li>{m['general.a11y.stateNavigate']()}</li>
       <li>{m['general.a11y.stateScreenReader']()}</li>
@@ -44,7 +61,7 @@
   </ul> -->
 
     <h2 id="amelioration-et-contact">{m['general.a11y.improveTitle']()}</h2>
-    <p>{m['general.a11y.improveDesc']()}</p>
+    <p>{m['general.a11y.improveDesc']({ domain: platformDomain })}</p>
     <ul>
       <li>
         {@html sanitize(
@@ -78,4 +95,4 @@
       <li>{m['general.a11y.remedyAdvocateAdress']()}</li>
     </ul>
   </div>
-</main>
+</section>

--- a/frontend/src/routes/arene/ecoconception/+page.svelte
+++ b/frontend/src/routes/arene/ecoconception/+page.svelte
@@ -6,8 +6,8 @@
 
 <SeoHead title={m['seo.titles.rgesn']()} />
 
-<main class="py-10 lg:py-15">
-  <div class="fr-container">
+<section class="py-10 lg:py-15" aria-labelledby="main-title">
+  <div class="fr-container max-w-[900px]">
     <h1 id="main-title" class="mb-8!">{m['general.rgesn.title']()}</h1>
     <p>{m['general.rgesn.desc']()}</p>
 
@@ -124,4 +124,4 @@
       {/each}
     </ul>
   </div>
-</main>
+</section>

--- a/frontend/src/routes/arene/parametres/+page.svelte
+++ b/frontend/src/routes/arene/parametres/+page.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+  import { resolve } from '$app/paths'
+  import { Button, Input, Link, Modal, Tabs } from '$components/dsfr'
+  import SeoHead from '$components/SEOHead.svelte'
+  import ThemeSelector from '$components/ThemeSelector.svelte'
+  import { getAuthContext, logout } from '$lib/auth.svelte'
+  import { getComparisonsContext } from '$lib/chatService.svelte'
+  import { withdrawLocalConsent } from '$lib/consent'
+  import { api } from '$lib/fastapi-client'
+  import { m } from '$lib/i18n/messages'
+  import { buildUserDataExport } from '$lib/userDataExport'
+
+  const auth = getAuthContext()
+  const comparisons = getComparisonsContext()
+  const tabs = [
+    { id: 'account', label: 'Compte' },
+    { id: 'about', label: 'À propos' }
+  ] as const
+
+  let eraseEmail = $state('')
+  let erasingAccount = $state(false)
+  let eraseError = $state('')
+
+  function exportData() {
+    if (!auth.user) return
+
+    const exportedAt = new Date()
+    const content = JSON.stringify(
+      buildUserDataExport(auth.user.email, comparisons, exportedAt),
+      null,
+      2
+    )
+    const url = URL.createObjectURL(new Blob([content], { type: 'application/json;charset=utf-8' }))
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `comparia-donnees-${exportedAt.toISOString().slice(0, 10)}.json`
+    document.body.append(anchor)
+    anchor.click()
+    anchor.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 0)
+  }
+
+  async function eraseAccount() {
+    if (!auth.user || eraseEmail.trim().toLowerCase() !== auth.user.email.toLowerCase()) {
+      eraseError = 'Saisissez exactement l’adresse électronique de votre compte.'
+      return
+    }
+
+    erasingAccount = true
+    eraseError = ''
+    try {
+      await api.request('/auth/me', {
+        method: 'DELETE',
+        body: JSON.stringify({ email: eraseEmail.trim() })
+      })
+      withdrawLocalConsent()
+      auth.user = null
+      window.location.href = '/arene'
+    } catch {
+      eraseError =
+        'Le compte n’a pas pu être supprimé. Réessayez ou contactez l’équipe pour exercer ce droit.'
+    } finally {
+      erasingAccount = false
+    }
+  }
+</script>
+
+<SeoHead title={m['seo.titles.settings']()} />
+
+<header class="bg-very-light-primary px-4 py-4 shadow-sm">
+  <div class="fr-container max-w-[1000px]">
+    <h1 class="fr-h5 mb-0!">Paramètres</h1>
+    <p class="fr-text--sm text-grey mb-0!">Compte, données et informations sur la plateforme</p>
+  </div>
+</header>
+
+<div class="py-6 lg:py-8">
+  <div class="fr-container max-w-[1000px]">
+    <Tabs {tabs} label="Rubriques des paramètres" noBorders kind="nav">
+      {#snippet tab(tab)}
+        {#if tab.id === 'account'}
+          <div class="fr-grid-row fr-grid-row--gutters">
+            <section class="fr-col-12 fr-col-lg-6" aria-labelledby="account-settings-title">
+              <h2 id="account-settings-title" class="fr-h4">Mon compte</h2>
+
+              {#if auth.user}
+                <Input
+                  id="account-email"
+                  type="email"
+                  value={auth.user.email}
+                  label="Adresse électronique"
+                  disabled
+                />
+                <div class="gap-3 flex flex-wrap">
+                  <Button
+                    variant="secondary"
+                    text="Se déconnecter"
+                    icon="logout-box-r-line"
+                    onclick={() => logout(auth, comparisons)}
+                  />
+                  <Button
+                    variant="tertiary"
+                    text="Supprimer mon compte"
+                    class="text-error!"
+                    aria-controls="account-erasure-modal"
+                    data-fr-opened="false"
+                  />
+                </div>
+              {:else}
+                <p>Connectez-vous pour accéder aux paramètres de votre compte.</p>
+              {/if}
+            </section>
+
+            <section class="fr-col-12 fr-col-lg-6" aria-labelledby="display-settings-title">
+              <h2 id="display-settings-title" class="fr-h4">Préférences</h2>
+              <ThemeSelector variant="select" />
+            </section>
+          </div>
+
+          {#if auth.user}
+            <section class="fr-mt-8v" aria-labelledby="export-data-title">
+              <h2 id="export-data-title" class="fr-h4">Exporter mes données</h2>
+              <p class="fr-text--sm text-grey">
+                Téléchargez une copie de vos conversations et de vos votes au format JSON.
+              </p>
+              <Button variant="secondary" text="Exporter mes données" onclick={exportData} />
+            </section>
+          {/if}
+        {:else}
+          <section aria-labelledby="useful-links-title">
+            <h2 id="useful-links-title" class="fr-h4">Liens utiles</h2>
+            <p class="fr-text--sm text-grey max-w-[800px]">
+              Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus
+              de ce site sont proposés sous
+              <a href="https://www.etalab.gouv.fr/licence-ouverte-open-licence/">
+                licence Etalab 2.0
+              </a>.
+            </p>
+            <ul class="fr-raw-list gap-3 flex flex-col items-start">
+              <li>
+                <Link
+                  href={resolve('/arene/modalites')}
+                  text="Conditions générales d’utilisation"
+                />
+              </li>
+              <li>
+                <Link
+                  href={resolve('/arene/donnees-personnelles')}
+                  text="Politique de confidentialité"
+                />
+              </li>
+              <li><Link href={resolve('/arene/accessibilite')} text="Accessibilité" /></li>
+              <li><Link href={resolve('/arene/ecoconception')} text="Écoconception" /></li>
+              <li><Link href="https://github.com/betagouv/ComparIA" text="Code source" /></li>
+            </ul>
+          </section>
+        {/if}
+      {/snippet}
+    </Tabs>
+  </div>
+</div>
+
+<Modal
+  id="account-erasure-modal"
+  titleId="account-erasure-title"
+  sizeClass="fr-col-12 fr-col-md-8 fr-col-lg-5"
+>
+  <h2 id="account-erasure-title" class="fr-modal__title">Supprimer le compte</h2>
+  <p>
+    La suppression est irréversible. Vos sessions seront révoquées, votre adresse électronique sera
+    anonymisée et vos conversations seront détachées du compte.
+  </p>
+  {#if auth.user}
+    <Input
+      id="account-erasure-email"
+      type="email"
+      bind:value={eraseEmail}
+      label="Confirmez votre adresse électronique"
+      help={`Saisissez ${auth.user.email} pour confirmer la suppression.`}
+      error={eraseError}
+      autocomplete="email"
+    />
+  {/if}
+  <div class="fr-btns-group fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+    <Button
+      text={erasingAccount ? 'Suppression…' : 'Supprimer mon compte'}
+      disabled={erasingAccount ||
+        !auth.user ||
+        eraseEmail.trim().toLowerCase() !== auth.user.email.toLowerCase()}
+      onclick={eraseAccount}
+    />
+    <Button variant="secondary" text="Annuler" aria-controls="account-erasure-modal" />
+  </div>
+</Modal>

--- a/tests/auth/test_account_erasure.py
+++ b/tests/auth/test_account_erasure.py
@@ -1,0 +1,47 @@
+import asyncio
+import sys
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.auth import services
+from utils.database.models.auth import User
+
+
+class FakeSession:
+    def __init__(self, user: User):
+        self.user = user
+        self.statements = []
+        self.committed = False
+
+    async def get(self, _model, _user_id):
+        return self.user
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+
+    def add(self, _value):
+        pass
+
+    async def commit(self):
+        self.committed = True
+
+
+def test_account_erasure_anonymizes_identity_and_runs_all_cleanup(monkeypatch):
+    user = User(id=uuid.uuid4(), email="personne@example.test")
+    session = FakeSession(user)
+
+    @asynccontextmanager
+    async def fake_get_session():
+        yield session
+
+    monkeypatch.setattr(services, "get_session", fake_get_session)
+
+    asyncio.run(services.erase_user_account(user.id))
+
+    assert session.committed
+    assert user.deleted_at is not None
+    assert user.email == f"deleted-{user.id}@deleted.invalid"
+    assert len(session.statements) == 6

--- a/tests/auth/test_consent.py
+++ b/tests/auth/test_consent.py
@@ -52,6 +52,25 @@ def test_authentication_contract_is_separate_from_consent():
     assert "consent" not in type(body).model_fields
 
 
+def test_public_config_exposes_the_deployment_url(monkeypatch):
+    async def fake_get_app_settings():
+        return SimpleNamespace(
+            auth_access_policy="anonymous_first",
+            auth_domain_allowlist=[],
+            platform_name="Example arena",
+            logo=None,
+        )
+
+    monkeypatch.setattr(auth_router, "get_app_settings", fake_get_app_settings)
+    monkeypatch.setattr(
+        auth_router.settings, "COMPARIA_APP_URL", "https://arena.example.test"
+    )
+
+    config = asyncio.run(auth_router.get_config())
+
+    assert config.platform_url == "https://arena.example.test"
+
+
 def test_legal_information_acknowledgement_cannot_be_false():
     try:
         auth_router.ConsentAssertion.model_validate(


### PR DESCRIPTION
## Summary

- group account, display and data controls in the settings page
- add account export and deletion
- add a DSFR theme selector and accessible settings tabs
- keep legal, accessibility and ecodesign pages inside the arena
- make the accessibility domain follow the deployed platform URL

## Checks

- frontend tests: 90 passed
- production frontend build passed
- account deletion and consent tests passed
- mouse and keyboard tab changes tested in the running app