### PR TITLE
feat(front): detail model openness scores

### DIFF
--- a/frontend/src/lib/components/ModelCard.svelte
+++ b/frontend/src/lib/components/ModelCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AILogo from '$components/AILogo.svelte'
   import InfoCard from '$components/InfoCard.svelte'
+  import OpennessScore from '$components/OpennessScore.svelte'
   import { m } from '$lib/i18n/messages'
   import type { BotModel, Commons } from '$lib/models'
   import { getModelCards } from '$lib/models'
@@ -50,7 +51,13 @@
 
       <dl class="fr-card__desc p-0 gap-2 mt-0! sm:grid-cols-3 grid grid-cols-2">
         {#each cards as card (card.id)}
-          <InfoCard {...card} size="xxs" titleTag="dt" contentTag="dd" />
+          {#if card.id === 'sovereignty'}
+            <InfoCard {...card} content={undefined} size="xxs" titleTag="dt" contentTag="dd">
+              <OpennessScore {model} detailed />
+            </InfoCard>
+          {:else}
+            <InfoCard {...card} size="xxs" titleTag="dt" contentTag="dd" />
+          {/if}
         {/each}
       </dl>
 

--- a/frontend/src/lib/components/ModelInfoModal.svelte
+++ b/frontend/src/lib/components/ModelInfoModal.svelte
@@ -8,6 +8,7 @@
   import { sanitize } from '$lib/utils/commons'
   import type { ClassValue } from 'svelte/elements'
   import InfoCard from './InfoCard.svelte'
+  import OpennessScore from './OpennessScore.svelte'
 
   let {
     model,
@@ -320,7 +321,10 @@
                   </section>
 
                   <section class="xl:col-span-2 flex w-full flex-col">
-                    <h2 class="text-base! mb-3!">{m['models.opennessSovereignty.title']()}</h2>
+                    <div class="mb-3 flex items-center justify-between gap-3">
+                      <h2 class="text-base! mb-0!">{m['models.opennessSovereignty.title']()}</h2>
+                      <OpennessScore {model} />
+                    </div>
 
                     <div class="cg-border bg-white p-4 h-full">
                       <dl class="p-0">

--- a/frontend/src/lib/components/OpennessScore.svelte
+++ b/frontend/src/lib/components/OpennessScore.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import { Icon } from '$components/dsfr'
+  import { m } from '$lib/i18n/messages'
+  import { SOVEREIGNTY_FIELDS, type BotModel } from '$lib/models'
+
+  let {
+    model,
+    detailed = false
+  }: {
+    model: BotModel
+    detailed?: boolean
+  } = $props()
+
+  let expanded = $state(false)
+
+  const criteria = $derived(
+    SOVEREIGNTY_FIELDS.map((id) => {
+      const value = id === 'commercial_use' || id === 'reuse' ? model.license[id] : model[id]
+      return {
+        id,
+        label: m[`models.opennessSovereignty.fields.${id}`](),
+        value
+      }
+    })
+  )
+
+  const score = $derived(`${model.sovereignty_score}/${SOVEREIGNTY_FIELDS.length}`)
+</script>
+
+{#if detailed}
+  <div class="group relative inline-flex">
+    <button
+      type="button"
+      class="relative z-10 flex min-h-8 min-w-10 items-center justify-center rounded-sm border-0 bg-transparent px-1 py-0.5 transition-transform hover:bg-[--grey-1000] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:scale-95"
+      aria-controls="openness-score-{model.id}"
+      aria-expanded={expanded}
+      onclick={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        expanded = !expanded
+      }}
+    >
+      <strong class="text-base leading-none" aria-hidden="true">{score}</strong>
+      <span class="sr-only">{m['models.opennessSovereignty.title']()} : {score}</span>
+    </button>
+
+    <div
+      id="openness-score-{model.id}"
+      class={[
+        'pointer-events-none absolute z-50 bottom-full left-1/2 mb-2 w-[calc(100vw-2rem)] max-w-72 -translate-x-1/2 rounded-lg bg-white p-4 shadow-lg transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100',
+        expanded ? 'visible opacity-100' : 'invisible opacity-0'
+      ]}
+      role="tooltip"
+    >
+      <p class="text-primary mb-3! text-xs font-bold uppercase tracking-[0.08em]">
+        {m['models.opennessSovereignty.title']()}
+      </p>
+      <div class="mb-4 gap-1.5 flex items-center">
+        <div class="gap-1 flex" aria-hidden="true">
+          {#each criteria as criterion (criterion.id)}
+            <span
+              class={[
+                'rounded-xs h-3 w-7',
+                criterion.value ? 'bg-success' : 'bg-[--grey-900-175]'
+              ]}
+            ></span>
+          {/each}
+        </div>
+        <strong class="text-lg leading-none">{score}</strong>
+      </div>
+      <ul class="gap-x-4 gap-y-1 m-0! grid list-none grid-cols-2 p-0">
+        {#each criteria as criterion (criterion.id)}
+          <li class="gap-1 m-0! flex items-center text-xs leading-tight">
+            <Icon
+              icon={criterion.value ? 'i-ri-check-line' : 'i-ri-close-line'}
+              size="xs"
+              class={criterion.value ? 'text-success' : 'text-error'}
+            />
+            <span>{criterion.label}</span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </div>
+{:else}
+  <strong class="text-lg leading-none">{score}</strong>
+{/if}

--- a/frontend/src/lib/components/OpennessScore.svelte
+++ b/frontend/src/lib/components/OpennessScore.svelte
@@ -31,7 +31,7 @@
   <div class="group relative inline-flex">
     <button
       type="button"
-      class="relative z-10 flex min-h-8 min-w-10 items-center justify-center rounded-sm border-0 bg-transparent px-1 py-0.5 transition-transform hover:bg-[--grey-1000] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:scale-95"
+      class="min-h-8 min-w-10 rounded-sm px-1 py-0.5 focus-visible:outline-primary relative z-10 flex items-center justify-center border-0 bg-transparent transition-transform hover:bg-[--grey-1000] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 active:scale-95"
       aria-controls="openness-score-{model.id}"
       aria-expanded={expanded}
       onclick={(event) => {
@@ -42,35 +42,33 @@
     >
       <strong class="text-base leading-none" aria-hidden="true">{score}</strong>
       <span class="sr-only">{m['models.opennessSovereignty.title']()} : {score}</span>
+      <Icon icon="i-ri-question-line" size="xs" class="ms-1" />
     </button>
 
     <div
       id="openness-score-{model.id}"
       class={[
-        'pointer-events-none absolute z-50 bottom-full left-1/2 mb-2 w-[calc(100vw-2rem)] max-w-72 -translate-x-1/2 rounded-lg bg-white p-4 shadow-lg transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100',
+        'mb-2 max-w-72 rounded-lg bg-white p-4 shadow-lg pointer-events-none absolute bottom-full left-1/2 z-50 w-[calc(100vw-2rem)] -translate-x-1/2 transition-opacity group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100',
         expanded ? 'visible opacity-100' : 'invisible opacity-0'
       ]}
       role="tooltip"
     >
-      <p class="text-primary mb-3! text-xs font-bold uppercase tracking-[0.08em]">
+      <p class="text-primary mb-3! text-xs font-bold tracking-[0.08em] uppercase">
         {m['models.opennessSovereignty.title']()}
       </p>
       <div class="mb-4 gap-1.5 flex items-center">
         <div class="gap-1 flex" aria-hidden="true">
           {#each criteria as criterion (criterion.id)}
             <span
-              class={[
-                'rounded-xs h-3 w-7',
-                criterion.value ? 'bg-success' : 'bg-[--grey-900-175]'
-              ]}
+              class={['rounded-xs h-3 w-7', criterion.value ? 'bg-success' : 'bg-[--grey-900-175]']}
             ></span>
           {/each}
         </div>
         <strong class="text-lg leading-none">{score}</strong>
       </div>
-      <ul class="gap-x-4 gap-y-1 m-0! grid list-none grid-cols-2 p-0">
+      <ul class="gap-x-4 gap-y-1 m-0! p-0 grid list-none grid-cols-2">
         {#each criteria as criterion (criterion.id)}
-          <li class="gap-1 m-0! flex items-center text-xs leading-tight">
+          <li class="gap-1 m-0! text-xs leading-tight flex items-center">
             <Icon
               icon={criterion.value ? 'i-ri-check-line' : 'i-ri-close-line'}
               size="xs"

--- a/frontend/src/lib/components/OpennessScore.svelte.test.ts
+++ b/frontend/src/lib/components/OpennessScore.svelte.test.ts
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import type { BotModel } from '$lib/models'
+import OpennessScore from './OpennessScore.svelte'
+
+const model = {
+  id: 'model-1',
+  sovereignty_score: 4,
+  license: {
+    reuse: true,
+    commercial_use: true
+  },
+  public_weights: true,
+  public_training_data: false,
+  public_training_code: false,
+  eu_hostable: true
+} as BotModel
+
+describe('OpennessScore', () => {
+  it('reveals the openness criteria when activated', async () => {
+    render(OpennessScore, { model, detailed: true })
+
+    const trigger = screen.getByRole('button', { name: 'Niveau d’ouverture : 4/6' })
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await fireEvent.click(trigger)
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Jeux de données d’entraînement')
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Hébergeable dans l’UE')
+  })
+})


### PR DESCRIPTION
## Summary

- Display the openness score in the model details view.
- Let users view the six criteria behind that score from the model list.
- Add a component test covering score details and keyboard activation.

<img width="664" height="396" alt="Screenshot 2026-07-29 at 14 14 32" src="https://github.com/user-attachments/assets/acb9cce6-cfd8-451b-bf5b-bb7bf4aac2bb" />
<img width="490" height="348" alt="Screenshot 2026-07-29 at 14 14 37" src="https://github.com/user-attachments/assets/fdae6792-48e2-4d48-9097-66120debd20e" />
