### PR TITLE
feat(front): add inline markdown renderer and document variant

### DIFF
--- a/frontend/src/lib/components/dsfr/Checkbox.svelte
+++ b/frontend/src/lib/components/dsfr/Checkbox.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import { sanitize } from '$lib/utils/commons'
   import type { SvelteHTMLElements } from 'svelte/elements'
+  import Link from './Link.svelte'
+
+  type CheckboxLink = { label: string; href: string }
 
   let {
     id,
     checked = $bindable(),
     label,
     help,
+    links = [],
+    linksClass,
     error,
     disabled,
     ...props
@@ -15,25 +20,65 @@
     checked: boolean
     label: string
     help?: string
+    links?: CheckboxLink[]
+    linksClass?: string
     error?: string
     disabled?: boolean
   } & SvelteHTMLElements['label'] = $props()
+
+  function safeHref(href: string): string | null {
+    if (href.startsWith('/') && !href.startsWith('//')) return href
+    try {
+      const url = new URL(href)
+      return url.protocol === 'https:' ? url.toString() : null
+    } catch {
+      return null
+    }
+  }
+
+  const safeLinks = $derived(
+    links.flatMap((link) => {
+      const href = safeHref(link.href)
+      return href ? [{ ...link, href }] : []
+    })
+  )
+  const describedBy = $derived(
+    error
+      ? `${id}-error-messages`
+      : [help ? `${id}-help` : '', safeLinks.length ? `${id}-links` : '']
+          .filter(Boolean)
+          .join(' ') || undefined
+  )
 </script>
 
 <div class="fr-checkbox-group fr-checkbox-group--sm" class:fr-checkbox-group--error={!!error}>
-  <input {id} aria-describedby="{id}-error-messages" type="checkbox" bind:checked {disabled} />
+  <input
+    {id}
+    aria-describedby={describedBy}
+    aria-invalid={error ? 'true' : undefined}
+    type="checkbox"
+    bind:checked
+    {disabled}
+  />
   <label {...props} class={['fr-label text-sm! mb-4 block!', props.class]} for={id}>
     {@html sanitize(label)}
     {#if help}
-      <p class="fr-message">{help}</p>
+      <p id="{id}-help" class="fr-message">{help}</p>
     {/if}
   </label>
+  {#if safeLinks.length > 0}
+    <div id="{id}-links" class="ms-8 mb-3 gap-x-3 gap-y-1 flex flex-wrap">
+      {#each safeLinks as link (link.href)}
+        <Link href={link.href} text={link.label} size="sm" class={linksClass} />
+      {/each}
+    </div>
+  {/if}
   <div
     class={['fr-messages-group', { hidden: !error }]}
     id="{id}-error-messages"
     aria-live="assertive"
   >
-    <p class="fr-message fr-message--error" id="checkbox-error-message-error">
+    <p class="fr-message fr-message--error" id="{id}-error-message">
       {error}
     </p>
   </div>

--- a/frontend/src/lib/components/dsfr/Checkbox.svelte.test.ts
+++ b/frontend/src/lib/components/dsfr/Checkbox.svelte.test.ts
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import Checkbox from './Checkbox.svelte'
+
+describe('Checkbox', () => {
+  it('describes the input with its help text and links', () => {
+    const { getByRole } = render(Checkbox, {
+      id: 'cgu',
+      checked: false,
+      label: 'J’accepte',
+      help: 'Obligatoire',
+      links: [
+        { label: 'Conditions', href: '/arene/modalites' },
+        { label: 'Externe', href: 'https://example.test/cgu' }
+      ]
+    })
+
+    const input = getByRole('checkbox')
+    expect(input.getAttribute('aria-describedby')).toBe('cgu-help cgu-links')
+    expect(input.getAttribute('aria-invalid')).toBeNull()
+    expect(getByRole('link', { name: 'Conditions' })).toBeTruthy()
+  })
+
+  it('drops links with an unsafe href', () => {
+    const { queryByRole } = render(Checkbox, {
+      id: 'cgu',
+      checked: false,
+      label: 'J’accepte',
+      links: [
+        { label: 'Piège', href: 'javascript:alert(1)' },
+        { label: 'Protocole', href: 'http://example.test/cgu' }
+      ]
+    })
+
+    expect(queryByRole('link')).toBeNull()
+  })
+
+  it('points to the error message when invalid', () => {
+    const { container, getByRole } = render(Checkbox, {
+      id: 'cgu',
+      checked: false,
+      label: 'J’accepte',
+      error: 'Champ requis'
+    })
+
+    const input = getByRole('checkbox')
+    expect(input.getAttribute('aria-describedby')).toBe('cgu-error-messages')
+    expect(input.getAttribute('aria-invalid')).toBe('true')
+    expect(container.querySelector('#cgu-error-message')?.textContent?.trim()).toBe('Champ requis')
+  })
+})

--- a/frontend/src/lib/components/dsfr/Select.svelte
+++ b/frontend/src/lib/components/dsfr/Select.svelte
@@ -8,8 +8,10 @@
     id: string
     selected: Value
     label: string
+    help?: string
     options: Option[]
     hideLabel?: boolean
+    reserveHintSpace?: boolean
     groupClass?: ClassValue
   } & HTMLSelectAttributes
 
@@ -17,8 +19,10 @@
     id,
     selected = $bindable(),
     label,
+    help,
     options,
     hideLabel = false,
+    reserveHintSpace = false,
     groupClass,
     ...props
   }: SelectProps = $props()
@@ -27,9 +31,20 @@
 <div class={['fr-select-group', groupClass]}>
   <label class={['fr-label', { 'fr-sr-only': hideLabel }]} for={id}>
     {label}
+    {#if help}
+      <span id="{id}-help" class="fr-hint-text">{help}</span>
+    {:else if reserveHintSpace}
+      <span class="fr-hint-text" aria-hidden="true">&nbsp;</span>
+    {/if}
   </label>
 
-  <select {...props} {id} bind:value={selected} class={['fr-select', props.class]}>
+  <select
+    {...props}
+    {id}
+    bind:value={selected}
+    aria-describedby={help ? `${id}-help` : props['aria-describedby']}
+    class={['fr-select', props.class]}
+  >
     {#each options as option (option.value)}
       <option value={option.value}>{option.label}</option>
     {/each}

--- a/frontend/src/lib/components/dsfr/Select.svelte.test.ts
+++ b/frontend/src/lib/components/dsfr/Select.svelte.test.ts
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import Select from './Select.svelte'
+
+const options = [
+  { value: 'a', label: 'A' },
+  { value: 'b', label: 'B' }
+]
+
+describe('Select', () => {
+  it('describes the field with its help text', () => {
+    const { container, getByRole } = render(Select, {
+      id: 'kind',
+      selected: 'a',
+      label: 'Type',
+      help: 'Choisissez un type',
+      options
+    })
+
+    expect(getByRole('combobox').getAttribute('aria-describedby')).toBe('kind-help')
+    expect(container.querySelector('#kind-help')?.textContent).toBe('Choisissez un type')
+  })
+
+  it('reserves the hint line when asked without help text', () => {
+    const { container, getByRole } = render(Select, {
+      id: 'kind',
+      selected: 'a',
+      label: 'Type',
+      reserveHintSpace: true,
+      options
+    })
+
+    expect(getByRole('combobox').getAttribute('aria-describedby')).toBeNull()
+    expect(container.querySelector('.fr-hint-text')?.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/frontend/src/lib/components/markdown/MarkdownCode.svelte
+++ b/frontend/src/lib/components/markdown/MarkdownCode.svelte
@@ -4,6 +4,7 @@
   // TODO could be reworked
   import 'katex/dist/katex.min.css'
   import { tick } from 'svelte'
+  import { normalizeDocumentHeadings } from './headings'
   import { standardHtmlAndSvgTags } from './html-tags'
   import './prism.css'
   import { copy, create_marked, sanitize } from './utils'
@@ -17,7 +18,8 @@
     header_links = false,
     allow_tags = false,
     theme_mode = 'system',
-    kind = 'bot'
+    kind = 'bot',
+    variant = 'chat'
   }: {
     message: string
     chatbot?: boolean
@@ -28,6 +30,7 @@
     allow_tags?: string[] | boolean
     theme_mode?: 'system' | 'light' | 'dark'
     kind?: 'bot' | 'user'
+    variant?: 'chat' | 'document'
   } = $props()
 
   let el = $state<HTMLElement>()
@@ -69,7 +72,7 @@
   }
 
   function process_message(value: string): string {
-    let parsedValue = value
+    let parsedValue = variant === 'document' ? normalizeDocumentHeadings(value) : value
     if (render_markdown) {
       parsedValue = marked.parse(parsedValue) as string
     }
@@ -142,6 +145,7 @@
 <span
   {@attach copy}
   class:chatbot
+  class:document={variant === 'document'}
   bind:this={el}
   class={['md', kind]}
   class:prose={render_markdown}
@@ -185,6 +189,52 @@
 
   span :global(p:not(:first-child)) {
     margin-top: var(--spacing-xxl);
+  }
+
+  span.document {
+    display: block;
+  }
+
+  span.document :global(p),
+  span.document :global(p:not(:first-child)) {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1rem;
+    line-height: 1.5;
+  }
+
+  span.document :global(h2),
+  span.document :global(h3),
+  span.document :global(h4),
+  span.document :global(h5),
+  span.document :global(h6) {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    line-height: 1.35;
+  }
+
+  span.document :global(h2) {
+    font-size: 1.5rem;
+  }
+
+  span.document :global(h3) {
+    font-size: 1.25rem;
+  }
+
+  span.document :global(ul),
+  span.document :global(ol) {
+    margin-top: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  span.document :global(li) {
+    margin-top: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  span.document :global(blockquote) {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
   }
 
   span :global(.md-header-anchor) {

--- a/frontend/src/lib/components/markdown/MarkdownCode.svelte.test.ts
+++ b/frontend/src/lib/components/markdown/MarkdownCode.svelte.test.ts
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import MarkdownCode from './MarkdownCode.svelte'
+
+describe('MarkdownCode', () => {
+  it('keeps the chat variant by default', () => {
+    const { container } = render(MarkdownCode, { message: '# Titre' })
+
+    expect(container.querySelector('.md.document')).toBeNull()
+    expect(container.querySelector('h1')).toBeTruthy()
+  })
+
+  it('normalizes headings in the document variant', () => {
+    const { container } = render(MarkdownCode, {
+      message: '# Titre\n\n#### Section\n\nContenu',
+      variant: 'document'
+    })
+
+    expect(container.querySelector('.md.document')).toBeTruthy()
+    expect(container.querySelector('h1')).toBeNull()
+    expect(Array.from(container.querySelectorAll('h2, h3')).map((el) => el.tagName)).toEqual([
+      'H2',
+      'H3'
+    ])
+  })
+})

--- a/frontend/src/lib/components/markdown/MarkdownInline.svelte
+++ b/frontend/src/lib/components/markdown/MarkdownInline.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  import { renderInlineMarkdown } from './inline'
+
+  let { message, allowLinks = true }: { message: string; allowLinks?: boolean } = $props()
+  const html = $derived(renderInlineMarkdown(message, allowLinks))
+</script>
+
+<span class="markdown-inline">{@html html}</span>

--- a/frontend/src/lib/components/markdown/MarkdownInline.svelte.test.ts
+++ b/frontend/src/lib/components/markdown/MarkdownInline.svelte.test.ts
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import MarkdownInline from './MarkdownInline.svelte'
+
+const message = 'Lire [**les conditions**](/arene/modalites)'
+
+describe('MarkdownInline', () => {
+  it('renders inline markdown', () => {
+    const { container } = render(MarkdownInline, { message })
+
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/arene/modalites')
+    expect(container.querySelector('strong')).toBeTruthy()
+  })
+
+  it('keeps formatting but no link when allowLinks is false', () => {
+    const { container } = render(MarkdownInline, { message, allowLinks: false })
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelector('strong')?.textContent).toBe('les conditions')
+  })
+})

--- a/frontend/src/lib/components/markdown/headings.test.ts
+++ b/frontend/src/lib/components/markdown/headings.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeDocumentHeadings } from './headings'
+
+describe('normalizeDocumentHeadings', () => {
+  it('starts document content at heading level two', () => {
+    expect(normalizeDocumentHeadings('# Title\n\n## Section')).toBe('## Title\n\n## Section')
+  })
+
+  it('prevents skipped heading levels', () => {
+    expect(normalizeDocumentHeadings('#### Section\n###### Detail')).toBe('## Section\n### Detail')
+  })
+
+  it('normalizes setext headings', () => {
+    expect(normalizeDocumentHeadings('Section\n---')).toBe('## Section')
+  })
+
+  it('leaves a thematic break after a heading alone', () => {
+    expect(normalizeDocumentHeadings('# Title\n---')).toBe('## Title\n---')
+  })
+
+  it('leaves headings inside code fences unchanged', () => {
+    expect(normalizeDocumentHeadings('```md\n# Example\n```')).toBe('```md\n# Example\n```')
+  })
+})

--- a/frontend/src/lib/components/markdown/headings.ts
+++ b/frontend/src/lib/components/markdown/headings.ts
@@ -1,0 +1,44 @@
+const FENCE = /^ {0,3}(`{3,}|~{3,})/
+const ATX = /^ {0,3}(#{1,6})(\s+.*)$/
+const SETEXT = /^ {0,3}(?:=+|-+)\s*$/
+
+export function normalizeDocumentHeadings(markdown: string): string {
+  const output: string[] = []
+  let previousLevel = 1
+  let fence: { marker: string; length: number } | undefined
+
+  for (const line of markdown.split('\n')) {
+    const fenceMatch = line.match(FENCE)
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0]
+      if (!fence) fence = { marker, length: fenceMatch[1].length }
+      else if (fence.marker === marker && fenceMatch[1].length >= fence.length) fence = undefined
+      output.push(line)
+      continue
+    }
+
+    if (fence) {
+      output.push(line)
+      continue
+    }
+
+    const heading = line.match(ATX)
+    if (heading) {
+      previousLevel = Math.min(Math.max(2, heading[1].length), previousLevel + 1)
+      output.push(`${'#'.repeat(previousLevel)}${heading[2]}`)
+      continue
+    }
+
+    const previous = output.at(-1)?.trim()
+    if (previous && !previous.startsWith('#') && SETEXT.test(line)) {
+      output.pop()
+      previousLevel = 2
+      output.push(`## ${previous}`)
+      continue
+    }
+
+    output.push(line)
+  }
+
+  return output.join('\n')
+}

--- a/frontend/src/lib/components/markdown/inline.test.ts
+++ b/frontend/src/lib/components/markdown/inline.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { renderInlineMarkdown } from './inline'
+
+describe('renderInlineMarkdown', () => {
+  it('renders inline formatting and links', () => {
+    const html = renderInlineMarkdown(
+      '**Important**, *à lire* sur [la page dédiée](https://example.test/conditions).'
+    )
+
+    expect(html).toContain('<strong>Important</strong>')
+    expect(html).toContain('<em>à lire</em>')
+    expect(html).toContain('href="https://example.test/conditions"')
+  })
+
+  it('drops unsafe markup', () => {
+    expect(
+      renderInlineMarkdown('[Piège](javascript:alert(1)) <script>alert(1)</script>')
+    ).not.toMatch(/javascript:|<script/i)
+  })
+
+  it('keeps link text only when links are not allowed', () => {
+    expect(renderInlineMarkdown('Lire [les conditions](/arene/modalites)', false)).toBe(
+      'Lire les conditions'
+    )
+    expect(renderInlineMarkdown('Lire <a href="https://evil.test">ici</a>', false)).toBe('Lire ici')
+    expect(renderInlineMarkdown('Lire [**les conditions**](/arene/modalites)', false)).toBe(
+      'Lire <strong>les conditions</strong>'
+    )
+  })
+})

--- a/frontend/src/lib/components/markdown/inline.ts
+++ b/frontend/src/lib/components/markdown/inline.ts
@@ -1,0 +1,8 @@
+import { sanitize } from '$lib/utils/commons'
+import { create_marked } from './utils'
+
+const inlineMarkdown = create_marked({ header_links: false, line_breaks: false })
+
+export function renderInlineMarkdown(value: string, allowLinks = true): string {
+  return sanitize(inlineMarkdown.parseInline(value) as string, allowLinks)
+}

--- a/frontend/src/lib/utils/commons.ts
+++ b/frontend/src/lib/utils/commons.ts
@@ -2,14 +2,18 @@ import sanitizeHtml from 'sanitize-html'
 
 export const noop = () => {}
 
-export function sanitize(html: string): string {
-  return sanitizeHtml(html, {
+export function sanitize(html: string, allowLinks = true): string {
+  const options: sanitizeHtml.IOptions = {
     allowedAttributes: {
       span: ['class'],
       a: ['href', 'rel', 'target', 'title', 'class', 'data-fr-opened', 'aria-controls'],
       br: []
     }
-  })
+  }
+  if (!allowLinks) {
+    options.allowedTags = sanitizeHtml.defaults.allowedTags.filter((tag) => tag !== 'a')
+  }
+  return sanitizeHtml(html, options)
 }
 
 export function propsToAttrs(props: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary

Groundwork for rendering legal documents from the database. No user-visible change on its own, which is why it is split out.

- `MarkdownInline` renders a single line of markdown, with an option to keep only the link text where a nested link would be invalid, for example inside a button.
- `MarkdownCode` gains a `document` variant that shifts headings so a long document starts at level two and never skips a level, and uses block spacing rather than chat spacing.
- The DSFR checkbox can list related links under its label, and the select takes a hint.

## Changes

- `markdown/inline.ts`, `MarkdownInline.svelte`, `markdown/headings.ts`.
- `MarkdownCode.svelte`: `variant` prop and document styles.
- `dsfr/Checkbox.svelte`: `links`, and `aria-describedby` now points at the help text, the links or the error. Its error paragraph had a hardcoded id, so two checkboxes on one page collided; it is derived from the field id now.
- `dsfr/Select.svelte`: `help` and `reserveHintSpace`.
- `utils/commons.ts`: `sanitize` takes an optional `allowLinks`, defaulting to `true` so every existing caller is byte for byte unchanged.

## Notes

`allowLinks: false` drops anchors at the sanitising step rather than by rewriting the rendered HTML, so it holds for a literal `<a>` in the source as well as for a markdown link. Both cases are covered by tests.

`normalizeDocumentHeadings` keeps its fence tracking, which stops `# comment` inside a code block being rewritten. It also fixes a case where an ATX heading followed by `---` was read as a setext underline and produced `## ## Foo`.

## Test plan

- [x] `npx vitest run`: 63 passed, up from 46
- [x] `npx vite build` clean
- [x] `svelte-check` unchanged from `next`
