### PR TITLE
Improve model catalog information

### DIFF
--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -2357,7 +2357,7 @@
                 "desc": "Plus la classe est proche de A, plus la consommation estimée à l’inférence est faible.",
                 "title": "Classe de consommation énergétique",
                 "title_short": "Score énergie",
-                "tooltip": "Classe estimée à partir de la consommation d’énergie à l’inférence, selon la méthodologie EcoLogits."
+                "tooltip": "Estimation EcoLogits 0.10.2 pour générer 1 million de jetons de sortie. Le calcul utilise le nombre total de paramètres et, pour les modèles à mélange d’experts (MoE), le nombre de paramètres actifs. Hypothèses : efficacité énergétique du centre de données (PUE) de 1,2, latence non renseignée et valeur médiane lorsque le résultat est une fourchette. Seuils : A < 100 Wh ; B < 300 Wh ; C < 1 000 Wh ; D < 3 000 Wh ; E < 10 000 Wh ; F ≥ 10 000 Wh. Il ne s’agit pas d’une mesure du fournisseur : le matériel réel, la quantification, la longueur des entrées et la latence peuvent modifier la consommation."
             },
             "license": {
                 "title": "Licence"
@@ -2435,7 +2435,7 @@
         "envImpact": {
             "hardware": {
                 "title": "Matériel nécessaire",
-                "tooltip": "Estimation du type de matériel nécessaire pour exécuter le modèle localement, selon sa taille et ses besoins en mémoire.",
+                "tooltip": "Estimation de la mémoire nécessaire pour charger les paramètres du modèle, hors cache KV, contexte, système et surcoût du moteur d’inférence. Catégories utilisées : jusqu’à 3 Go, smartphone ; jusqu’à 16 Go, ordinateur portable ; jusqu’à 80 Go, station de travail avec un GPU ; au-delà, serveur. Le nombre de GPU est arrondi à l’entier supérieur sur l’hypothèse de 80 Go de mémoire par carte. Il s’agit d’un minimum théorique : la précision des poids, la quantification, la longueur du contexte, la mise en lots et le logiciel d’inférence peuvent augmenter ou réduire le besoin réel.",
                 "types": {
                     "laptop": {
                         "detail": "Aucune carte graphique nécessaire",

--- a/frontend/src/lib/components/ModelInfoModal.svelte
+++ b/frontend/src/lib/components/ModelInfoModal.svelte
@@ -3,8 +3,10 @@
   import { Badge, Button, Icon, Link, Tooltip } from '$components/dsfr'
   import { ENERGY_CLASSES } from '$lib/generated/constants'
   import { m } from '$lib/i18n/messages'
+  import { getLocale } from '$lib/i18n/runtime'
   import type { BotModel, Commons, RankClass } from '$lib/models'
   import { ENERGY_CLASS_COLORS, getModelCards, MODALITIES } from '$lib/models'
+  import { formatRegion } from '$lib/regions'
   import { sanitize } from '$lib/utils/commons'
   import type { ClassValue } from 'svelte/elements'
   import InfoCard from './InfoCard.svelte'
@@ -331,7 +333,7 @@
                   </section>
 
                   <section class="xl:col-span-2 flex w-full flex-col">
-                    <div class="mb-3 flex items-center justify-between gap-3">
+                    <div class="mb-3 gap-3 flex items-center justify-between">
                       <h2 class="text-base! mb-0!">{m['models.opennessSovereignty.title']()}</h2>
                       <OpennessScore {model} />
                     </div>
@@ -351,8 +353,9 @@
                               {:else if field.id === 'license_name'}
                                 {field.value}
                               {:else if field.id === 'origin_country'}
-                                <!-- FIXME flag -->
-                                {field.value.toUpperCase()}
+                                {@const region = formatRegion(field.value, getLocale())}
+                                <span aria-hidden="true">{region.flag}</span>
+                                {region.name} ({region.code})
                               {:else}
                                 {@const words =
                                   field.id === 'eu_hostable'

--- a/frontend/src/lib/regions.test.ts
+++ b/frontend/src/lib/regions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { formatRegion } from './regions'
+
+describe('formatRegion', () => {
+  it('localizes a country and derives its flag', () => {
+    expect(formatRegion('us', 'fr')).toEqual({ code: 'US', flag: '🇺🇸', name: 'États-Unis' })
+  })
+
+  it('supports supranational ISO region codes', () => {
+    expect(formatRegion('EU', 'fr')).toEqual({
+      code: 'EU',
+      flag: '🇪🇺',
+      name: 'Union européenne'
+    })
+  })
+})

--- a/frontend/src/lib/regions.ts
+++ b/frontend/src/lib/regions.ts
@@ -1,0 +1,15 @@
+export function formatRegion(code: string, locale: string) {
+  const normalizedCode = code.trim().toUpperCase()
+  const flag = /^[A-Z]{2}$/.test(normalizedCode)
+    ? String.fromCodePoint(...[...normalizedCode].map((letter) => letter.charCodeAt(0) + 127397))
+    : ''
+
+  try {
+    const name =
+      new Intl.DisplayNames([locale], { type: 'region', fallback: 'code' }).of(normalizedCode) ??
+      normalizedCode
+    return { code: normalizedCode, flag, name }
+  } catch {
+    return { code: normalizedCode, flag, name: normalizedCode }
+  }
+}

--- a/frontend/src/routes/arene/modeles/+page.svelte
+++ b/frontend/src/routes/arene/modeles/+page.svelte
@@ -220,7 +220,7 @@
       class="w-auto! max-w-full"
     />
 
-    <div class="gap-6 md:grid-cols-2 xl:grid-cols-3 grid">
+    <div class="gap-6 md:grid-cols-2 2xl:grid-cols-3 grid">
       {#each filteredModels as model (model.id)}
         <ModelCard
           {model}


### PR DESCRIPTION
Keeps license labels on one line by reducing card density at narrower desktop widths, expands the energy and hardware methodology tooltips, and displays localized country names with flag emojis and ISO codes. Tested with focused region-formatting tests and browser verification.