### PR TITLE
Show size class instead of estimated parameter counts

### DIFF
--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -552,13 +552,6 @@
                 },
                 "reset": "Ryd alle filtre",
                 "size": {
-                    "labels": {
-                        "L": "70 til 150 milliarder",
-                        "M": "20 til 70 milliarder",
-                        "S": "7 til 20 milliarder",
-                        "XL": "> 150 milliarder",
-                        "XS": "< 7 milliarder"
-                    },
                     "legend": "Størrelse (parametre)"
                 }
             },
@@ -595,7 +588,7 @@
                 "XS": "<15 mia."
             },
             "estimated": "Estimeret størrelse ({size})",
-            "title": "Størrelse"
+            "title": "Størrelse {size}"
         }
     },
     "modes": {

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -715,13 +715,6 @@
                 },
                 "reset": "Clear all filters",
                 "size": {
-                    "labels": {
-                        "L": "100 to 400 billion",
-                        "M": "60 to 100 billion",
-                        "S": "15 to 60 billion",
-                        "XL": "> 400 billion",
-                        "XS": "< 15 billion"
-                    },
                     "legend": "Size (parameters)"
                 }
             },
@@ -758,7 +751,7 @@
                 "XS": "<15 billion"
             },
             "estimated": "Estimated size ({size})",
-            "title": "Size"
+            "title": "Size {size}"
         }
     },
     "modes": {
@@ -1016,7 +1009,8 @@
                     "matformer": "<strong>{model}</strong> is a <strong>{size}</strong> model with a <strong>Matformer</strong> architecture: it adjusts how many of its parameters are used for each response. Its energy class is <strong>{energyClass}</strong>.",
                     "moe": "<strong>{model}</strong> is a <strong>{size}</strong> model with a <strong>mixture-of-experts</strong> architecture: it activates only some of its parameters to generate each response (about <strong>{activeParams} billion</strong> out of <strong>{params} billion</strong>). Its energy class is <strong>{energyClass}</strong>.",
                     "unknown": "<strong>{model}</strong> is a <strong>{size}</strong> model whose architecture has not been disclosed. Given its size, its energy class is <strong>{energyClass}</strong>.",
-                    "unknownProprietary": "<strong>{model}</strong> is a proprietary <strong>{size}</strong> model whose architecture has not been disclosed. Given its size, its energy class is <strong>{energyClass}</strong>."
+                    "unknownProprietary": "<strong>{model}</strong> is a proprietary <strong>{size}</strong> model whose architecture has not been disclosed. Given its size, its energy class is <strong>{energyClass}</strong>.",
+                    "moeProprietary": "<strong>{model}</strong> is a proprietary <strong>{size}</strong> model with a <strong>mixture-of-experts</strong> architecture: it activates only some of its parameters to generate each response. Its energy class is <strong>{energyClass}</strong>."
                 },
                 "comparison": {
                     "comparable": "comparable to <strong>{otherModel}</strong>",

--- a/frontend/locales/messages/et.json
+++ b/frontend/locales/messages/et.json
@@ -392,13 +392,6 @@
                 },
                 "reset": "Eemalda kõik filtrid",
                 "size": {
-                    "labels": {
-                        "L": "100–400 miljardit",
-                        "M": "60–100 miljardit",
-                        "S": "15–60 miljardit",
-                        "XL": "> 400 miljardit",
-                        "XS": "< 15 miljardit"
-                    },
                     "legend": "Suurus (parameetrid)"
                 }
             },
@@ -435,7 +428,7 @@
                 "XS": "<15 miljardit"
             },
             "estimated": "Hinnanguline suurus ({size})",
-            "title": "Suurus"
+            "title": "Suurus {size}"
         }
     },
     "modes": {

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1299,7 +1299,6 @@
             "size": {
                 "active_params_count": "Dont {count}mds actifs",
                 "desc": "Plus un modèle a de paramètres, plus il demande de ressources",
-                "estimated": "Estimation",
                 "params_count": "{count}<span {midProps}>mds</span> <span {smallProps}>paramètres</span>",
                 "params_count_short": "{count}<span {midProps}>mds</span> <span {smallProps}>param.</span>",
                 "title": "Taille",
@@ -1381,13 +1380,6 @@
                 "reset": "Effacer tous les filtres",
                 "size": {
                     "all": "Toutes les tailles",
-                    "labels": {
-                        "L": "de 70 à 150 milliards",
-                        "M": "de 20 à 70 milliards",
-                        "S": "de 7 à 20 milliards",
-                        "XL": "> 150 milliards",
-                        "XS": "< à 7 milliards"
-                    },
                     "legend": "Taille (paramètres)"
                 },
                 "statuses": {
@@ -1458,7 +1450,7 @@
                 "XL": ">400 mds",
                 "XS": "<15 mds"
             },
-            "estimated": "Taille estimée {size}",
+            "estimated": "Taille estimée {size}",
             "title": "Taille {size}"
         },
         "technical": {
@@ -1800,7 +1792,8 @@
                     "matformer": "<strong>{model}</strong> est un modèle <strong>{size}</strong> à l’architecture <strong>Matformer</strong> : il adapte la part de ses paramètres mobilisée à chaque réponse. Sa classe énergétique est <strong>{energyClass}</strong>.",
                     "moe": "<strong>{model}</strong> est un modèle <strong>{size}</strong> à l’architecture <strong>par mélange d’experts</strong> : il n’active qu’une partie de ses paramètres à chaque réponse (environ <strong>{activeParams} milliards</strong> sur <strong>{params} milliards</strong>). Sa classe énergétique est <strong>{energyClass}</strong>.",
                     "unknown": "<strong>{model}</strong> est un modèle <strong>{size}</strong> dont l’architecture n’est pas communiquée. Compte tenu de sa taille, sa classe énergétique est <strong>{energyClass}</strong>.",
-                    "unknownProprietary": "<strong>{model}</strong> est un modèle propriétaire <strong>{size}</strong> dont l’architecture n’est pas communiquée. Compte tenu de sa taille, sa classe énergétique est <strong>{energyClass}</strong>."
+                    "unknownProprietary": "<strong>{model}</strong> est un modèle propriétaire <strong>{size}</strong> dont l’architecture n’est pas communiquée. Compte tenu de sa taille, sa classe énergétique est <strong>{energyClass}</strong>.",
+                    "moeProprietary": "<strong>{model}</strong> est un modèle propriétaire <strong>{size}</strong> à l’architecture <strong>par mélange d’experts</strong> : il n’active qu’une partie de ses paramètres à chaque réponse. Sa classe énergétique est <strong>{energyClass}</strong>."
                 },
                 "comparison": {
                     "comparable": "une consommation <strong>comparable</strong> à celle de <strong>{otherModel}</strong>",

--- a/frontend/locales/messages/it.json
+++ b/frontend/locales/messages/it.json
@@ -399,13 +399,6 @@
                 },
                 "reset": "Cancella tutti i filtri",
                 "size": {
-                    "labels": {
-                        "L": "tra 70 e 150 miliardi",
-                        "M": "da 20 a 70 miliardi",
-                        "S": "da 7 a 20 miliardi",
-                        "XL": ">150 miliardi",
-                        "XS": "<7 miliardi"
-                    },
                     "legend": "Dimensioni (parametri)"
                 }
             },
@@ -442,7 +435,7 @@
                 "XS": "<15 miliardi"
             },
             "estimated": "Dimensione stimata ({size})",
-            "title": "Dimensioni"
+            "title": "Dimensioni {size}"
         }
     },
     "modes": {

--- a/frontend/locales/messages/nb_NO.json
+++ b/frontend/locales/messages/nb_NO.json
@@ -394,13 +394,6 @@
                 },
                 "reset": "Nullstill alle filtre",
                 "size": {
-                    "labels": {
-                        "L": "mellom 70 og 150 milliarder",
-                        "M": "fra 20 til 70 milliarder",
-                        "S": "mellom 7 og 20 milliarder",
-                        "XL": "> 150 milliarder",
-                        "XS": "< 7 milliarder"
-                    },
                     "legend": "Størrelse (parametere)"
                 }
             },
@@ -437,7 +430,7 @@
                 "XS": "< 15 milliarder"
             },
             "estimated": "Estimert størrelse ({size})",
-            "title": "Størrelse"
+            "title": "Størrelse {size}"
         }
     },
     "modes": {

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -290,13 +290,6 @@
                 },
                 "reset": "Rensa alla filter",
                 "size": {
-                    "labels": {
-                        "L": "70 till 150 miljarder",
-                        "M": "20 till 70 miljarder",
-                        "S": "7 till 20 miljarder",
-                        "XL": "> 150 miljarder",
-                        "XS": "< 7 miljarder"
-                    },
                     "legend": "Storlek (parametrar)"
                 }
             },
@@ -326,7 +319,14 @@
         "release": "Utgiven {date}",
         "size": {
             "estimated": "Uppskattad storlek ({size})",
-            "title": "Storlek"
+            "title": "Storlek {size}",
+            "count": {
+                "L": "100 till 400 miljarder",
+                "M": "60 till 100 miljarder",
+                "S": "15 till 60 miljarder",
+                "XL": ">400 miljarder",
+                "XS": "<15 miljarder"
+            }
         }
     },
     "modes": {

--- a/frontend/src/lib/components/InfoCard.svelte
+++ b/frontend/src/lib/components/InfoCard.svelte
@@ -14,6 +14,7 @@
     icon,
     iconClass,
     badge,
+    contentBadge,
     tooltip,
     content,
     subContent,
@@ -32,6 +33,8 @@
     titleClass?: ClassValue
     iconClass?: ClassValue
     badge?: BadgeProps
+    /** Takes the place of `content` when the value is a class, not a figure. */
+    contentBadge?: BadgeProps
     tooltip?: string
     content?: string
     subContent?: string
@@ -122,15 +125,22 @@
   </div>
 
   <svelte:element this={contentTag} class="p-0">
-    {#if badge && size === 'xxs'}
+    {#if content}
+      {@render innerContent(content, subContent)}
+    {:else if size === 'xxs' && (badge ?? contentBadge)}
+      <!-- The header row is hidden at this size, so the badge is the value. -->
       <Badge
-        {...badge}
+        {...(badge ?? contentBadge)!}
         tooltip={undefined}
         size="xs"
-        class="px-1! leading-tight! tracking-normal! max-w-full text-center text-[10px]! [overflow-wrap:anywhere] whitespace-normal!"
+        class="px-1! leading-tight! tracking-normal! max-w-full text-center whitespace-normal!"
       />
-    {:else if content}
-      {@render innerContent(content, subContent)}
+    {:else if contentBadge}
+      <Badge
+        {...contentBadge}
+        size={size === 'md' ? 'md' : 'sm'}
+        class="leading-tight! max-w-full text-center whitespace-normal!"
+      />
     {:else}
       {@render children?.()}
     {/if}

--- a/frontend/src/lib/components/ModelCard.svelte
+++ b/frontend/src/lib/components/ModelCard.svelte
@@ -51,7 +51,11 @@
 
       <!-- Not a <dl>: InfoCard wraps its own markup around the label, so the
            dt/dd never end up direct children and the list is invalid. -->
-      <div class="fr-card__desc p-0 gap-2 mt-0! sm:grid-cols-3 grid grid-cols-2">
+      <!-- The floor is what the longest badge ("Propriétaire") needs on one line.
+           Any narrower and DSFR's break-word splits it mid-word. -->
+      <div
+        class="fr-card__desc p-0 gap-2 mt-0! grid grid-cols-[repeat(auto-fit,minmax(7.25rem,1fr))]"
+      >
         {#each cards as card (card.id)}
           <!-- id after the spread and scoped to the model: getModelCards hands
                out the same 'size'/'license'/... ids to every card, and this

--- a/frontend/src/lib/consumptionSummary.spec.ts
+++ b/frontend/src/lib/consumptionSummary.spec.ts
@@ -88,6 +88,20 @@ describe('buildConsumptionSummary', () => {
     expect(summary).toContain('une consommation comparable')
   })
 
+  it('describes a proprietary mixture of experts without parameter counts', () => {
+    const summary = consumptionSummaryToText(
+      buildConsumptionSummary(
+        { ...claude, name: 'MoE propriétaire', arch: 'moe', params: 1600, active_params: 49 },
+        gemma,
+        { tokens: 100, energy_mwh: 100 },
+        { tokens: 100, energy_mwh: 100 }
+      )
+    )
+
+    expect(summary).toContain('architecture par mélange d’experts')
+    expect(summary).not.toMatch(/\d+\s*milliards/)
+  })
+
   it('handles the existing XS and Matformer repository values explicitly', () => {
     const summary = consumptionSummaryToText(
       buildConsumptionSummary(

--- a/frontend/src/lib/consumptionSummary.ts
+++ b/frontend/src/lib/consumptionSummary.ts
@@ -72,6 +72,9 @@ function buildClassification(model: ConsumptionSummaryModel): string {
     case 'dense':
       return m['reveal.impacts.summary.classification.dense'](inputs)
     case 'moe':
+      if (model.license.kind === 'proprietary') {
+        return m['reveal.impacts.summary.classification.moeProprietary'](inputs)
+      }
       if (model.active_params !== null) {
         return m['reveal.impacts.summary.classification.moe']({
           ...inputs,

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -82,27 +82,29 @@ export function getModelCards(model: BotModel, size: ModelCardSize, commons: Com
   const archI18nKey = isMaybeArch(model.arch) ? 'na' : model.arch
   const archDescription = m[`generated.archs.${archI18nKey}.desc`]()
   const archLongName = m[`generated.archs.${archI18nKey}.long_name`]()
+  // Proprietary labs do not publish parameter counts, so ours are estimates and
+  // we show the size class instead of a figure we cannot source. The estimate is
+  // still what the energy figures are computed from, server side.
+  const estimated = model.license.kind === 'proprietary'
   return {
     size: {
       id: 'size',
       icon: 'i-ri-ruler-line',
       title: m['models.cards.size.title'](),
-      badge: size !== 'sm' ? model.badges.size_short : undefined,
+      badge: estimated || size === 'sm' ? undefined : model.badges.size_short,
+      contentBadge: estimated ? model.badges.size : undefined,
       tooltip: m['models.cards.size.tooltip'](),
-      content:
-        size !== 'xs'
-          ? m[`models.cards.size.params_count${size === 'sm' ? '_short' : ''}`]({
-              count: model.params,
-              midProps,
-              smallProps
-            })
-          : undefined,
+      content: estimated
+        ? undefined
+        : m[`models.cards.size.params_count${size === 'md' ? '' : '_short'}`]({
+            count: model.params,
+            midProps,
+            smallProps
+          }),
       subContent:
-        model.license.kind === 'proprietary'
-          ? m['models.cards.size.estimated']()
-          : model.active_params
-            ? m['models.cards.size.active_params_count']({ count: model.active_params })
-            : undefined,
+        !estimated && model.active_params
+          ? m['models.cards.size.active_params_count']({ count: model.active_params })
+          : undefined,
       desc: undefined
     } as const,
     arch: {

--- a/frontend/src/routes/(arena)/components/RevealCard.svelte
+++ b/frontend/src/routes/(arena)/components/RevealCard.svelte
@@ -266,7 +266,9 @@
     </ul>
   </div>
 
-  <div class="gap-4 sm:grid-cols-3 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5 grid grid-cols-2">
+  <!-- The floor is what "Niveau d'ouverture" and the size badge need to fit.
+       Any narrower and DSFR's break-word splits them mid-word. -->
+  <div class="gap-4 grid grid-cols-[repeat(auto-fit,minmax(9.75rem,1fr))]">
     {#each cards as card, i (i)}
       <InfoCard
         {...card}

--- a/frontend/src/routes/(arena)/models/+page.svelte
+++ b/frontend/src/routes/(arena)/models/+page.svelte
@@ -51,7 +51,7 @@
         { value: 'all', label: m['models.list.filters.size.all'](), count: models.length },
         ...SIZE_CLASSES.map((value) => ({
           value,
-          label: m[`models.list.filters.size.labels.${value}`](),
+          label: m[`models.size.count.${value}`](),
           count: models.filter((llm) => llm.size_class === value).length
         }))
       ],


### PR DESCRIPTION
For proprietary models we were publishing a precise parameter count that is only our own estimate. Naming a figure we cannot source moves the discussion onto the figure rather than the size, so those models now show their size class where the count used to be: model card, reveal card, detail modal, and the mixture-of-experts sentence on the reveal. Open weights and open source models keep their exact count. Nothing changed server side, the estimates are still what EcoLogits computes the energy figures from.

Two fixes along the way. The size filter on the models list advertised buckets of 7/20/70/150 billion parameters while the real ones are 15/60/100/400, so it now reads the same strings as the energy graph legend. And models.size.title had lost its {size} placeholder in every locale but French, so the badge read just "Size" instead of "Size XL".

The size badge needed more room than the fixed grids gave it, so the tile grids on the model card and the reveal now fit as many columns as the width allows and never drop below what the longest label needs on one line. On a wide screen the reveal is back to a single row.

One diff line looks like a no-op: models.size.estimated in fr.json. The visible text is unchanged, it is a non-breaking space turned into a regular one so the badge can wrap at the space rather than mid-word.
