### PR TITLE
refactor(front): scope locales to the instance, not the domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # Instance configuration
 export DEFAULT_COUNTRY_PORTAL=fr
-export DEFAULT_LOCALE=fr
 
 # Currency used to display model prices and conversation costs (ISO 4217).
 # Rates are refreshed daily from the open-source Frankfurter API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Copy the example env file and fill in the required values:
 cp .env.example .env
 ```
 
-Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_COUNTRY_PORTAL=da`, `DEFAULT_LOCALE=da`, and point `COMPARIA_DB_URI` to the DA database.
+Set `OPENROUTER_API_KEY` for real LLM calls, or uncomment `MOCK_RESPONSE=true` to skip them. For the DA instance, change `DEFAULT_COUNTRY_PORTAL=da` and point `COMPARIA_DB_URI` to the DA database.
 
 Start Postgres and Redis, then run:
 
@@ -39,7 +39,7 @@ source .env
 make dev      # backend on :8008, frontend on :5173
 ```
 
-For the DA instance, copy `.env.example` and set `DEFAULT_COUNTRY_PORTAL=da`, `DEFAULT_LOCALE=da`, and `COMPARIA_DB_URI` to the DA database before sourcing.
+For the DA instance, copy `.env.example` and set `DEFAULT_COUNTRY_PORTAL=da` and `COMPARIA_DB_URI` to the DA database before sourcing.
 
 ---
 

--- a/devops/instances/da/app.compose.da.yml
+++ b/devops/instances/da/app.compose.da.yml
@@ -6,7 +6,6 @@ services:
     depends_on:
       - backend-da
     environment:
-      DEFAULT_LOCALE: da
       PUBLIC_LANGUIA_DEBUG: "true"
       PUBLIC_API_LOCAL_URL: "http://backend-da:80"
       PUBLIC_API_URL: "${PUBLIC_API_URL:-http://localhost:8002}"

--- a/devops/instances/fr/app.compose.fr.yml
+++ b/devops/instances/fr/app.compose.fr.yml
@@ -6,7 +6,6 @@ services:
     depends_on:
       - backend-fr
     environment:
-      DEFAULT_LOCALE: fr
       PUBLIC_LANGUIA_DEBUG: "true"
       PUBLIC_API_LOCAL_URL: "http://backend-fr:80"
       PUBLIC_API_URL: "${PUBLIC_API_URL:-http://localhost:8001}"

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -42,7 +42,8 @@
             "saved": "Indstillinger opdateret",
             "locales": {
                 "enabled": {
-                    "label": "Aktiverede sprog"
+                    "label": "Aktiverede sprog",
+                    "hint": "Fjernes markeringen for et sprog, forsvinder det straks fra menuen. Besøgende, der allerede læser på det sprog, skifter til standardsproget ved næste sideindlæsning."
                 },
                 "default": {
                     "label": "Standardsprog"

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -41,7 +41,8 @@
             "saved": "Settings updated",
             "locales": {
                 "enabled": {
-                    "label": "Enabled languages"
+                    "label": "Enabled languages",
+                    "hint": "Unchecking a language removes it from the menu immediately. Visitors already reading in it switch to the default language on their next page load."
                 },
                 "default": {
                     "label": "Default language"

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -255,7 +255,8 @@
                     "label": "Langue par défaut"
                 },
                 "enabled": {
-                    "label": "Langues activées"
+                    "label": "Langues activées",
+                    "hint": "Décocher une langue la retire immédiatement du menu. Les personnes qui la lisaient basculent vers la langue par défaut au prochain chargement."
                 }
             },
             "save": "Enregistrer",

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,6 +1,5 @@
 import { env } from '$env/dynamic/private'
 import { api, UnauthorizedError } from '$lib/fastapi-client'
-import { HOST_TO_LOCALE } from '$lib/global.svelte'
 import { defineCustomServerStrategy } from '$lib/i18n/runtime'
 import { paraglideMiddleware } from '$lib/i18n/server'
 import { logger } from '$lib/logger.server'
@@ -12,53 +11,67 @@ import { sequence } from '@sveltejs/kit/hooks'
 const MATOMO_ID = env.MATOMO_ID || ''
 const MATOMO_URL = env.MATOMO_URL || ''
 
-const DEFAULT_LOCALE_CHECK_TTL_MS = 20_000
+const LOCALE_SETTINGS_TTL_MS = 20_000
 
-// Cached per Node process (same rationale as maintenanceCache below): the
-// admin-editable default locale doesn't need to be read from the backend on
-// every single request.
-let defaultLocaleCache: { value: string; checkedAt: number } | null = null
+type LocaleSettings = { enabled_locales: string[]; default_locale: string }
 
-async function getDefaultLocale(): Promise<string> {
+// Cached per Node process (same rationale as maintenanceCache below). The
+// in-flight promise is cached rather than its result, so a cold process fires
+// one request instead of one per concurrent render.
+let localeSettingsCache: { promise: Promise<LocaleSettings>; checkedAt: number } | null = null
+let lastLocaleSettings: LocaleSettings = { enabled_locales: [], default_locale: '' }
+
+function getLocaleSettings(): Promise<LocaleSettings> {
   const now = Date.now()
-  if (!defaultLocaleCache || now - defaultLocaleCache.checkedAt >= DEFAULT_LOCALE_CHECK_TTL_MS) {
-    let value = defaultLocaleCache?.value ?? ''
-    try {
-      ;({ default_locale: value } = await api.request<{ default_locale: string }>('/auth/config'))
-    } catch (error) {
-      // Fail open: fall back to Paraglide's own strategies if the check fails
-      logger.error('Default locale check failed', { error: `${error}` })
+  if (!localeSettingsCache || now - localeSettingsCache.checkedAt >= LOCALE_SETTINGS_TTL_MS) {
+    localeSettingsCache = {
+      checkedAt: now,
+      promise: api
+        .request<Partial<LocaleSettings>>('/auth/config')
+        .then((config) => {
+          lastLocaleSettings = {
+            enabled_locales: config.enabled_locales ?? [],
+            default_locale: config.default_locale ?? ''
+          }
+          return lastLocaleSettings
+        })
+        .catch((error) => {
+          // Fail open: keep serving the last known settings, and let Paraglide's
+          // own strategies decide if we never managed to read any.
+          logger.error('Locale settings fetch failed', { error: `${error}` })
+          return lastLocaleSettings
+        })
     }
-    defaultLocaleCache = { value, checkedAt: now }
   }
-  return defaultLocaleCache.value
+  return localeSettingsCache.promise
 }
 
 defineCustomServerStrategy('custom-url', {
+  // Paraglide runs custom strategies before every built-in one, so this is the
+  // only place that sees all the locale sources at once, and the only place that
+  // can turn one down. It reads PARAGLIDE_LOCALE itself instead of leaving it to
+  // the built-in cookie strategy, because a cookie holding a locale the admin
+  // has since disabled has to be overridden rather than honoured.
+  //
+  // Returning undefined hands over to those built-in strategies, which is what
+  // we want when the backend is unreachable and we have nothing to enforce.
   getLocale: async (request) => {
     if (!request) return
-    const url = new URL(request.url)
-    const locale = url.searchParams.get('locale')
+    const { enabled_locales, default_locale } = await getLocaleSettings()
+    if (!enabled_locales.length) return
 
-    if (url.host in HOST_TO_LOCALE) {
-      return HOST_TO_LOCALE[url.host as keyof typeof HOST_TO_LOCALE]
-    } else if (locale) {
-      return locale
-    } else {
-      // Only apply the default locale if no user cookie is already set.
-      // Paraglide runs custom strategies before built-in ones (including cookie),
-      // so without this check it would silently override the user's locale
-      // preference stored in PARAGLIDE_LOCALE.
-      const cookieLocale = request.headers
-        .get('cookie')
-        ?.split('; ')
-        .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
-        ?.split('=')[1]
-      if (!cookieLocale) {
-        const defaultLocale = await getDefaultLocale()
-        if (defaultLocale) return defaultLocale
-      }
+    const cookieLocale = request.headers
+      .get('cookie')
+      ?.split('; ')
+      .find((c) => c.startsWith('PARAGLIDE_LOCALE='))
+      ?.split('=')[1]
+
+    const requested = new URL(request.url).searchParams.get('locale')
+    for (const candidate of [requested, cookieLocale]) {
+      if (candidate && enabled_locales.includes(candidate)) return candidate
     }
+
+    return default_locale || undefined
   }
 })
 

--- a/frontend/src/lib/components/header/LanguageSelector.svelte
+++ b/frontend/src/lib/components/header/LanguageSelector.svelte
@@ -1,29 +1,16 @@
 <script lang="ts">
-  import { page } from '$app/state'
   import { getAuthContext } from '$lib/auth.svelte'
   import Dropdown from '$components/Dropdown.svelte'
-  import { getLocales, type LocaleOption } from '$lib/global.svelte'
+  import { getLocales } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale, setLocale } from '$lib/i18n/runtime'
   import type { SvelteHTMLElements } from 'svelte/elements'
-  import { SvelteURL } from 'svelte/reactivity'
 
   let { id, ...props }: { id: string } & SvelteHTMLElements['nav'] = $props()
 
   const auth = getAuthContext()
   const locales = $derived(getLocales(auth.config.enabled_locales))
   const currentLocale = getLocale()
-
-  function onLocaleSelect(locale: LocaleOption) {
-    if (page.url.host !== locale.host) {
-      const url = new SvelteURL(window.location.href)
-      url.host = locale.host
-      url.search = `locale=${locale.code}`
-      window.location.href = url.href
-    } else {
-      setLocale(locale.code)
-    }
-  }
 </script>
 
 <nav {...props} class={['language-selector fr-translate fr-nav whitespace-nowrap', props.class]}>
@@ -42,7 +29,7 @@
             class="fr-sidemenu__link py-2! font-normal! font-sm!"
             lang={locale.code}
             aria-current={locale.code == currentLocale}
-            onclick={() => onLocaleSelect(locale)}
+            onclick={() => setLocale(locale.code)}
           >
             {locale.long}
           </button>

--- a/frontend/src/lib/global.svelte.ts
+++ b/frontend/src/lib/global.svelte.ts
@@ -1,29 +1,23 @@
-import { dev } from '$app/environment'
 import { getLocale, type Locale } from '$lib/i18n/runtime'
 import { getContext, setContext } from 'svelte'
 
-export type LocaleOption = { code: Locale; short: string; long: string; host: string }
+export type LocaleOption = { code: Locale; short: string; long: string }
 
-const DEFAULT_HOST = dev ? 'localhost:5173' : 'comparia.beta.gouv.fr'
-export const HOST_TO_LOCALE = dev
-  ? {
-      '127.0.0.1:8080': 'da'
-    }
-  : {
-      'ai-arenaen.dk': 'da',
-      'aiarenaen.dk': 'da'
-    }
+// Every locale the bundle ships with. Which of them an instance offers is an
+// admin setting (AppSettings.enabled_locales), not a property of the domain:
+// picking a language never moves you to another instance.
 export const ALL_LOCALES = [
-  { code: 'da', short: 'DA', long: 'DA - Dansk', host: dev ? '127.0.0.1:8080' : 'ai-arenaen.dk' },
-  { code: 'fr', short: 'FR', long: 'FR - Français', host: DEFAULT_HOST },
-  { code: 'en', short: 'EN', long: 'EN - English', host: DEFAULT_HOST },
-  { code: 'lt', short: 'LT', long: 'LT - Lietuvių', host: DEFAULT_HOST },
-  { code: 'sv', short: 'SV', long: 'SV - Svensk', host: DEFAULT_HOST }
+  { code: 'da', short: 'DA', long: 'DA - Dansk' },
+  { code: 'fr', short: 'FR', long: 'FR - Français' },
+  { code: 'en', short: 'EN', long: 'EN - English' },
+  { code: 'lt', short: 'LT', long: 'LT - Lietuvių' },
+  { code: 'sv', short: 'SV', long: 'SV - Svensk' }
 ] satisfies LocaleOption[]
 
-// enabledLocales comes from AppSettings (admin-editable, see auth.config),
-// replacing the old build-time PUBLIC_DISABLED_LOCALES env var.
-export function getLocales(enabledLocales: string[]): LocaleOption[] {
+// Falls back to the full list so a frontend deployed ahead of its backend still
+// renders a language menu instead of throwing on a missing field.
+export function getLocales(enabledLocales: string[] | undefined): LocaleOption[] {
+  if (!enabledLocales?.length) return ALL_LOCALES
   return ALL_LOCALES.filter((locale) => enabledLocales.includes(locale.code))
 }
 

--- a/frontend/src/routes/(admin)/admin/locales/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/locales/+page.svelte
@@ -35,8 +35,6 @@
     loading = true
     try {
       const data = await api.request<AppSettingsPublic>('/admin/settings')
-      // Unchecking a locale takes it away from visitors already reading in it:
-      // the next request rewrites their PARAGLIDE_LOCALE cookie to the default.
       enabledLocales = Object.fromEntries(
         ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales?.includes(locale.code)])
       )
@@ -79,6 +77,7 @@
     <form onsubmit={save} class="max-w-[480px]">
       <div>
         <p class="fr-label mb-2!">{m['admin.settings.locales.enabled.label']()}</p>
+        <p class="fr-hint-text mt-0! mb-2!">{m['admin.settings.locales.enabled.hint']()}</p>
         {#each ALL_LOCALES as locale (locale.code)}
           <Checkbox
             id="settings-locale-{locale.code}"

--- a/frontend/src/routes/(admin)/admin/locales/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/locales/+page.svelte
@@ -35,8 +35,10 @@
     loading = true
     try {
       const data = await api.request<AppSettingsPublic>('/admin/settings')
+      // Unchecking a locale takes it away from visitors already reading in it:
+      // the next request rewrites their PARAGLIDE_LOCALE cookie to the default.
       enabledLocales = Object.fromEntries(
-        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales.includes(locale.code)])
+        ALL_LOCALES.map((locale) => [locale.code, data.enabled_locales?.includes(locale.code)])
       )
       defaultLocale = data.default_locale
     } finally {


### PR DESCRIPTION
## The question

Now that `enabled_locales` and `default_locale` are admin settings, does `HOST_TO_LOCALE` still need to exist, or is the DA pin just `default_locale=da` plus enforcement?

I've written the version where it doesn't, because it was easier to judge with the diff in front of me than as an argument. Draft on purpose: I'm not sure this is the right call and I'd rather you decided it. Happy to close it if the answer is no.

## Why I think the map should go

Two things it does, taken separately.

**host to locale.** On `ai-arenaen.dk` it returns `da` before anything else is checked, so it beats `default_locale`. That makes the new settings page inert on that instance: five checkboxes and a default dropdown, none of which can change what the site serves. `default_locale=da` covers the same ground and is visible to the admin.

**locale to host.** Picking "DA - Dansk" on comparia.beta.gouv.fr doesn't translate the page. It sends you to ai-arenaen.dk, a different instance with its own database, models, votes and dataset. That's a link to another product sitting in a language dropdown. With `enabled_locales`, the fr instance can just not list Danish, and the link has nothing left to do.

There's also a bug attached to it. `DEFAULT_HOST` is `comparia.beta.gouv.fr` in any built deployment, so on staging, a preview, or any instance that isn't the canonical domain, switching language throws the user onto production. Deleting the map fixes that; keeping it means fixing it some other way.

## What replaces it

`enabled_locales` currently only filters the menu, so `?locale=lt` and a cookie from before an admin unchecked a locale both still work. Without the map there's no unbypassable pin left, so the strategy has to do the refusing. It now reads `PARAGLIDE_LOCALE` itself and turns down anything the instance hasn't enabled. Order is otherwise unchanged: `?locale=`, then cookie, then `default_locale`.

It uses both fields from the `/auth/config` call the branch already makes, and caches the in-flight promise instead of its result, so a cold process fires one request rather than one per concurrent render.

## If the answer is no

If the route between instances is worth keeping, I'd rather it were a footer link than a language option, and I'll write that instead. Say the word.

Either way this touches a site Danish Foundation Models run, so it probably wants a heads-up from someone rather than landing as a surprise. That call is yours, not mine.

## Changes

- `frontend/src/lib/global.svelte.ts`: drop `HOST_TO_LOCALE`, `DEFAULT_HOST` and `LocaleOption.host`. `getLocales` falls back to the full list when the field is missing, so a frontend deployed ahead of its backend renders a menu instead of throwing.
- `frontend/src/lib/components/header/LanguageSelector.svelte`: `onLocaleSelect` collapses to `setLocale`.
- `frontend/src/hooks.server.ts`: enforcement, described above.
- `frontend/src/routes/(admin)/admin/locales/+page.svelte`: read `enabled_locales` defensively, and a note that unchecking a locale now evicts people already reading in it.
- `.env.example`, `CONTRIBUTING.md`, `devops/instances/{da,fr}/app.compose.*.yml`: drop `DEFAULT_LOCALE`, replaced by the DB field and still set in three places where it read like live config.

## Behaviour worth knowing

Unchecking a locale takes it away from visitors already reading in it. Their next request resolves to `default_locale` and `paraglideHandle` rewrites their cookie, so it self-heals rather than stranding them. Probably wants a line of help text on the admin page, which I left out to avoid adding translation keys to a draft.

## Test plan

Ran against a local stack, admin panel driven in a browser.

- [x] Set `enabled_locales` to `["da","fr","en"]` from `/admin/locales`, saved, confirmed it reached the database and `/auth/config`
- [x] Unchecking a locale narrows the default dropdown to the checked ones
- [x] Header menu drops to the three enabled entries
- [x] `?locale=sv` and `?locale=lt`, both now disabled, render `fr` and rewrite the cookie
- [x] A stale `PARAGLIDE_LOCALE=sv` cookie renders `fr` and gets rewritten to `fr`
- [x] `?locale=da` and a `PARAGLIDE_LOCALE=en` cookie, both still enabled, are honoured
- [x] Fresh visitor with no cookie gets `default_locale`, and follows it when the default is changed to `en`
- [x] Switching to Danish in the header stays on the current host. `<html lang>` becomes `da`, URL unchanged. Before this it went to `127.0.0.1:8080` in dev
- [x] `yarn build` passes, `svelte-check` unchanged at 14 errors / 12 warnings, none in the touched files

## Related

The validation and migration fixes are on a separate branch, opened as a normal PR. No overlapping files, so the two go in independently and in any order.
