### PR TITLE
Fix the failing brand theme test on next

### DIFF
--- a/frontend/src/lib/theme.spec.ts
+++ b/frontend/src/lib/theme.spec.ts
@@ -49,11 +49,12 @@ describe('brand theme', () => {
     expect(css).toContain(':root:root[data-fr-theme="dark"]')
     expect(css).toContain(':root:root[data-fr-theme="system"]')
     expect(css).toContain('@media (prefers-color-scheme:dark)')
+    // Only the brand tokens are emitted here. The DSFR names that consume them
+    // are mapped to var(--brand-*) in app.css.
     expect(css).toContain('--brand-primary:#112233')
-    expect(css).toContain('--text-active-blue-france:#112233')
-    expect(css).toContain('--background-open-blue-france:#D9DCDE')
-    expect(css).toContain('--background-open-blue-france-hover:#C6CACE')
-    expect(css).toContain('--background-open-blue-france-active:#B3B8BE')
+    expect(css).toContain('--brand-primary-soft:#D9DCDE')
+    expect(css).toContain('--brand-primary-soft-hover:#C6CACE')
+    expect(css).toContain('--brand-primary-soft-active:#B3B8BE')
     expect(css).not.toMatch(/undefined|null/)
   })
 


### PR DESCRIPTION
`createBrandThemeCss` used to emit the DSFR variables inline. cedcd3f0 moved
them into `app.css`, where they resolve to `var(--brand-*)`, so the function now
emits only the brand tokens. The test was not updated and has been failing on
`next` since that merge.

It asserts the same three computed soft colours, under the names they are
actually written with, and no longer looks for the DSFR aliases that live in
`app.css`.

Frontend suite on this branch: 96 passed, 0 failed.

The same test also fails on #628, for the same reason and not because of
anything in that branch. Merging this one clears it there too.
