### PR TITLE
Protect operational diagnostics

### DIFF
--- a/backend/arena/conversation.py
+++ b/backend/arena/conversation.py
@@ -159,9 +159,15 @@ async def bot_response_async(
     # Check for empty responses and raise error (check on data that is not stripped)
     if not llm_msg.content and not llm_msg.reasoning_content:
         logger.error(
-            f"reponse_vide: {llm.id}, message: {llm_msg}",
-            exc_info=True,
-            extra={"request": request},
+            "Empty response received from model",
+            extra={
+                "request": request,
+                "extra": {
+                    "event": "arena.empty_model_response",
+                    "model_id": str(llm.id),
+                    "generation_id": llm_msg.generation_id,
+                },
+            },
         )
         raise EmptyResponseError(
             f"No answer from API '{llm.endpoint.api_model_id}' for model '{llm.id}'"

--- a/backend/arena/litellm.py
+++ b/backend/arena/litellm.py
@@ -19,6 +19,7 @@ from backend.config import (
     settings,
 )
 from backend.errors import ContextTooLongError
+from backend.logger import exception_metadata
 
 if TYPE_CHECKING:
     from fastapi import Request
@@ -71,10 +72,7 @@ def litellm_stream_iter(
     # if debug:
     #     litellm._turn_on_debug()
 
-    # Configure Sentry error tracking if available
-    if settings.SENTRY_DSN:
-        litellm.input_callback = ["sentry"]  # adds sentry breadcrumbing
-        litellm.failure_callback.append("sentry")
+    # LiteLLM's Sentry callback receives full request payloads.
 
     # nice to have: openrouter specific params
     # completion = client.chat.completions.create(
@@ -131,8 +129,15 @@ def litellm_stream_iter(
         response: Generator[litellm.ModelResponse] = litellm.completion(**kwargs)
     except litellm.ContextWindowExceededError as e:
         logger.error(
-            f"context_window_exceeded: {endpoint.model}: {e}",
-            extra={"request": request},
+            "Model context window exceeded",
+            extra={
+                "request": request,
+                "extra": {
+                    "event": "arena.context_window_exceeded",
+                    "model": endpoint.model,
+                    **exception_metadata(e),
+                },
+            },
         )
         raise ContextTooLongError from e
 
@@ -179,8 +184,15 @@ def litellm_stream_iter(
             elif choice.finish_reason == "length":
                 # Output truncated at max_tokens limit — response is still valid
                 logger.warning(
-                    "output_truncated_at_max_tokens: " + str(chunk),
-                    extra={"request": request},
+                    "Model response truncated at max token limit",
+                    extra={
+                        "request": request,
+                        "extra": {
+                            "event": "arena.output_truncated",
+                            "model": endpoint.model,
+                            "generation_id": chunk.id,
+                        },
+                    },
                 )
                 break
 

--- a/backend/arena/moderation.py
+++ b/backend/arena/moderation.py
@@ -28,6 +28,7 @@ import litellm
 import sentry_sdk
 
 from backend.config import settings
+from backend.logger import exception_metadata
 
 if TYPE_CHECKING:
     from fastapi import Request
@@ -152,7 +153,17 @@ async def check_prompt(
         content = response.choices[0].message.content or ""
     except Exception as e:
         # Fail open, but make it visible: a dark guard must not be silent.
-        logger.error(f"guardrail_check_failed: {e}", extra={"request": request})
+        logger.error(
+            "Guardrail check failed",
+            extra={
+                "request": request,
+                "extra": {
+                    "event": "guardrail.failed",
+                    "model": settings.GUARDRAIL_MODEL,
+                    **exception_metadata(e),
+                },
+            },
+        )
         if settings.SENTRY_DSN:
             sentry_sdk.capture_exception(e)
         return GuardrailVerdict(

--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -198,8 +198,17 @@ async def add_first_text(
             )
 
     logger.info(
-        f"'/add_first_text' called with: {args.model_dump_json()}",
-        extra={"request": request},
+        "Arena first message received",
+        extra={
+            "request": request,
+            "extra": {
+                "event": "arena.first_message",
+                "mode": args.mode,
+                "web_search": args.web_search,
+                "prompt_chars": len(args.prompt_value),
+                "custom_model_count": len(args.custom_models_selection or []),
+            },
+        },
     )
 
     guardrail = await run_guardrail(args.prompt_value, "prompt_value", request)
@@ -308,8 +317,15 @@ async def add_text(
         HTTPException: If Comparison not found or rate limiting triggered
     """
     logger.info(
-        f"'/add_text' on comparison '{comparison_.id}' called with: {args.model_dump_json()}",
-        extra={"request": request},
+        "Arena follow-up received",
+        extra={
+            "request": request,
+            "extra": {
+                "event": "arena.follow_up",
+                "comparison_id": str(comparison_.id),
+                "prompt_chars": len(args.message),
+            },
+        },
     )
 
     guardrail = await run_guardrail(args.message, "message", request)
@@ -399,8 +415,15 @@ async def retry(
     store_comparison_metadata(comparison.id, is_streaming=True)
 
     logger.info(
-        f"retry with user message: {turn.user_msg.content}",
-        extra={"request": request},
+        "Arena response retry requested",
+        extra={
+            "request": request,
+            "extra": {
+                "event": "arena.retry",
+                "comparison_id": str(comparison.id),
+                "prompt_chars": len(turn.user_msg.content),
+            },
+        },
     )
 
     # Re-stream responses
@@ -449,8 +472,25 @@ async def vote(
         HTTPException: If Comparison not found or forbidden vote attempts.
     """
     logger.info(
-        f"'/vote' on comparison '{comparison.id}' called with: {vote.model_dump_json()}",
-        extra={"request": request},
+        "Arena vote received",
+        extra={
+            "request": request,
+            "extra": {
+                "event": "arena.vote",
+                "comparison_id": str(comparison.id),
+                "vote_kind": type(vote).__name__,
+                "annotation_count": (
+                    len(vote.keyword_annotations)
+                    if isinstance(vote, TurnVoteAnnotate)
+                    else 0
+                ),
+                "custom_annotation_chars": (
+                    len(vote.custom_annotation or "")
+                    if isinstance(vote, TurnVoteAnnotate)
+                    else 0
+                ),
+            },
+        },
     )
 
     turn = next((turn for turn in comparison.turns if turn.id == vote.turn_id), None)

--- a/backend/arena/session.py
+++ b/backend/arena/session.py
@@ -15,6 +15,7 @@ from backend.config import (
     RATELIMIT_BLOCKED_PROMPTS_PER_HOUR,
     RATELIMIT_PRICEY_MODELS_INPUT,
 )
+from backend.logger import exception_metadata
 from utils.storage.redis import (
     REDIS_BLOCKED_COUNT_KEY,
     REDIS_COMPARISON_KEY,
@@ -135,7 +136,15 @@ def increment_blocked_prompts(ip: str) -> None:
         client.incr(REDIS_BLOCKED_COUNT_KEY.format(ip=ip))
         client.expire(REDIS_BLOCKED_COUNT_KEY.format(ip=ip), 3600)
     except Exception as e:
-        logger.error(f"[SESSION] Error incrementing blocked count for '{ip}': {e}")
+        logger.error(
+            "Failed to increment blocked prompt count",
+            extra={
+                "extra": {
+                    "event": "guardrail.blocked_count_failed",
+                    **exception_metadata(e),
+                }
+            },
+        )
 
 
 def is_block_cooldown(ip: str) -> bool:
@@ -149,5 +158,13 @@ def is_block_cooldown(ip: str) -> bool:
         assert not isinstance(counter, Awaitable)
         return bool(counter and int(counter) >= RATELIMIT_BLOCKED_PROMPTS_PER_HOUR)
     except Exception as e:
-        logger.error(f"[SESSION] Error checking block cooldown for '{ip}': {e}")
+        logger.error(
+            "Failed to check blocked prompt cooldown",
+            extra={
+                "extra": {
+                    "event": "guardrail.blocked_cooldown_failed",
+                    **exception_metadata(e),
+                }
+            },
+        )
         return False

--- a/backend/arena/streaming.py
+++ b/backend/arena/streaming.py
@@ -6,7 +6,6 @@ Handles real-time streaming of model responses to the frontend using SSE protoco
 
 import json
 import logging
-import traceback
 from typing import Any, AsyncGenerator, Literal, TypedDict
 
 import litellm
@@ -23,6 +22,7 @@ from backend.arena.conversation import (
 from backend.arena.services import update_comparison_error, update_comparison_llm_id
 from backend.config import CustomModelsSelection, SelectionMode, settings
 from backend.errors import ChatError
+from backend.logger import exception_metadata
 from backend.llms.data import get_llms_data, pick_replacement_model
 from backend.llms.models import LLMDataEnabled
 from utils.database.models import (
@@ -131,8 +131,17 @@ async def stream_llm_response(
         yield {"type": "complete", "pos": pos}
 
         logger.info(
-            f"response_modele_{pos} ({llm.id}): {llm_msg.content}",
-            extra={"request": request},
+            "Model response completed",
+            extra={
+                "request": request,
+                "extra": {
+                    "event": "arena.model_response_completed",
+                    "model_id": str(llm.id),
+                    "position": pos,
+                    "response_chars": len(llm_msg.content or ""),
+                    "output_tokens": llm_msg.tokens,
+                },
+            },
         )
 
     except Exception as e:
@@ -144,7 +153,9 @@ async def stream_llm_response(
             sentry_sdk.capture_exception(e)
 
         error_reason = (
-            f"error_during_convo: {llm.id}, {llm.endpoint.api_type}, {error_message}"
+            "error_during_convo: "
+            f"model={llm.id}, api_type={llm.endpoint.api_type}, "
+            f"exception={type(e).__name__}"
         )
 
         # TODO ContextLengthError: do not log to controller?
@@ -159,14 +170,17 @@ async def stream_llm_response(
         except:
             pass
 
-        logger.exception(
+        logger.error(
             error_reason,
             extra={
                 "request": request,
-                "error": error_message,
-                "stacktrace": traceback.format_exc(),
+                "extra": {
+                    "event": "arena.model_response_failed",
+                    "model_id": str(llm.id),
+                    "position": pos,
+                    **exception_metadata(e),
+                },
             },
-            exc_info=True,
         )
 
         raise ChatError(
@@ -300,11 +314,19 @@ async def stream_comparison_messages(
             # Error is silenced to be sent thru sse message, send it to sentry manually
             sentry_sdk.capture_exception(e)
 
-        await update_comparison_error(comparison, ErrorDetails(message=str(e)))
+        error_message = str(e)
+        await update_comparison_error(comparison, ErrorDetails(message=error_message))
         logger.error(
-            f"[STREAMING] Error in stream_comparison_messages: {e}", exc_info=True
+            "Comparison streaming failed",
+            extra={
+                "extra": {
+                    "event": "arena.comparison_stream_failed",
+                    "comparison_id": str(comparison.id),
+                    **exception_metadata(e),
+                }
+            },
         )
-        yield {"type": "error", "error": str(e)}
+        yield {"type": "error", "error": error_message}
 
 
 def _get_messages(comparison: ComparisonRead, pos: BotPos) -> list[AnyMessageRead]:

--- a/backend/arena/web_search.py
+++ b/backend/arena/web_search.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from linkup import LinkupClient, LinkupSearchResults, LinkupSearchTextResult
 
 from backend.config import WEB_SEARCH_INTRO, settings
+from backend.logger import exception_metadata
 from utils.storage.redis import REDIS_WEB_SEARCH_KEY, get_redis_client, hash_content
 
 logger = logging.getLogger("languia")
@@ -50,8 +51,17 @@ async def search_web(
 
         return results
 
-    except Exception:
-        logger.exception("Linkup web search failed")
+    except Exception as exc:
+        logger.error(
+            "Linkup web search failed",
+            extra={
+                "extra": {
+                    "event": "web_search.failed",
+                    "provider": "linkup",
+                    **exception_metadata(exc),
+                }
+            },
+        )
         return None
 
 
@@ -90,7 +100,10 @@ def get_cached_web_search(prompt: str) -> list[LinkupSearchTextResult] | None:
         if not results:
             return None
 
-        logger.info(f"[CACHE] Web search cache hit for prompt: '{prompt}'.")
+        logger.info(
+            "Web search cache hit",
+            extra={"extra": {"event": "web_search.cache_hit"}},
+        )
         return [LinkupSearchTextResult.model_construct(**result) for result in results]
 
     except Exception as e:
@@ -116,7 +129,10 @@ def store_cached_search_results(
             settings.CACHE_TTL,
             json.dumps([result.model_dump() for result in web_search_results]),
         )
-        logger.info(f"[CACHE] Stored web search cache for prompt: '{prompt}'.")
+        logger.info(
+            "Web search result cached",
+            extra={"extra": {"event": "web_search.cache_store"}},
+        )
 
     except Exception as e:
         logger.warning(f"[CACHE] Error storing web search cache: {e}")

--- a/backend/logger.py
+++ b/backend/logger.py
@@ -3,7 +3,10 @@ import json
 import logging
 import os
 import queue
+import re
 import sys
+import traceback
+import uuid
 from logging.handlers import WatchedFileHandler
 
 from fastapi import Request
@@ -21,27 +24,39 @@ class LokiHandler(BaseLokiQueueHandler):
 from rich.logging import RichHandler
 
 from backend.config import settings
-from backend.utils.user import get_ip
+
+_ERROR_CODE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+
+
+def exception_metadata(exc: BaseException) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "exception_type": type(exc).__name__,
+        "traceback": [
+            {
+                "file": frame.filename,
+                "line": frame.lineno,
+                "function": frame.name,
+            }
+            for frame in traceback.extract_tb(exc.__traceback__)
+        ],
+    }
+    for attribute in ("status_code", "status"):
+        status = getattr(exc, attribute, None)
+        if isinstance(status, int) and 100 <= status <= 599:
+            metadata["status_code"] = status
+            break
+    for attribute in ("code", "error_code"):
+        code = getattr(exc, attribute, None)
+        if isinstance(code, str) and _ERROR_CODE_PATTERN.fullmatch(code):
+            metadata["error_code"] = code
+            break
+    return metadata
 
 
 class JSONFormatter(logging.Formatter):
-    """
-    Custom logging formatter that outputs structured JSON.
-
-    Converts log records to JSON with context information (IP, session, query params).
-    Used for both file and database logging.
-    """
+    """Format logs as JSON with safe request metadata."""
 
     def format(self, record) -> str:
-        """
-        Format a log record as JSON with request context.
-
-        Args:
-            record: LogRecord from Python logging
-
-        Returns:
-            str: JSON-formatted log entry
-        """
         msg = super().format(record)
 
         log_data: dict[str, dict | str | None] = {"message": msg}
@@ -49,15 +64,14 @@ class JSONFormatter(logging.Formatter):
         # Extract request context if available
         if hasattr(record, "request") and isinstance(record.request, Request):
             try:
-                log_data["query_params"] = dict(record.request.query_params)
-                log_data["path_params"] = dict(record.request.path_params)
-                # TODO: remove IP? (privacy concern)
-                log_data["ip"] = get_ip(record.request)
-                log_data["comparison_id"] = record.request.headers.get(
-                    "x-comparison-id"
-                )
+                log_data["method"] = record.request.method
+                route = record.request.scope.get("route")
+                log_data["route"] = getattr(route, "path", None)
+                comparison_id = record.request.headers.get("x-comparison-id")
+                if comparison_id:
+                    log_data["comparison_id"] = str(uuid.UUID(comparison_id))
 
-            except:
+            except (AttributeError, TypeError, ValueError):
                 pass
         # Include extra metadata if provided
         if hasattr(record, "extra"):

--- a/backend/sentry.py
+++ b/backend/sentry.py
@@ -1,11 +1,130 @@
 import logging
 import os
+import re
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import UUID
 
 import sentry_sdk
+from sentry_sdk.types import Event
 
 from backend.config import settings
+from backend.logger import exception_metadata
 
 logger = logging.getLogger("languia")
+
+_SAFE_TEXT_KEYS = {
+    "event",
+    "model",
+    "model_id",
+    "provider",
+    "position",
+    "exception_type",
+    "generation_id",
+    "mode",
+    "vote_kind",
+}
+_SAFE_NUMBER_KEYS = {
+    "status_code",
+    "output_tokens",
+    "prompt_chars",
+    "response_chars",
+    "custom_model_count",
+    "annotation_count",
+    "custom_annotation_chars",
+}
+_SAFE_BOOL_KEYS = {"web_search"}
+_SAFE_TEXT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,127}$")
+_ERROR_CODE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+
+
+def _safe_operational_extra(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    source = value.get("extra") if isinstance(value.get("extra"), dict) else value
+    safe: dict[str, Any] = {}
+    for key in _SAFE_TEXT_KEYS:
+        item = source.get(key)
+        if isinstance(item, str) and _SAFE_TEXT_PATTERN.fullmatch(item):
+            safe[key] = item
+    for key in _SAFE_NUMBER_KEYS:
+        item = source.get(key)
+        if (
+            isinstance(item, int)
+            and not isinstance(item, bool)
+            and (key != "status_code" or 100 <= item <= 599)
+        ):
+            safe[key] = item
+    for key in _SAFE_BOOL_KEYS:
+        item = source.get(key)
+        if isinstance(item, bool):
+            safe[key] = item
+    code = source.get("error_code")
+    if isinstance(code, str) and _ERROR_CODE_PATTERN.fullmatch(code):
+        safe["error_code"] = code
+    comparison_id = source.get("comparison_id")
+    if isinstance(comparison_id, str):
+        try:
+            safe["comparison_id"] = str(UUID(comparison_id))
+        except ValueError:
+            pass
+    return safe
+
+
+def scrub_sensitive_event(event: Event, _hint: dict[str, Any]) -> Event:
+    """Remove request content and free-text values before sending to Sentry."""
+    event.pop("user", None)
+    event.pop("message", None)
+    safe_extra = _safe_operational_extra(event.get("extra"))
+    exc_info = _hint.get("exc_info")
+    if isinstance(exc_info, tuple) and len(exc_info) > 1:
+        exc = exc_info[1]
+        if isinstance(exc, BaseException):
+            safe_extra.update(
+                {
+                    key: value
+                    for key, value in exception_metadata(exc).items()
+                    if key in {"exception_type", "status_code", "error_code"}
+                }
+            )
+    if safe_extra:
+        event["extra"] = safe_extra
+    else:
+        event.pop("extra", None)
+    request = event.get("request")
+    if isinstance(request, dict):
+        for key in ("data", "cookies", "query_string", "headers", "env"):
+            request.pop(key, None)
+        if isinstance(request.get("url"), str):
+            url = urlsplit(request["url"])
+            request["url"] = url.path
+
+    for breadcrumb in event.get("breadcrumbs", {}).get("values", []):
+        if isinstance(breadcrumb, dict):
+            breadcrumb.pop("data", None)
+            breadcrumb.pop("message", None)
+
+    exception = event.get("exception")
+    if isinstance(exception, dict):
+        for value in exception.get("values", []):
+            if isinstance(value, dict) and value.get("value"):
+                value["value"] = value.get("type", "Application error")
+            if isinstance(value, dict):
+                for frame in value.get("stacktrace", {}).get("frames", []):
+                    if isinstance(frame, dict):
+                        frame.pop("vars", None)
+
+    for span in event.get("spans", []):
+        if isinstance(span, dict):
+            span.pop("data", None)
+            span.pop("description", None)
+
+    logentry = event.get("logentry")
+    if isinstance(logentry, dict):
+        logentry.pop("params", None)
+        logentry["message"] = "Application log event"
+
+    return event
 
 
 def init_sentry() -> None:
@@ -24,6 +143,10 @@ def init_sentry() -> None:
         traces_sample_rate=settings.SENTRY_SAMPLE_RATE,
         profiles_sample_rate=settings.SENTRY_SAMPLE_RATE,
         project_root=os.getcwd(),
+        send_default_pii=False,
+        max_request_body_size="never",
+        before_send=scrub_sensitive_event,
+        include_local_variables=False,
     )
     logger.debug(
         "Sentry loaded with traces_sample_rate="

--- a/backend/utils/user.py
+++ b/backend/utils/user.py
@@ -55,7 +55,6 @@ def get_matomo_tracker_from_cookies(cookies: dict[str, str]) -> str | None:
     # Matomo cookies start with "_pk_id."
     for key, value in cookies.items():
         if key.startswith("_pk_id."):
-            logger.debug(f"Found matomo cookie: {key}: {value}")
             return value
 
     return None

--- a/tests/arena/test_privacy_logging.py
+++ b/tests/arena/test_privacy_logging.py
@@ -1,0 +1,189 @@
+import json
+import logging
+import sys
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from fastapi import Request
+
+from backend.logger import JSONFormatter, exception_metadata
+from backend.sentry import scrub_sensitive_event
+from backend.utils.user import get_matomo_tracker_from_cookies
+
+COMPARISON_ID = "59aa09e4-e75d-45f9-8209-586b1d0d237d"
+
+
+class ProviderError(RuntimeError):
+    status_code = 429
+    code = "rate_limit_exceeded"
+
+
+def test_sentry_scrubber_removes_free_text_and_request_identifiers():
+    event = {
+        "request": {
+            "method": "POST",
+            "url": "https://example.test/arena/add_first_text?secret=query",
+            "data": {"prompt_value": "secret prompt"},
+            "cookies": "session=secret",
+            "query_string": "secret=query",
+            "headers": {"authorization": "Bearer secret"},
+            "env": {"REMOTE_ADDR": "192.0.2.1"},
+        },
+        "breadcrumbs": {
+            "values": [
+                {"category": "llm", "message": "secret prompt", "data": {"x": 1}}
+            ]
+        },
+        "exception": {
+            "values": [
+                {
+                    "type": "ProviderError",
+                    "value": "secret response",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "filename": "backend/arena/streaming.py",
+                                "function": "stream_llm_response",
+                                "lineno": 150,
+                                "vars": {"prompt": "secret"},
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        "logentry": {"message": "Provider failed", "params": ["secret prompt"]},
+        "extra": {
+            "extra": {
+                "event": "arena.model_response_failed",
+                "model_id": "model-1",
+                "comparison_id": COMPARISON_ID,
+                "prompt": "secret prompt",
+                "response": "secret response",
+            }
+        },
+        "spans": [{"description": "secret query", "data": {"prompt": "secret"}}],
+    }
+
+    error = ProviderError("secret provider response")
+    scrubbed = scrub_sensitive_event(
+        event, {"exc_info": (ProviderError, error, error.__traceback__)}
+    )
+    serialized = json.dumps(scrubbed)
+
+    assert "secret" not in serialized
+    assert scrubbed["request"]["method"] == "POST"
+    assert scrubbed["request"]["url"] == "/arena/add_first_text"
+    assert scrubbed["exception"]["values"][0]["value"] == "ProviderError"
+    assert scrubbed["exception"]["values"][0]["stacktrace"]["frames"] == [
+        {
+            "filename": "backend/arena/streaming.py",
+            "function": "stream_llm_response",
+            "lineno": 150,
+        }
+    ]
+    assert scrubbed["extra"] == {
+        "event": "arena.model_response_failed",
+        "model_id": "model-1",
+        "comparison_id": COMPARISON_ID,
+        "exception_type": "ProviderError",
+        "status_code": 429,
+        "error_code": "rate_limit_exceeded",
+    }
+
+
+def test_exception_metadata_keeps_safe_traceback_without_error_content():
+    try:
+        raise ProviderError("secret provider response")
+    except ProviderError as exc:
+        details = exception_metadata(exc)
+
+    assert details["exception_type"] == "ProviderError"
+    assert details["status_code"] == 429
+    assert details["error_code"] == "rate_limit_exceeded"
+    assert details["traceback"]
+    assert "secret provider response" not in json.dumps(details)
+
+
+def test_json_logger_keeps_route_metadata_without_request_personal_data():
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/arena/add_first_text",
+            "query_string": b"prompt=secret",
+            "headers": [
+                (b"cookie", b"session=secret"),
+                (b"x-comparison-id", COMPARISON_ID.encode()),
+            ],
+            "client": ("192.0.2.1", 1234),
+            "server": ("example.test", 443),
+            "scheme": "https",
+            "route": SimpleNamespace(path="/arena/add_first_text"),
+        }
+    )
+    record = logging.LogRecord(
+        "languia", logging.INFO, __file__, 1, "Arena event", (), None
+    )
+    record.request = request
+
+    payload = json.loads(JSONFormatter("%(message)s").format(record))
+
+    assert payload["method"] == "POST"
+    assert payload["route"] == "/arena/add_first_text"
+    assert payload["comparison_id"] == COMPARISON_ID
+    assert "query_params" not in payload
+    assert "ip" not in payload
+    assert "secret" not in json.dumps(payload)
+
+
+def test_json_logger_ignores_invalid_comparison_id():
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/arena/comparison",
+            "query_string": b"",
+            "headers": [(b"x-comparison-id", b"not-a-uuid")],
+            "client": ("192.0.2.1", 1234),
+            "server": ("example.test", 443),
+            "scheme": "https",
+            "route": SimpleNamespace(path="/arena/comparison"),
+        }
+    )
+    record = logging.LogRecord("languia", logging.INFO, __file__, 1, "Event", (), None)
+    record.request = request
+
+    payload = json.loads(JSONFormatter("%(message)s").format(record))
+
+    assert "comparison_id" not in payload
+
+
+def test_matomo_cookie_identifier_is_not_logged():
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("languia")
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        identifier = get_matomo_tracker_from_cookies(
+            {"_pk_id.1.example": "secret-visitor-identifier"}
+        )
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+    assert identifier == "secret-visitor-identifier"
+    assert "secret-visitor-identifier" not in stream.getvalue()
+
+
+if __name__ == "__main__":
+    test_sentry_scrubber_removes_free_text_and_request_identifiers()
+    test_exception_metadata_keeps_safe_traceback_without_error_content()
+    test_json_logger_keeps_route_metadata_without_request_personal_data()
+    test_json_logger_ignores_invalid_comparison_id()
+    test_matomo_cookie_identifier_is_not_logged()


### PR DESCRIPTION
## Summary

- keep useful error details for users and operators
- avoid putting prompts, responses, cookies and IP addresses in logs and Sentry
- keep safe request, model, status and traceback metadata for debugging
- leave Matomo and dataset publication behavior unchanged

## Checks

- backend tests: 47 passed
- privacy logging tests passed
- formatting and diff checks passed
- rebased on the updated legal consent branch
- tested with the full consent and settings stack