### PR TITLE
chore(ci): run the backend and frontend tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,3 +44,7 @@ jobs:
       - name: Run frontend tests
         working-directory: frontend
         run: npx vitest run
+
+      - name: Build frontend
+        working-directory: frontend
+        run: yarn build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           enable-cache: true
 
       - name: Run backend tests
-        run: uv run --locked --group data pytest tests -q
+        run: uv run --locked --group dev --group data pytest tests -q
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           enable-cache: true
 
       - name: Run backend tests
-        run: uv run --group data pytest tests -q
+        run: uv run --locked --group data pytest tests -q
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - next
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+    branches:
+      - next
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.13'
+
+      - name: Run backend tests
+        run: uv run --group data pytest tests -q
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: yarn install --frozen-lockfile
+
+      - name: Run frontend tests
+        working-directory: frontend
+        run: npx vitest run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run frontend tests
         working-directory: frontend
-        run: npx vitest run
+        run: yarn vitest run
 
       - name: Build frontend
         working-directory: frontend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.13'
+          enable-cache: true
 
       - name: Run backend tests
         run: uv run --group data pytest tests -q
@@ -40,6 +41,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
 
       - name: Install dependencies
         working-directory: frontend

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ test-backend: ## Run the python test suite (no DB required)
 	$(UV) run --group dev --group data pytest tests -q
 
 test-frontend: ## Run the frontend unit tests
-	cd frontend && npx vitest run
+	cd frontend && yarn vitest run
 
 test-dataset: ## Run dataset export tests (no DB required)
 	$(UV) run --group data python tests/dataset/test_comparison_to_turns.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-backend install-frontend test test-backend test-dataset dev dev-redis dev-backend dev-frontend dev-controller build-frontend db-generate-init-old db db-prd-local docker-app-up docker-app-down docker-app-logs clean redis models-doc up-fr down-fr logs-fr display-env-fr up-da down-da logs-da display-env-da dataset-export-fr
+.PHONY: help install install-backend install-frontend test test-backend test-frontend test-dataset dev dev-redis dev-backend dev-frontend dev-controller build-frontend db-generate-init-old db db-prd-local docker-app-up docker-app-down docker-app-logs clean redis models-doc up-fr down-fr logs-fr display-env-fr up-da down-da logs-da display-env-da dataset-export-fr
 
 # Variables
 PYTHON := python3
@@ -117,7 +117,13 @@ display-env-da: ## Display env vars loaded from KeePass for DA instance
 # Development with local code
 ###################################
 
-test: test-dataset ## Run all tests
+test: test-backend test-frontend ## Run all tests
+
+test-backend: ## Run the python test suite (no DB required)
+	$(UV) run --group data pytest tests -q
+
+test-frontend: ## Run the frontend unit tests
+	cd frontend && npx vitest run
 
 test-dataset: ## Run dataset export tests (no DB required)
 	$(UV) run --group data python tests/dataset/test_comparison_to_turns.py

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ display-env-da: ## Display env vars loaded from KeePass for DA instance
 test: test-backend test-frontend ## Run all tests
 
 test-backend: ## Run the python test suite (no DB required)
-	$(UV) run --group data pytest tests -q
+	$(UV) run --group dev --group data pytest tests -q
 
 test-frontend: ## Run the frontend unit tests
 	cd frontend && npx vitest run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
     "types-psycopg2>=2.9.21.20251012",
     "types-requests>=2.32.4.20260107",
     "pydantic-to-typescript>=2.0.0",
+    "pytest>=9.1.1",
 ]
 
 [tool.mypy]

--- a/tests/arena/test_auth_ratelimit.py
+++ b/tests/arena/test_auth_ratelimit.py
@@ -12,6 +12,7 @@ import contextlib
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -55,6 +56,10 @@ async def _fake_send_login_code(email, code):
     pass
 
 
+async def _fake_get_app_settings():
+    return SimpleNamespace(auth_domain_allowlist=None)
+
+
 @contextlib.contextmanager
 def fake_router(verify_login_code=None):
     fake = FakeRedis()
@@ -65,11 +70,13 @@ def fake_router(verify_login_code=None):
         "request_login_code": auth_router.request_login_code,
         "send_login_code": auth_router.send_login_code,
         "verify_login_code": auth_router.verify_login_code,
+        "get_app_settings": auth_router.get_app_settings,
     }
     auth_router.get_redis_client = lambda: fake
     auth_router.verify_altcha_token = lambda payload: (True, None)
     auth_router.request_login_code = _fake_request_login_code
     auth_router.send_login_code = _fake_send_login_code
+    auth_router.get_app_settings = _fake_get_app_settings
     if verify_login_code is not None:
         auth_router.verify_login_code = verify_login_code
     try:

--- a/tests/dataset/test_comparison_to_turns.py
+++ b/tests/dataset/test_comparison_to_turns.py
@@ -14,12 +14,16 @@ No DB and no pytest required:
     uv run --group data python tests/dataset/test_comparison_to_turns.py
 """
 
+import asyncio
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
 
 from utils.database.models import Comparison, Turn
 from utils.database.models.messages import LLMMessage, UserMessage
@@ -36,17 +40,27 @@ LLMS = {
     "model-a": SimpleNamespace(wh_per_million_token=1000.0),
     "model-b": SimpleNamespace(wh_per_million_token=500.0),
 }
-compute.get_raw_llms_data = lambda: LLMS  # patch for both oracle and new code
+
+
+async def _llms_data():
+    return LLMS
+
+
+compute.get_llms_data = _llms_data  # patch, so no DB is needed
+
+
+def comparison_to_turns(db_comparison: Comparison) -> list[dict]:
+    """Sync wrapper, `compute.comparison_to_turns` is a coroutine."""
+    return asyncio.run(compute.comparison_to_turns(db_comparison))
 
 
 # --- oracle: the original implementation, unchanged ------------------------
 
 
 def oracle_comparison_to_turns(db_comparison: Comparison) -> list[dict]:
-    llms = compute.get_raw_llms_data()
     ctx = {
-        "llm_a": llms.get(db_comparison.llm_id_a),
-        "llm_b": llms.get(db_comparison.llm_id_b),
+        "llm_a": LLMS.get(db_comparison.llm_id_a),
+        "llm_b": LLMS.get(db_comparison.llm_id_b),
         "metadata": DatasetComparisonBaseMetadata.model_validate(
             db_comparison
         ).model_dump(),
@@ -407,7 +421,7 @@ def run():
 
     for name, comp in equivalent_cases():
         expected = oracle_comparison_to_turns(comp)
-        actual = compute.comparison_to_turns(comp)
+        actual = comparison_to_turns(comp)
         if actual != expected:
             failures.append(f"[VALUE] {name}")
             for i, (a, e) in enumerate(zip(actual, expected)):
@@ -421,7 +435,7 @@ def run():
 
     for name, comp in skip_cases():
         o, n = _raises(oracle_comparison_to_turns, comp), _raises(
-            compute.comparison_to_turns, comp
+            comparison_to_turns, comp
         )
         if not (o and n):
             failures.append(f"[SKIP oracle={o} new={n}] {name}")
@@ -429,7 +443,7 @@ def run():
             print(f"  ok  skip: {name}")
 
     for name, comp, expected in time_to_vote_value_cases():
-        got = compute.comparison_to_turns(comp)[0]["metadata"]["time_to_vote"]
+        got = comparison_to_turns(comp)[0]["metadata"]["time_to_vote"]
         if got != expected:
             failures.append(f"[TIME_TO_VOTE {name}] got {got!r}, expected {expected!r}")
         else:
@@ -444,22 +458,20 @@ def run():
     print("All equivalence cases passed.")
 
 
-# pytest entry points (if pytest is ever added)
+# pytest entry points
 def test_equivalence():
     for name, comp in equivalent_cases():
-        assert compute.comparison_to_turns(comp) == oracle_comparison_to_turns(
-            comp
-        ), name
+        assert comparison_to_turns(comp) == oracle_comparison_to_turns(comp), name
 
 
 def test_skips():
     for name, comp in skip_cases():
-        assert _raises(compute.comparison_to_turns, comp), name
+        assert _raises(comparison_to_turns, comp), name
 
 
 def test_time_to_vote_values():
     for name, comp, expected in time_to_vote_value_cases():
-        got = compute.comparison_to_turns(comp)[0]["metadata"]["time_to_vote"]
+        got = comparison_to_turns(comp)[0]["metadata"]["time_to_vote"]
         assert got == expected, f"{name}: got {got!r}, expected {expected!r}"
 
 

--- a/tests/dataset/test_streaming_export.py
+++ b/tests/dataset/test_streaming_export.py
@@ -14,6 +14,7 @@ captured from the first batch).
     uv run --group data python tests/dataset/test_streaming_export.py
 """
 
+import os
 import sys
 import tempfile
 from datetime import datetime
@@ -22,6 +23,8 @@ from pathlib import Path
 import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
 
 from utils.dataset.export import StreamingDatasetExporter
 
@@ -161,8 +164,8 @@ def check_reference_schema(failures):
                 voted_at=datetime(2024, 1, 1, 12, 0, 5),
             )
         ],
-        sys_a=fix.system_msg("s"),
-        sys_b=fix.system_msg("s"),
+        sys_a="s",
+        sys_b="s",
         mode="custom",
         custom_models_selection=["model-a", "model-b"],
         categories=["c"],
@@ -178,7 +181,7 @@ def check_reference_schema(failures):
         archived_at=datetime(2024, 1, 1),
     )
     real = pa.Table.from_pandas(
-        pd.DataFrame(compute.comparison_to_turns(full)), preserve_index=False
+        pd.DataFrame(fix.comparison_to_turns(full)), preserve_index=False
     ).schema
     ref = pa.Table.from_pandas(
         pd.DataFrame(compute._reference_rows()), preserve_index=False

--- a/uv.lock
+++ b/uv.lock
@@ -873,7 +873,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -882,7 +881,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -891,7 +889,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1113,6 +1110,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isort"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1329,6 +1335,7 @@ dev = [
     { name = "isort" },
     { name = "mypy" },
     { name = "pydantic-to-typescript" },
+    { name = "pytest" },
     { name = "python-jenkins" },
     { name = "types-markdown" },
     { name = "types-psycopg2" },
@@ -1387,6 +1394,7 @@ dev = [
     { name = "isort", specifier = ">=7.0.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pydantic-to-typescript", specifier = ">=2.0.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "python-jenkins", specifier = ">=1.8.3" },
     { name = "types-markdown", specifier = ">=3.10.0.20251106" },
     { name = "types-psycopg2", specifier = ">=2.9.21.20251012" },
@@ -1922,6 +1930,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.38.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2382,6 +2399,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2739,8 +2772,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Nothing ran the test suite automatically. `make test` only invoked two dataset scripts, no workflow ran pytest or vitest, and pytest was not even a declared dependency, so the several test files using its fixtures could never have run.
- Six tests were already failing on `next`. CI cannot go green without them, so they are fixed here.

## Changes

- `pyproject.toml`, `uv.lock`: add pytest to the dev group.
- `tests/dataset/test_comparison_to_turns.py`, `test_streaming_export.py`: `comparison_to_turns` became a coroutine and these still called it synchronously, and `get_raw_llms_data` no longer exists. Both files also need `COMPARIA_DB_URI` set before the project imports, matching what `test_auth_ratelimit.py` already does, otherwise importing `utils.dataset.compute` dies at module level.
- `tests/arena/test_auth_ratelimit.py`: the login route now calls `get_app_settings()`, which opens a database session, so the fake router stubs it alongside the redis, altcha and mail fakes it already installs.
- `.github/workflows/test.yml`: backend and frontend jobs, on pull requests and pushes to `next`.
- `Makefile`: `test` now runs the whole suite. `test-dataset` is unchanged and both scripts still run as scripts.

## Test plan

- [x] `uv run --group data pytest tests -q`: 39 passed
- [x] `make test-dataset` still passes
- [x] `cd frontend && npx vitest run`: 46 passed

`make lint-python` is deliberately not in the workflow. mypy reports 97 pre-existing errors under `tests/`, which is a separate piece of work.
