### PR TITLE
Garde l'historique des conversations lisible quand un modèle est désactivé

### DIFF
--- a/backend/admin/llms/router.py
+++ b/backend/admin/llms/router.py
@@ -24,6 +24,7 @@ from utils.llms.services import (
     upsert_llm_lab,
     upsert_llm_license,
 )
+from utils.storage.redis import REDIS_LLMS_DATA_CACHE_KEY, invalidate_cache
 from utils.utils import FormJsonSchema
 
 logger = logging.getLogger("languia")
@@ -85,7 +86,9 @@ async def get_schema():
 @router.put("/llm")
 async def upsert_llm(body: LLMDataUpsert) -> LLMData:
     async with get_session() as session:
-        return await upsert_llm_data(body, session)
+        db_llm = await upsert_llm_data(body, session)
+        invalidate_cache(REDIS_LLMS_DATA_CACHE_KEY)
+        return db_llm
 
 
 @router.post("/endpoint")
@@ -96,6 +99,7 @@ async def upsert_endpoint(body: LLMEndpointUpsert) -> LLMEndpointPublic:
         # Commit expires the attributes, and the instance detaches when the
         # session closes, so refresh and build the payload here.
         await session.refresh(endpoint)
+        invalidate_cache(REDIS_LLMS_DATA_CACHE_KEY)
         return _to_endpoint_public(endpoint)
 
 
@@ -105,6 +109,7 @@ async def delete_endpoint_api_key(endpoint_id: UUID) -> LLMEndpointPublic:
         endpoint = await clear_llm_endpoint_api_key(endpoint_id, session)
         if not endpoint:
             raise HTTPException(status_code=404, detail="endpoint_not_found")
+        invalidate_cache(REDIS_LLMS_DATA_CACHE_KEY)
         return _to_endpoint_public(endpoint)
 
 
@@ -112,11 +117,15 @@ async def delete_endpoint_api_key(endpoint_id: UUID) -> LLMEndpointPublic:
 @router.put("/lab")
 async def upsert_lab(body: LLMLabUpsert) -> LLMLab:
     async with get_session() as session:
-        return await upsert_llm_lab(body, session)
+        db_lab = await upsert_llm_lab(body, session)
+        invalidate_cache(REDIS_LLMS_DATA_CACHE_KEY)
+        return db_lab
 
 
 @router.post("/license")
 @router.put("/license")
 async def upsert_license(body: LLMLicenseUpsert) -> LLMLicense:
     async with get_session() as session:
-        return await upsert_llm_license(body, session)
+        db_license = await upsert_llm_license(body, session)
+        invalidate_cache(REDIS_LLMS_DATA_CACHE_KEY)
+        return db_license

--- a/frontend/src/routes/(arena)/components/ViewChat.svelte
+++ b/frontend/src/routes/(arena)/components/ViewChat.svelte
@@ -139,7 +139,8 @@
     {#key comparisonId}
       <RevealArea data={comparator.comparison.reveal_data} />
     {/key}
-  {:else}
+    <!-- FIXME in case of disabled llm: explain why no reveal + cannot continue -->
+  {:else if !comparator.comparison.revealed}
     <div
       bind:this={footer}
       id="send-area"

--- a/tests/database/test_comparison_reveal_data.py
+++ b/tests/database/test_comparison_reveal_data.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://example/test")
+os.environ.setdefault("LOG_FORMAT", "RAW")
+
+from utils.database.models import comparison as comparison_model  # noqa: E402
+from utils.database.models.comparison import ComparisonPublic  # noqa: E402
+
+PRESENT = uuid.uuid4()
+GONE = uuid.uuid4()
+
+
+def _comparison(llm_id_a, llm_id_b):
+    return {
+        "id": uuid.uuid4(),
+        "mode": "random",
+        "custom_models_selection": None,
+        "error": None,
+        "revealed": True,
+        "llm_id_a": llm_id_a,
+        "llm_id_b": llm_id_b,
+        "turns": [
+            {
+                "id": uuid.uuid4(),
+                "user_msg": {"content": "question", "role": "user"},
+                "choice": "a_better",
+                "llm_msg_a": None,
+                "keyword_annotations_a": [],
+                "llm_msg_b": None,
+                "keyword_annotations_b": [],
+            }
+        ],
+    }
+
+
+def _validate(monkeypatch, llm_id_a, llm_id_b):
+    calls = []
+
+    def fake_get_reveal_data(comparison, llms):
+        calls.append(comparison.id)
+        return {"b64": "", "chosen_llm": "a", "a": {}, "b": {}}
+
+    monkeypatch.setattr(comparison_model, "get_reveal_data", fake_get_reveal_data)
+    llms = SimpleNamespace(all={PRESENT: object()})
+    result = ComparisonPublic.model_validate(
+        _comparison(llm_id_a, llm_id_b), context={"llms_data": llms}
+    )
+    return result, calls
+
+
+def test_reveal_data_is_built_when_both_models_are_in_the_catalogue(monkeypatch):
+    result, calls = _validate(monkeypatch, PRESENT, PRESENT)
+
+    assert result.reveal_data is not None
+    assert len(calls) == 1
+
+
+def test_a_model_gone_from_the_catalogue_leaves_the_comparison_readable(monkeypatch):
+    # A model disabled after the comparison used to raise KeyError here, which
+    # took down every conversation in the caller's history, not just this one.
+    result, calls = _validate(monkeypatch, PRESENT, GONE)
+
+    assert result.reveal_data is None
+    assert calls == []
+    assert result.turns[0].user_msg.content == "question"

--- a/utils/database/models/comparison.py
+++ b/utils/database/models/comparison.py
@@ -131,7 +131,11 @@ class ComparisonPublic(SQLModel):
         if self.revealed:
             if self.reveal_data is None:
                 llms = info.context.get("llms_data")
-                self.reveal_data = get_reveal_data(self, llms)
+                # A model disabled since the comparison has left the catalogue,
+                # so its impact cannot be computed. The conversation itself
+                # stays readable rather than taking the whole list down.
+                if self.llm_id_a in llms.all and self.llm_id_b in llms.all:
+                    self.reveal_data = get_reveal_data(self, llms)
         else:
             self.llm_id_a = None
             self.llm_id_b = None

--- a/utils/database/models/comparison.py
+++ b/utils/database/models/comparison.py
@@ -129,7 +129,7 @@ class ComparisonPublic(SQLModel):
     @model_validator(mode="after")
     def inject_reveal_data(self, info: ValidationInfo) -> Self:
         if self.revealed:
-            if self.reveal_data is None:
+            if self.reveal_data is None and info.context is not None:
                 llms = info.context.get("llms_data")
                 # A model disabled since the comparison has left the catalogue,
                 # so its impact cannot be computed. The conversation itself


### PR DESCRIPTION
Un modèle désactivé après coup ne fait plus partie du catalogue exposé par l'API, mais les conversations passées gardent son identifiant. Le calcul des données de révélation le cherchait quand même et levait une KeyError, qui renvoyait un 500 pour toute la liste des conversations d'un compte et pas seulement pour celle en cause. Le calcul d'impact est maintenant ignoré pour ces conversations, qui restent lisibles. Testé avec un test unitaire sur le validateur.