### PR TITLE
fix(front): allow changing email during sign-in code step

### DIFF
--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -119,6 +119,7 @@
                 "submitting": "Sender..."
             },
             "code": {
+                "changeEmail": "Skift e-mailadresse",
                 "label": "6-cifret kode",
                 "submit": "Bekræft",
                 "verifying": "Verificerer...",

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -282,6 +282,7 @@
                 "submitting": "Sending..."
             },
             "code": {
+                "changeEmail": "Change email address",
                 "label": "6-digit code",
                 "submit": "Verify",
                 "verifying": "Verifying...",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -620,6 +620,7 @@
         },
         "modal": {
             "code": {
+                "changeEmail": "Modifier l’adresse email",
                 "error": "Code invalide ou expiré.",
                 "label": "Code reçu par email",
                 "notReceived": "Vous n’avez rien reçu ?",

--- a/frontend/src/lib/components/SignInForm.svelte
+++ b/frontend/src/lib/components/SignInForm.svelte
@@ -14,7 +14,7 @@
   import { useToast } from '$lib/helpers/useToast.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale } from '$lib/i18n/runtime'
-  import { onMount } from 'svelte'
+  import { onMount, tick } from 'svelte'
   import type { SvelteHTMLElements } from 'svelte/elements'
 
   let {
@@ -41,6 +41,7 @@
   let consented = $state(false)
   let consentLoading = $state(true)
   let consentError = $state<string>()
+  let formContainer: HTMLDivElement
 
   const consentLabel = $derived(terms ? consentCheckboxLabel(terms, true) : '')
   const canMergeComparisons = $derived(auth.config.access_policy === 'anonymous_first')
@@ -127,6 +128,14 @@
     requestCode()
   }
 
+  async function onChangeEmail() {
+    step = 'email'
+    error = undefined
+    code = ''
+    await tick()
+    formContainer.querySelector<HTMLInputElement>('#login-email')?.focus()
+  }
+
   function onSubmit(e: SubmitEvent) {
     e.preventDefault()
     if (step === 'email') requestCode()
@@ -134,7 +143,7 @@
   }
 </script>
 
-<div {...props} class={['my-10 mx-8', props.class]}>
+<div bind:this={formContainer} {...props} class={['my-10 mx-8', props.class]}>
   <h2 id={titleId} class="fr-h4 text-primary! mb-4!">{m['auth.modal.email.title']()}</h2>
   <p class="text-xs! mb-6! text-grey">
     {m['auth.modal.email.subtitle']()}
@@ -152,6 +161,18 @@
       required
       class="mb-4!"
     />
+
+    {#if step === 'code'}
+      <Button
+        type="button"
+        size="xs"
+        variant="tertiary-no-outline"
+        text={m['auth.modal.code.changeEmail']()}
+        disabled={loading}
+        onclick={onChangeEmail}
+        class="-mt-2! mb-4! text-black! underline"
+      />
+    {/if}
 
     {#if canMergeComparisons}
       <Checkbox

--- a/frontend/src/lib/components/SignInForm.svelte.test.ts
+++ b/frontend/src/lib/components/SignInForm.svelte.test.ts
@@ -1,4 +1,5 @@
 import { resetConsent } from '$lib/consent'
+import { expectAccessible } from '$lib/testing/a11y'
 import { fireEvent, render, waitFor } from '@testing-library/svelte'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SignInForm from './SignInForm.svelte'
@@ -119,6 +120,41 @@ describe('SignInForm consent', () => {
       )
     ).toHaveLength(0)
     expect(container.querySelector<HTMLInputElement>('#login-consent')?.disabled).toBe(true)
+  })
+
+  it('clears the code and error before changing the email address', async () => {
+    servesTerms(true)
+    const { container, getByRole } = render(SignInForm)
+    const emailInput = container.querySelector<HTMLInputElement>('#login-email')!
+    const submit = container.querySelector<HTMLButtonElement>('button[type="submit"]')!
+    await waitFor(() => expect(submit.disabled).toBe(false))
+
+    await fireEvent.input(emailInput, { target: { value: 'personne@example.test' } })
+    await fireEvent.click(submit)
+
+    const codeInput = await waitFor(() => {
+      const input = container.querySelector<HTMLInputElement>('#login-code')
+      expect(input).not.toBeNull()
+      return input!
+    })
+    await fireEvent.input(codeInput, { target: { value: '123456' } })
+    await expectAccessible(container)
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('button[type="submit"]')!)
+    await waitFor(() => expect(container.textContent).toContain('Code invalide ou expiré.'))
+
+    const changeEmail = getByRole('button', { name: 'Modifier l’adresse email' })
+    expect(changeEmail).toHaveAttribute('type', 'button')
+    await fireEvent.click(changeEmail)
+
+    expect(container.querySelector('#login-code')).toBeNull()
+    expect(container.textContent).not.toContain('Code invalide ou expiré.')
+    expect(emailInput.disabled).toBe(false)
+    expect(document.activeElement).toBe(emailInput)
+
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('button[type="submit"]')!)
+    await waitFor(() => {
+      expect(container.querySelector<HTMLInputElement>('#login-code')?.value).toBe('')
+    })
   })
 
   it('offers a working retry when the terms cannot be loaded', async () => {


### PR DESCRIPTION
## Summary

- once the sign-in code step is reached, the email field was disabled with no way back
- adds a link to return to the email step and edit the address

Fixes #638

## Test plan

- open the sign-in modal, submit an email, then click the new "Modifier l'adresse email" link and confirm the email field becomes editable again