### PR TITLE
Polish settings and navigation

### DIFF
--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -207,8 +207,8 @@
         },
         "modelSelection": "Model selection",
         "prompt": {
-            "label": "Write your first message",
-            "placeholder": "Write your first message here"
+            "label": "Write your first prompt",
+            "placeholder": "Write your first prompt here"
         },
         "selectModels": {
             "help": "Choose the comparison mode",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -548,8 +548,8 @@
         },
         "modelSelection": "Sélection des modèles",
         "prompt": {
-            "label": "Écrivez votre premier message",
-            "placeholder": "Écrivez votre premier message ici"
+            "label": "Écrivez votre première requête",
+            "placeholder": "Écrivez votre première requête ici"
         },
         "selectModels": {
             "help": "Sélectionnez le mode de comparaison qui vous convient",

--- a/frontend/src/lib/components/SignInForm.svelte
+++ b/frontend/src/lib/components/SignInForm.svelte
@@ -153,7 +153,7 @@
     {#if canMergeComparisons}
       <Checkbox
         id="login-merge"
-        class="text-xs!"
+        class="text-xs! mt-1!"
         bind:checked={mergeComparisons}
         disabled={step === 'code'}
         label={m['auth.modal.merge']()}
@@ -163,11 +163,12 @@
     {#if terms}
       <Checkbox
         id="login-consent"
-        class="text-xs!"
+        class="text-xs! mt-1!"
         bind:checked={consented}
         disabled={loading || step === 'code' || !consentRequired}
         label={consentLabel}
         links={legalLinks()}
+        linksClass="text-xs! leading-5!"
         error={consentError}
       />
     {:else if consentError}

--- a/frontend/src/lib/components/dsfr/Tabs.svelte
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte
@@ -97,6 +97,7 @@
       role="tabpanel"
       aria-labelledby={`tab-${item.id}`}
       tabindex="0"
+      hidden={item.id !== currentTabId}
       class={[
         'fr-tabs__panel',
         {

--- a/frontend/src/lib/components/dsfr/Tabs.svelte.test.ts
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte.test.ts
@@ -4,7 +4,7 @@ import Tabs from './Tabs.svelte'
 
 describe('Tabs', () => {
   it('updates the selected tab and panel', async () => {
-    const { getByRole } = render(Tabs, {
+    const { container, getByRole } = render(Tabs, {
       tabs: [
         { id: 'add', label: 'Ajouter', content: 'Formulaire' },
         { id: 'manage', label: 'Gérer', content: 'Liste' }
@@ -17,12 +17,15 @@ describe('Tabs', () => {
 
     expect(addTab).toHaveAttribute('aria-selected', 'true')
     expect(manageTab).toHaveAttribute('aria-selected', 'false')
+    expect(getByRole('tabpanel', { name: 'Ajouter' })).not.toHaveAttribute('hidden')
+    expect(container.querySelector('#tab-manage-panel')).toHaveAttribute('hidden')
 
     await fireEvent.click(manageTab)
 
     expect(addTab).toHaveAttribute('aria-selected', 'false')
     expect(manageTab).toHaveAttribute('aria-selected', 'true')
     expect(getByRole('tabpanel', { name: 'Gérer' })).toHaveClass('fr-tabs__panel--selected')
+    expect(container.querySelector('#tab-add-panel')).toHaveAttribute('hidden')
   })
 
   it('moves between tabs with the arrow, home and end keys', async () => {

--- a/frontend/src/lib/components/header/NavBar.svelte
+++ b/frontend/src/lib/components/header/NavBar.svelte
@@ -130,7 +130,7 @@
 
 {#snippet footer(mode: 'desktop' | 'mobile' = 'desktop')}
   <div class="gap-2 flex flex-col">
-    <VoteGauge id="vote-gauge" class={{ 'lg:hidden': !expanded }} />
+    <VoteGauge id="vote-gauge-{mode}" class={{ 'lg:hidden': !expanded }} />
 
     <div class="gap-2 flex items-center">
       <div class="min-w-0 flex-1">


### PR DESCRIPTION
Prevents inactive Settings tabs from overflowing, aligns sign-in checkboxes and legal links, gives desktop and mobile vote tooltips unique anchors, and updates prompt-field wording in French and English. Tested with focused component tests and browser verification.