### PR TITLE
Stop sending endpoint API keys to the browser

### DIFF
--- a/backend/admin/llms/router.py
+++ b/backend/admin/llms/router.py
@@ -1,13 +1,14 @@
 import logging
 from typing import Literal
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from sqlmodel import SQLModel, select
 
 from utils.database.models.llms import (
     LLMData,
     LLMDataUpsert,
     LLMEndpoint,
+    LLMEndpointPublic,
     LLMEndpointUpsert,
     LLMLab,
     LLMLabUpsert,
@@ -16,6 +17,7 @@ from utils.database.models.llms import (
 )
 from utils.database.session import get_session
 from utils.llms.services import (
+    clear_llm_endpoint_api_key,
     upsert_llm_data,
     upsert_llm_endpoint,
     upsert_llm_lab,
@@ -37,6 +39,13 @@ MODELS_UPSERT: dict[ModelKind, SQLModel] = {
 }
 
 
+def _to_endpoint_public(endpoint: LLMEndpoint) -> LLMEndpointPublic:
+    """The endpoint without its key. Call inside the session that loaded it."""
+    return LLMEndpointPublic(
+        **endpoint.model_dump(exclude={"api_key"}), has_api_key=bool(endpoint.api_key)
+    )
+
+
 @router.get("/data")
 async def get_data():
     try:
@@ -51,6 +60,11 @@ async def get_data():
                 k: (await session.exec(select(model).order_by(model.created_at))).all()
                 for k, model in models.items()
             }
+            # The key never leaves the backend. The panel only ever needed to
+            # know whether one is set.
+            db_data["endpoints"] = [
+                _to_endpoint_public(endpoint) for endpoint in db_data["endpoints"]
+            ]
 
         return db_data
     except Exception as e:
@@ -75,9 +89,22 @@ async def upsert_llm(body: LLMDataUpsert) -> LLMData:
 
 @router.post("/endpoint")
 @router.put("/endpoint")
-async def upsert_endpoint(body: LLMEndpointUpsert) -> LLMEndpoint:
+async def upsert_endpoint(body: LLMEndpointUpsert) -> LLMEndpointPublic:
     async with get_session() as session:
-        return await upsert_llm_endpoint(body, session)
+        endpoint = await upsert_llm_endpoint(body, session)
+        # Commit expires the attributes, and the instance detaches when the
+        # session closes, so refresh and build the payload here.
+        await session.refresh(endpoint)
+        return _to_endpoint_public(endpoint)
+
+
+@router.delete("/endpoint/{endpoint_id}/api-key")
+async def delete_endpoint_api_key(endpoint_id: UUID) -> LLMEndpointPublic:
+    async with get_session() as session:
+        endpoint = await clear_llm_endpoint_api_key(endpoint_id, session)
+        if not endpoint:
+            raise HTTPException(status_code=404, detail="endpoint_not_found")
+        return _to_endpoint_public(endpoint)
 
 
 @router.post("/lab")

--- a/backend/admin/llms/router.py
+++ b/backend/admin/llms/router.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Literal
+from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
 from sqlmodel import SQLModel, select

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -113,6 +113,14 @@
                 "title": "Conditions d’utilisation"
             }
         },
+        "endpointKey": {
+            "set": "Clé enregistrée",
+            "unset": "Aucune clé",
+            "hint": "Laissez le champ vide pour conserver la clé actuelle. Saisissez-en une nouvelle pour la remplacer.",
+            "remove": "Retirer la clé",
+            "removeConfirm": "Confirmer le retrait",
+            "removed": "Clé retirée. Les modèles de ce point d'accès ne sont plus servis."
+        },
         "llms": {
             "subTitle": "LLMs, labs, licenses and endpoints.",
             "title": "LLMs data configuration"

--- a/frontend/src/lib/components/form/Form.svelte
+++ b/frontend/src/lib/components/form/Form.svelte
@@ -3,6 +3,7 @@
   import { m } from '$lib/i18n/messages'
   import { toEntries } from '$lib/utils/commons'
   import type { AnyFormItemProps } from '$lib/utils/form'
+  import type { Snippet } from 'svelte'
   import type { SvelteHTMLElements } from 'svelte/elements'
   import AnyFormItem from './AnyFormItem.svelte'
 
@@ -13,6 +14,8 @@
     items,
     form,
     errors = $bindable({}),
+    fieldSnippets,
+    children,
     onSubmit,
     ...props
   }: Omit<SvelteHTMLElements['form'], 'method'> & {
@@ -21,6 +24,7 @@
     items: AnyFormItemProps[]
     form: Record<string, any>
     errors?: Record<string, string>
+    fieldSnippets?: Record<string, Snippet>
     onSubmit: () => void
   } = $props()
 
@@ -42,7 +46,11 @@
   </h2>
 
   {#each items as item (item.id)}
-    <AnyFormItem {...item} bind:value={form[item.id]!} {errors} />
+    {#if fieldSnippets?.[item.id]}
+      {@render fieldSnippets[item.id]()}
+    {:else}
+      <AnyFormItem {...item} bind:value={form[item.id]!} {errors} />
+    {/if}
   {/each}
 
   {#if anyError.length}

--- a/frontend/src/lib/components/form/FormInput.svelte
+++ b/frontend/src/lib/components/form/FormInput.svelte
@@ -1,20 +1,33 @@
 <script module lang="ts">
   export type FormInputProps = {
     type: HTMLInputElement['type']
+    placeholder: HTMLInputElement['placeholder']
     step?: HTMLInputElement['step']
   } & BaseFormFieldProps<'input', string | number>
 </script>
 
 <script lang="ts">
   import type { BaseFormFieldProps } from '$lib/utils/form'
+  import type { SvelteHTMLElements } from 'svelte/elements'
   import { FormField } from '.'
 
-  let { value = $bindable(), type, disabled, step, ...props }: FormInputProps = $props()
+  let {
+    value = $bindable(),
+    type,
+    disabled,
+    placeholder,
+    step,
+    children,
+    ...props
+  }: FormInputProps & SvelteHTMLElements['div'] = $props()
 </script>
 
 <FormField {...props} component="input">
   {#snippet formItem(fieldProps)}
-    <input {...fieldProps} {type} {disabled} {step} bind:value class="fr-input" />
+    <div class="gap-3 mt-2 flex">
+      <input {...fieldProps} {type} {placeholder} {disabled} {step} bind:value class="fr-input" />
+      {@render children?.()}
+    </div>
   {/snippet}
 </FormField>
 

--- a/frontend/src/lib/generated/admin.ts
+++ b/frontend/src/lib/generated/admin.ts
@@ -217,6 +217,34 @@ export interface LLMEndpoint {
   api_key?: string | null;
 }
 /**
+ * What the admin panel is allowed to see: whether a key is set, not the key.
+ *
+ * The panel only ever needed the boolean, and a key that reaches the browser
+ * also reaches devtools, the cache and anything that logs the response.
+ */
+export interface LLMEndpointPublic {
+  id?: string;
+  created_at?: string;
+  updated_at?: string;
+  /**
+   * Readable endpoint name (e.g. 'OpenRouter').
+   */
+  name: string;
+  /**
+   * API format (e.g. 'openrouter' or 'openai' for OpenAI-compatible APIs).
+   */
+  api_type: string;
+  /**
+   * Base URL for the API endpoint.
+   */
+  api_base?: string | null;
+  /**
+   * API version (optional)
+   */
+  api_version?: string | null;
+  has_api_key?: boolean;
+}
+/**
  * LLM lab/organization metadata.
  */
 export interface LLMLab {

--- a/frontend/src/routes/(admin)/admin/llms/+layout.ts
+++ b/frontend/src/routes/(admin)/admin/llms/+layout.ts
@@ -1,11 +1,11 @@
 import { api } from '$lib/fastapi-client'
-import type { LLMData, LLMEndpoint, LLMLab, LLMLicense } from '$lib/generated/admin'
+import type { LLMData, LLMEndpointPublic, LLMLab, LLMLicense } from '$lib/generated/admin'
 import type { JSONSchema } from '$lib/utils/form'
 import type { LayoutLoad } from './$types'
 
 export const load: LayoutLoad = async ({ fetch }) => {
   const data = await api.request<{
-    endpoints: LLMEndpoint[]
+    endpoints: LLMEndpointPublic[]
     licenses: LLMLicense[]
     labs: LLMLab[]
     llms: LLMData[]

--- a/frontend/src/routes/(admin)/admin/llms/endpoints/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/llms/endpoints/+page.svelte
@@ -14,7 +14,7 @@
   const endpoints = $derived(
     data.endpoints.map((endpoint) => ({
       ...endpoint,
-      configured: !!endpoint.api_key,
+      configured: !!endpoint.has_api_key,
       llms_count: data.llms.filter((llm) => llm.endpoint_id === endpoint.id!).length,
       updated_at: new Date(endpoint.updated_at!),
       created_at: new Date(endpoint.created_at!),

--- a/frontend/src/routes/(admin)/admin/llms/endpoints/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/llms/endpoints/[id]/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
+  import { goto, invalidateAll } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
+  import { Badge, Button } from '$components/dsfr'
   import Form from '$components/form/Form.svelte'
+  import { api } from '$lib/fastapi-client'
+  import type { LLMEndpointPublic } from '$lib/generated/admin'
+  import { useToast } from '$lib/helpers/useToast.svelte'
+  import { m } from '$lib/i18n/messages'
   import { useForm } from '$lib/stores/form.svelte'
   import type { PageProps } from './$types'
 
@@ -10,6 +15,11 @@
 
   const id = $derived(page.params.id)
   const method = $derived(id === 'create' ? 'post' : 'put')
+  const hasApiKey = $derived(!!(data.formProps.data as LLMEndpointPublic).has_api_key)
+
+  let confirmingRemoval = $state(false)
+  let removing = $state(false)
+
   const form = $derived(
     useForm({
       url: '/admin/llms/endpoint',
@@ -27,8 +37,60 @@
       }
     })
   )
+
+  async function removeApiKey() {
+    removing = true
+    try {
+      await api.request(`/admin/llms/endpoint/${id}/api-key`, { method: 'delete' })
+      confirmingRemoval = false
+      await invalidateAll()
+      useToast(m['admin.endpointKey.removed'](), 5000, 'success')
+    } catch (error) {
+      useToast((error as Error).message, 6000, 'error')
+    } finally {
+      removing = false
+    }
+  }
 </script>
 
 <div>
   <Form {id} label="Endpoint" subLabel={id} {...form} />
+
+  {#if id !== 'create'}
+    <div id="endpoint-api-key-state" class="gap-3 mt-6 flex flex-wrap items-center">
+      <Badge
+        size="sm"
+        variant={hasApiKey ? 'green' : 'orange'}
+        text={hasApiKey ? m['admin.endpointKey.set']() : m['admin.endpointKey.unset']()}
+      />
+      <span class="fr-text--sm text-[--text-mention-grey]">
+        {m['admin.endpointKey.hint']()}
+      </span>
+
+      {#if hasApiKey}
+        {#if confirmingRemoval}
+          <Button
+            id="endpoint-api-key-remove-confirm"
+            variant="secondary"
+            text={m['admin.endpointKey.removeConfirm']()}
+            disabled={removing}
+            onclick={removeApiKey}
+          />
+          <Button
+            variant="tertiary-no-outline"
+            text={m['words.back']()}
+            disabled={removing}
+            onclick={() => (confirmingRemoval = false)}
+          />
+        {:else}
+          <Button
+            id="endpoint-api-key-remove"
+            variant="tertiary-no-outline"
+            text={m['admin.endpointKey.remove']()}
+            onclick={() => (confirmingRemoval = true)}
+          />
+        {/if}
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/frontend/src/routes/(admin)/admin/llms/endpoints/[id]/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/llms/endpoints/[id]/+page.svelte
@@ -2,10 +2,10 @@
   import { goto, invalidateAll } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
-  import { Badge, Button } from '$components/dsfr'
+  import { Button } from '$components/dsfr'
+  import { FormInput, type FormInputProps } from '$components/form'
   import Form from '$components/form/Form.svelte'
   import { api } from '$lib/fastapi-client'
-  import type { LLMEndpointPublic } from '$lib/generated/admin'
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { m } from '$lib/i18n/messages'
   import { useForm } from '$lib/stores/form.svelte'
@@ -15,7 +15,7 @@
 
   const id = $derived(page.params.id)
   const method = $derived(id === 'create' ? 'post' : 'put')
-  const hasApiKey = $derived(!!(data.formProps.data as LLMEndpointPublic).has_api_key)
+  const hasApiKey = $derived(!!data.formProps.data.has_api_key)
 
   let confirmingRemoval = $state(false)
   let removing = $state(false)
@@ -38,6 +38,19 @@
     })
   )
 
+  const apiKeyField = $derived.by(() => {
+    const field = form.items.find((item) => item.id === 'api_key')!
+    return (
+      hasApiKey
+        ? {
+            ...field,
+            placeholder: '• '.repeat(20),
+            help: hasApiKey ? m['admin.endpointKey.hint']() : field.help
+          }
+        : field
+    ) as FormInputProps
+  })
+
   async function removeApiKey() {
     removing = true
     try {
@@ -54,19 +67,8 @@
 </script>
 
 <div>
-  <Form {id} label="Endpoint" subLabel={id} {...form} />
-
-  {#if id !== 'create'}
-    <div id="endpoint-api-key-state" class="gap-3 mt-6 flex flex-wrap items-center">
-      <Badge
-        size="sm"
-        variant={hasApiKey ? 'green' : 'orange'}
-        text={hasApiKey ? m['admin.endpointKey.set']() : m['admin.endpointKey.unset']()}
-      />
-      <span class="fr-text--sm text-[--text-mention-grey]">
-        {m['admin.endpointKey.hint']()}
-      </span>
-
+  {#snippet apiKey()}
+    <FormInput {...apiKeyField} type="password" bind:value={form.form['api_key']}>
       {#if hasApiKey}
         {#if confirmingRemoval}
           <Button
@@ -74,10 +76,10 @@
             variant="secondary"
             text={m['admin.endpointKey.removeConfirm']()}
             disabled={removing}
+            class="text-nowrap"
             onclick={removeApiKey}
           />
           <Button
-            variant="tertiary-no-outline"
             text={m['words.back']()}
             disabled={removing}
             onclick={() => (confirmingRemoval = false)}
@@ -85,12 +87,15 @@
         {:else}
           <Button
             id="endpoint-api-key-remove"
-            variant="tertiary-no-outline"
+            icon="delete-bin-line"
             text={m['admin.endpointKey.remove']()}
+            class="text-nowrap"
             onclick={() => (confirmingRemoval = true)}
           />
         {/if}
       {/if}
-    </div>
-  {/if}
+    </FormInput>
+  {/snippet}
+
+  <Form {id} label="Endpoint" subLabel={id} {...form} fieldSnippets={{ api_key: apiKey }} />
 </div>

--- a/frontend/src/routes/(admin)/admin/llms/endpoints/[id]/+page.ts
+++ b/frontend/src/routes/(admin)/admin/llms/endpoints/[id]/+page.ts
@@ -1,4 +1,4 @@
-import type { LLMEndpoint } from '$lib/generated/admin'
+import type { LLMEndpointPublic } from '$lib/generated/admin'
 import { error } from '@sveltejs/kit'
 import type { PageLoad } from './$types'
 
@@ -8,6 +8,6 @@ export const load: PageLoad = async ({ parent, params }) => {
   if (!data && params.id !== 'create') error(404)
 
   return {
-    formProps: { schema: schemas.endpoints, data: data ?? ({} as LLMEndpoint) }
+    formProps: { schema: schemas.endpoints, data: data ?? ({} as LLMEndpointPublic) }
   }
 }

--- a/internal/typescript/admin_types.py
+++ b/internal/typescript/admin_types.py
@@ -5,7 +5,13 @@ from backend.admin.router import (
 )
 from utils.database.models.app_settings import AppSettingsPatch, AppSettingsPublic
 from utils.database.models.auth import UserPublic, UserUpsert
-from utils.database.models.llms import LLMData, LLMEndpoint, LLMLab, LLMLicense
+from utils.database.models.llms import (
+    LLMData,
+    LLMEndpoint,
+    LLMEndpointPublic,
+    LLMLab,
+    LLMLicense,
+)
 from utils.database.models.prompt_check import PromptCheckPatch, PromptCheckStatus
 from utils.database.models.suggestion import (
     AdminSuggestion,

--- a/tests/llms/test_endpoint_api_key.py
+++ b/tests/llms/test_endpoint_api_key.py
@@ -1,0 +1,118 @@
+"""The endpoint key must not reach the browser, and must survive a form save."""
+
+import asyncio
+import uuid
+
+import pytest
+
+from utils.database.models.llms import (
+    LLMEndpoint,
+    LLMEndpointPublic,
+    LLMEndpointUpsert,
+)
+from utils.llms.services import clear_llm_endpoint_api_key, upsert_llm_endpoint
+
+
+class FakeSession:
+    def __init__(self, stored: LLMEndpoint | None = None):
+        self.stored = stored
+        self.added: list = []
+        self.committed = False
+
+    async def get(self, _model, _id):
+        return self.stored
+
+    def add(self, item):
+        self.added.append(item)
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, _item):
+        return None
+
+
+def endpoint(**overrides) -> LLMEndpoint:
+    return LLMEndpoint(
+        **{
+            "id": uuid.uuid4(),
+            "name": "OpenRouter",
+            "api_type": "openrouter",
+            "api_key": "sk-real-key",
+            **overrides,
+        }
+    )
+
+
+def test_the_public_shape_has_no_key_field():
+    assert "api_key" not in LLMEndpointPublic.model_fields
+    assert "has_api_key" in LLMEndpointPublic.model_fields
+
+
+def test_a_save_without_a_key_keeps_the_stored_one():
+    """The panel is not told the key, so a form round trip carries an empty one.
+    Writing that through would disable every LLM on the endpoint."""
+    stored = endpoint()
+    session = FakeSession(stored)
+
+    asyncio.run(
+        upsert_llm_endpoint(
+            LLMEndpointUpsert(id=stored.id, name="OpenRouter", api_type="openrouter"),
+            session,  # type: ignore[arg-type]
+        )
+    )
+
+    assert session.added[0].api_key == "sk-real-key"
+
+
+@pytest.mark.parametrize("blank", ["", None])
+def test_a_blank_key_is_not_a_clear(blank):
+    stored = endpoint()
+    session = FakeSession(stored)
+
+    asyncio.run(
+        upsert_llm_endpoint(
+            LLMEndpointUpsert(
+                id=stored.id, name="OpenRouter", api_type="openrouter", api_key=blank
+            ),
+            session,  # type: ignore[arg-type]
+        )
+    )
+
+    assert session.added[0].api_key == "sk-real-key"
+
+
+def test_a_new_key_replaces_the_stored_one():
+    stored = endpoint()
+    session = FakeSession(stored)
+
+    asyncio.run(
+        upsert_llm_endpoint(
+            LLMEndpointUpsert(
+                id=stored.id,
+                name="OpenRouter",
+                api_type="openrouter",
+                api_key="sk-new-key",
+            ),
+            session,  # type: ignore[arg-type]
+        )
+    )
+
+    assert session.added[0].api_key == "sk-new-key"
+
+
+def test_clearing_is_explicit():
+    stored = endpoint()
+    session = FakeSession(stored)
+
+    cleared = asyncio.run(clear_llm_endpoint_api_key(stored.id, session))  # type: ignore[arg-type]
+
+    assert cleared is not None
+    assert cleared.api_key is None
+    assert session.committed
+
+
+def test_clearing_an_unknown_endpoint_returns_none():
+    session = FakeSession(None)
+
+    assert asyncio.run(clear_llm_endpoint_api_key(uuid.uuid4(), session)) is None  # type: ignore[arg-type]

--- a/utils/database/models/llms/endpoint.py
+++ b/utils/database/models/llms/endpoint.py
@@ -48,4 +48,10 @@ class LLMEndpointUpsert(LLMEndpointPrivate):
 
 
 class LLMEndpointPublic(LLMEndpointBase):
-    pass
+    """What the admin panel is allowed to see: whether a key is set, not the key.
+
+    The panel only ever needed the boolean, and a key that reaches the browser
+    also reaches devtools, the cache and anything that logs the response.
+    """
+
+    has_api_key: bool = False

--- a/utils/llms/services.py
+++ b/utils/llms/services.py
@@ -13,6 +13,8 @@ from utils.database.models.llms import (
 )
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from sqlmodel.ext.asyncio.session import AsyncSession
 
 logger = logging.getLogger("comparia.db")
@@ -66,7 +68,34 @@ async def upsert_llm_lab(
 async def upsert_llm_endpoint(
     endpoint: LLMEndpointUpsert, session: "AsyncSession", commit: bool = True
 ) -> LLMEndpoint:
+    """Upsert an endpoint, leaving its key alone unless a new one is given.
+
+    The admin panel is no longer told the key, so a form round trip carries an
+    empty one. Writing that through would silently disable every LLM on the
+    endpoint. Clearing a key is `clear_llm_endpoint_api_key`, on purpose.
+    """
+    if not endpoint.api_key and endpoint.id:
+        stored = await session.get(LLMEndpoint, endpoint.id)
+        if stored:
+            endpoint = endpoint.model_copy(update={"api_key": stored.api_key})
+
     return await _upsert_item(LLMEndpoint, endpoint, session, commit)
+
+
+async def clear_llm_endpoint_api_key(
+    endpoint_id: "UUID", session: "AsyncSession"
+) -> LLMEndpoint | None:
+    """Drop the stored key. Every LLM on this endpoint stops being served."""
+    endpoint = await session.get(LLMEndpoint, endpoint_id)
+    if not endpoint:
+        return None
+
+    endpoint.api_key = None
+    session.add(endpoint)
+    await session.commit()
+    await session.refresh(endpoint)
+    logger.info(f"Cleared api_key of LLMEndpoint '{endpoint_id}'")
+    return endpoint
 
 
 async def upsert_llm_data(


### PR DESCRIPTION
## Summary

`GET /admin/llms/data` selected `LLMEndpoint` rows and returned them with no
response model, so every provider API key was serialised into the response. The
endpoints page never displayed them, it only ever read `!!endpoint.api_key` for
its Configured column, but the keys still reached devtools, the browser cache and
anything that logs or proxies that traffic.

It returns `has_api_key` now. `LLMEndpointPublic` already existed and already
stripped the key; it was simply never wired up.

## The part that made this more than one line

The edit form loads the endpoint from that same response and puts the whole
object back on save. Removing the key from the response would have left the field
empty, and the next save would have written that empty value over the stored key,
disabling every LLM on the endpoint with nothing on screen to say so. Our
OpenRouter endpoint serves 33 of them.

So `upsert_llm_endpoint` now leaves the stored key alone unless a new one is
given. Blanking the field is no longer how you remove a key; there is a
`DELETE /admin/llms/endpoint/{id}/api-key` behind a confirmation for that, and
the form says which is which.

## Not addressed here

The keys are still stored in plain text. That is the same exposure as an
environment variable, and it needs a decision about where secrets should live
rather than a patch.

## Test plan

- `uv run python -m pytest tests`: 111 passed, 13 skipped. Six new tests cover
  the public shape carrying no key, a save without one keeping the stored key,
  a blank one not counting as a clear, a new one replacing it, and the explicit
  removal. Checked they fail without the fix.
- Against a local instance with a real key stored: the field renders empty where
  it used to show the key, saving the form returns 200 and leaves the key intact,
  and the Configured column still reads correctly from `has_api_key`.
- `frontend`: 95 passed, 1 pre-existing failure in `theme.spec.ts` fixed by #629.
  No new `svelte-check` errors.
