### PR TITLE
fix(db): validate locale settings and seed default_locale

### DIFF
--- a/tests/auth/test_account.py
+++ b/tests/auth/test_account.py
@@ -157,6 +157,8 @@ def test_public_config_carries_the_deployment_url():
             secondary_color_dark="#CACAFB",
             homepage_url=None,
             logo=None,
+            enabled_locales=["fr"],
+            default_locale="fr",
         )
 
     with patched(auth_router, get_app_settings=get_app_settings):

--- a/tests/database/test_app_settings_locales.py
+++ b/tests/database/test_app_settings_locales.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
+os.environ["LOG_FORMAT"] = "JSON"
+
+from utils.database.models.app_settings import (
+    SUPPORTED_LOCALES,
+    AppSettings,
+    AppSettingsPatch,
+)
+
+
+def test_a_fresh_instance_enables_every_shipped_locale() -> None:
+    assert AppSettings().enabled_locales == list(SUPPORTED_LOCALES)
+
+
+def test_defaults_are_not_shared_between_instances() -> None:
+    first = AppSettings()
+    first.enabled_locales.append("xx")
+
+    assert AppSettings().enabled_locales == list(SUPPORTED_LOCALES)
+
+
+@pytest.mark.parametrize("locales", [["fr"], ["da", "en"], list(SUPPORTED_LOCALES)])
+def test_supported_locales_are_accepted(locales: list[str]) -> None:
+    assert AppSettingsPatch(enabled_locales=locales).enabled_locales == locales
+
+
+def test_unsupported_locales_are_refused() -> None:
+    with pytest.raises(ValidationError, match="Unsupported locales: de, xx"):
+        AppSettingsPatch(enabled_locales=["fr", "xx", "de"])
+
+
+def test_enabling_no_locale_is_refused() -> None:
+    # An empty list would leave the language menu empty and every visitor stuck
+    # on whatever Paraglide falls back to.
+    with pytest.raises(ValidationError, match="At least one locale"):
+        AppSettingsPatch(enabled_locales=[])
+
+
+def test_unsupported_default_locale_is_refused() -> None:
+    with pytest.raises(ValidationError, match="Unsupported locale: xx"):
+        AppSettingsPatch(default_locale="xx")
+
+
+def test_locales_are_left_alone_when_the_patch_omits_them() -> None:
+    patch = AppSettingsPatch(platform_name="Whatever")
+
+    assert patch.enabled_locales is None
+    assert patch.default_locale is None
+    assert patch.model_dump(exclude_unset=True) == {"platform_name": "Whatever"}

--- a/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
+++ b/utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py
@@ -5,6 +5,7 @@ Revises: e3a7c5f19b04
 Create Date: 2026-07-21 00:00:00.000000
 
 """
+import os
 from typing import Sequence, Union
 
 from alembic import op
@@ -17,6 +18,18 @@ down_revision: Union[str, Sequence[str], None] = 'e3a7c5f19b04'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+# Frozen copy of SUPPORTED_LOCALES at the time of this revision. Migrations don't
+# import app code, so this list stays right even after the model's list moves on.
+_SUPPORTED_LOCALES = ('da', 'en', 'fr', 'lt', 'sv')
+
+
+def _instance_locale() -> str:
+    # The da instance used to get its locale from the frontend's DEFAULT_LOCALE
+    # env var, which this column replaces. Seed from the backend's own instance
+    # name so ai-arenaen.dk doesn't come back up in French after the upgrade.
+    portal = os.environ.get('DEFAULT_COUNTRY_PORTAL', 'fr')
+    return portal if portal in _SUPPORTED_LOCALES else 'fr'
+
 
 def upgrade() -> None:
     op.add_column(
@@ -25,7 +38,7 @@ def upgrade() -> None:
             'default_locale',
             sqlmodel.sql.sqltypes.AutoString(),
             nullable=False,
-            server_default='fr',
+            server_default=_instance_locale(),
         ),
     )
     op.alter_column('app_settings', 'default_locale', server_default=None)

--- a/utils/database/models/app_settings.py
+++ b/utils/database/models/app_settings.py
@@ -72,6 +72,22 @@ def _normalize_homepage_url(value: object) -> str | None:
     return url
 
 
+# Locales compiled into the frontend bundle, see frontend/comparia.inlang/settings.json.
+# An instance enables a subset of these. Anything outside the tuple is refused
+# rather than stored, because the frontend has no messages for it and would fall
+# back to the base locale without telling anyone.
+SUPPORTED_LOCALES = ("da", "en", "fr", "lt", "sv")
+
+
+def _check_enabled_locales(value: list[str]) -> list[str]:
+    if not value:
+        raise ValueError("At least one locale must be enabled")
+    unknown = sorted(set(value) - set(SUPPORTED_LOCALES))
+    if unknown:
+        raise ValueError(f"Unsupported locales: {', '.join(unknown)}")
+    return value
+
+
 class AppSettings(SQLModel, table=True):
     """Singleton row (id=1) holding product settings editable from the admin panel."""
 
@@ -94,13 +110,9 @@ class AppSettings(SQLModel, table=True):
     homepage_url: str | None = Field(default=None, max_length=_HOMEPAGE_URL_MAX_LENGTH)
     logo: Annotated[bytes | None, Field(sa_type=LargeBinary)] = None
     logo_content_type: str | None = None
-    enabled_locales: Annotated[list[str], Field(sa_type=JSONB)] = [
-        "da",
-        "en",
-        "fr",
-        "lt",
-        "sv",
-    ]
+    enabled_locales: Annotated[list[str], Field(sa_type=JSONB)] = list(
+        SUPPORTED_LOCALES
+    )
     default_locale: str = Field(default="fr")
     updated_at: AutoDatetime
     updated_by: uuid.UUID | None = Field(default=None, foreign_key="auth_user.id")
@@ -165,3 +177,15 @@ class AppSettingsPatch(SQLModel):
     @classmethod
     def normalize_homepage_url(cls, value: object) -> str | None:
         return _normalize_homepage_url(value)
+
+    @field_validator("enabled_locales")
+    @classmethod
+    def validate_enabled_locales(cls, value: list[str] | None) -> list[str] | None:
+        return value if value is None else _check_enabled_locales(value)
+
+    @field_validator("default_locale")
+    @classmethod
+    def validate_default_locale(cls, value: str | None) -> str | None:
+        if value is not None and value not in SUPPORTED_LOCALES:
+            raise ValueError(f"Unsupported locale: {value}")
+        return value

--- a/utils/database/settings.py
+++ b/utils/database/settings.py
@@ -2,15 +2,24 @@ import uuid
 from datetime import datetime
 
 from backend.config import settings
-from utils.database.models.app_settings import AppSettings
+from utils.database.models.app_settings import SUPPORTED_LOCALES, AppSettings
 from utils.database.session import get_session
 from utils.storage.redis import REDIS_APP_SETTINGS_KEY, invalidate_cache, redis_cache
+
+# DEFAULT_COUNTRY_PORTAL names the instance and happens to be a locale code on
+# the fr and da instances. One-off instances name themselves something else, so
+# fall back to fr rather than seeding a locale the frontend can't render.
+_INSTANCE_LOCALE = (
+    settings.DEFAULT_COUNTRY_PORTAL
+    if settings.DEFAULT_COUNTRY_PORTAL in SUPPORTED_LOCALES
+    else "fr"
+)
 
 _DEFAULTS = AppSettings(
     auth_access_policy=settings.AUTH_ACCESS_POLICY,
     auth_domain_allowlist=settings.AUTH_DOMAIN_ALLOWLIST,
     votes_objective=settings.VOTES_OBJECTIVE,
-    enabled_locales=["da", "en", "fr", "lt", "sv"],
+    default_locale=_INSTANCE_LOCALE,
 )
 
 


### PR DESCRIPTION
## Summary

Three fixes found while reading `feat/available-locales-setting`. Based on that branch, targeting it, so it can go in before the rebase onto `next`.

The one that matters is the second: as it stands, the da instance comes back up in French after the upgrade.

## Changes

- `utils/database/models/app_settings.py`: add `SUPPORTED_LOCALES` and validate `AppSettingsPatch` against it. Both fields were free-form strings, so a patch could store a code with no compiled messages behind it. `enabled_locales: ["xx"]` was accepted and left every visitor with an empty language menu. An empty list is refused too, since it has the same effect.
- `utils/database/alembic/versions/f8c2b6a41d70_add_default_locale.py`: the column landed with `server_default='fr'`, which backfills every existing row. `DEFAULT_LOCALE` is a frontend env var, so a migration can't read it, and `ai-arenaen.dk` would have had `default_locale='fr'` written into its database. Read `DEFAULT_COUNTRY_PORTAL` instead, which the backend does have, and keep `fr` for instances that name themselves something other than a locale code.
- `utils/database/settings.py`: same seed for `_DEFAULTS`, and drop the `enabled_locales` list that repeated the model default.
- `tests/database/test_app_settings_locales.py`: new, in the shape of `test_app_settings_branding.py` on `next`.

## Test plan

- [x] `pytest tests/database` passes, 9 tests
- [x] Ran the migration against a database with an existing `app_settings` row, at each of the three instance names:

  ```
  DEFAULT_COUNTRY_PORTAL=fr     -> default_locale = fr
  DEFAULT_COUNTRY_PORTAL=da     -> default_locale = da
  DEFAULT_COUNTRY_PORTAL=musee  -> default_locale = fr
  ```

  The `da` row is the one that would have been `fr` before this change.
- [x] `PATCH /admin/settings` against a running backend:

  ```
  {"enabled_locales":["fr","xx"]}   -> 422  Unsupported locales: xx
  {"default_locale":"xx"}           -> 422  Unsupported locale: xx
  {"enabled_locales":[]}            -> 422  At least one locale must be enabled
  {"enabled_locales":["da","fr"]}   -> 200
  ```

  The existing cross-field guard still returns 400 when the default isn't in the enabled list.

## Related

Opened alongside a second branch that questions whether `HOST_TO_LOCALE` should still exist now that these settings are in the database. That one is a draft, since it's a direction question rather than a fix. This PR stands on its own either way.
