### PR TITLE
fix(tabs): key selected state off the reactive current tab

### DIFF
--- a/frontend/src/lib/components/dsfr/Tabs.svelte
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte
@@ -2,9 +2,14 @@
   lang="ts"
   generics="T extends { id: string; label: string; href?: string; content?: string, icon?: string }"
 >
-  import type { Snippet } from 'svelte'
+  import { resolve } from '$app/paths'
+  import { untrack, type Snippet } from 'svelte'
   import type { ClassValue, SvelteHTMLElements } from 'svelte/elements'
   import { Icon } from '.'
+
+  // resolve() is typed for routes known at compile time, one literal per call. Tabs
+  // takes its hrefs as plain strings, so the generic signature can never match.
+  const resolveHref = resolve as (href: string) => string
 
   let {
     tabs,
@@ -25,15 +30,15 @@
     tab?: Snippet<[T]>
   } & SvelteHTMLElements['div'] = $props()
 
-  let currentTabId = $state(initialId)
+  let currentTabId = $state(untrack(() => initialId))
 
   const items = $derived.by(() =>
     tabs.map((tab) => ({
       props: {
         id: `tab-${tab.id}`,
-        tabindex: tab.id === initialId ? 0 : -1,
+        tabindex: tab.id === currentTabId ? 0 : -1,
         role: 'tab',
-        'aria-selected': tab.id === initialId ? true : false,
+        'aria-selected': tab.id === currentTabId ? true : false,
         'aria-controls': `tab-${tab.id}-panel`,
         class: kind === 'tab' ? 'fr-tabs__tab' : 'fr-nav__link',
         onclick: () => (currentTabId = tab.id)
@@ -55,7 +60,7 @@
     {#each items as item, i (i)}
       <li role="presentation" class="whitespace-nowrap">
         {#if item.href}
-          <a {...item.props} href={item.href}>
+          <a {...item.props} href={resolveHref(item.href)}>
             {#if item.icon}<Icon icon={item.icon} size="xs" class="me-2" />{/if}{item.label}
           </a>
         {:else}
@@ -75,7 +80,7 @@
       class={[
         'fr-tabs__panel',
         {
-          'fr-tabs__panel--selected': item.id === initialId,
+          'fr-tabs__panel--selected': item.id === currentTabId,
           'px-0! py-5!': noBorders,
           'visibility-none! transition-none!': item.href && item.id !== currentTabId
         },

--- a/frontend/src/lib/components/dsfr/Tabs.svelte.test.ts
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte.test.ts
@@ -1,0 +1,27 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import Tabs from './Tabs.svelte'
+
+describe('Tabs', () => {
+  it('updates the selected tab and panel', async () => {
+    const { getByRole } = render(Tabs, {
+      tabs: [
+        { id: 'add', label: 'Ajouter', content: 'Formulaire' },
+        { id: 'manage', label: 'Gérer', content: 'Liste' }
+      ],
+      label: 'Catégories'
+    })
+
+    const addTab = getByRole('tab', { name: 'Ajouter' })
+    const manageTab = getByRole('tab', { name: 'Gérer' })
+
+    expect(addTab).toHaveAttribute('aria-selected', 'true')
+    expect(manageTab).toHaveAttribute('aria-selected', 'false')
+
+    await fireEvent.click(manageTab)
+
+    expect(addTab).toHaveAttribute('aria-selected', 'false')
+    expect(manageTab).toHaveAttribute('aria-selected', 'true')
+    expect(getByRole('tabpanel', { name: 'Gérer' })).toHaveClass('fr-tabs__panel--selected')
+  })
+})

--- a/frontend/src/vitest.d.ts
+++ b/frontend/src/vitest.d.ts
@@ -1,0 +1,4 @@
+// vitest-setup-client.ts imports this at runtime, but it sits outside the
+// include list in .svelte-kit/tsconfig.json, so the matcher types never
+// reached svelte-check. Pull them in from a file that is included.
+import '@testing-library/jest-dom/vitest'


### PR DESCRIPTION
## The bug

`Tabs.svelte` built `aria-selected`, `tabindex` and the `fr-tabs__panel--selected` class from the `initialId` prop. Those are evaluated once and never recomputed, so clicking a tab moved the visible panel but left the first tab marked as selected for assistive technology, and kept it as the only tab in the roving tabindex.

Anyone navigating with a screen reader or the keyboard was told the first tab was still current, whichever tab they had actually opened. This affects every use of the component.

## The fix

Read `currentTabId`, which is the state the click handler already updates.

Two smaller changes come with it:

- `initialId` is read through `untrack()`, so a later change to the prop cannot clobber a selection the user has made.
- Tab hrefs go through `resolve()` from `$app/paths`, which also clears one of the existing `svelte/no-navigation-without-resolve` lint errors. `resolve()` is typed for a single route literal known at compile time while `Tabs` takes plain strings, so the call goes through a locally narrowed alias. Typing `href` as `Pathname` does not work: the argument type distributes over the route union, so a value holding the whole union matches none of the resulting signatures, and it also breaks `product/[tab]/+page.svelte` where the mapped path widens to `string`.

The second commit is unrelated to the bug but needed to keep the type checker honest. `vitest-setup-client.ts` imports the jest-dom matchers at runtime, but it sits outside the include list in the generated tsconfig, so their types never reached `svelte-check`. Any test using `toHaveAttribute` or `toHaveClass` reported an error despite passing. Importing them from a file that is included fixes it for every test file, not just the one added here.

## Notes for reviewers

Only one component passes `href` to `Tabs`, `product/[tab]/+page.svelte`, and it builds paths from a hardcoded list. No caller passes an external or user supplied URL, so `resolve()` cannot reject anything at runtime.

This was found while reviewing #616, which carried the same change bundled in. It has been taken out of that branch, so the two do not overlap.

## Validation

- New unit test covering the click and the resulting `aria-selected` and panel class.
- Full frontend suite passes.
- `svelte-check` reports the same 14 errors as `next`, down from 20 before the typing and tsconfig fixes.
- Formatting clean.
