### PR TITLE
Personal leaderboard for signed-in users

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from backend.auth.router import router as auth_router
 from backend.config import settings
 from backend.llms.router import router as models_router
 from backend.logger import configure_logger, configure_uvicorn_logging
+from backend.ranking.router import router as ranking_router
 from backend.sentry import init_sentry
 from backend.settings.router import router as settings_router
 from backend.statistics import router as statistics_router
@@ -88,6 +89,7 @@ app.include_router(auth_router)
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(statistics_router)
+app.include_router(ranking_router)
 
 
 @app.get("/counter")

--- a/backend/ranking/models.py
+++ b/backend/ranking/models.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+from utils.ranking.personal import PersonalRankingRow
+
+
+class PersonalRanking(BaseModel):
+    """
+    The signed-in user's own ranking, already scored, ordered and numbered.
+
+    Rows carry no model metadata beyond the identity: the client joins them on
+    the model list it already holds.
+    """
+
+    rows: list[PersonalRankingRow]
+    votes_count: int

--- a/backend/ranking/router.py
+++ b/backend/ranking/router.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from backend.auth.dependencies import RequiredUser
+
+from .models import PersonalRanking
+from .services import get_personal_ranking
+
+router = APIRouter(prefix="/ranking", tags=["ranking"])
+
+
+@router.get("/personal")
+async def personal_ranking(user: RequiredUser) -> PersonalRanking:
+    return await get_personal_ranking(user.id)

--- a/backend/ranking/services.py
+++ b/backend/ranking/services.py
@@ -1,0 +1,85 @@
+import logging
+from uuid import UUID
+
+from sqlmodel import col, func, select
+
+from backend.config import settings
+from backend.llms.models import DatasetData
+from backend.utils.countries import get_ranking
+from utils.database.models import Comparison, Turn
+from utils.database.models.llms import LLMData
+from utils.database.session import get_session
+from utils.ranking.personal import OUTCOMES, rank_personal_models, tally_votes
+
+from .models import PersonalRanking
+
+logger = logging.getLogger("languia")
+
+
+def _general_ranks() -> dict[UUID, int]:
+    """Position of each model in the last computed general ranking, if any."""
+    ranking = get_ranking()
+    if not ranking:
+        return {}
+    return {
+        UUID(str(llm_id)): DatasetData.model_validate(data).rank
+        for llm_id, data in ranking.rankings.items()
+    }
+
+
+async def get_personal_ranking(user_id: UUID) -> PersonalRanking:
+    """
+    Rank every model this user has voted on, from their votes alone.
+
+    Not cached: the point of the feature is that the table moves as soon as a
+    vote is cast.
+    """
+    empty = PersonalRanking(rows=[], votes_count=0)
+    if not settings.COMPARIA_DB_URI:
+        logger.warning("Cannot compute personal ranking: no database configured")
+        return empty
+
+    async with get_session() as session:
+        votes = (
+            await session.exec(
+                select(
+                    Comparison.llm_id_a,
+                    Comparison.llm_id_b,
+                    Turn.choice,
+                    func.count(col(Turn.id)),
+                )
+                .join(Comparison, col(Turn.comparison_id) == col(Comparison.id))
+                .where(Comparison.user_id == user_id)
+                .where(col(Comparison.archived).is_not(True))
+                .where(col(Turn.choice).in_(list(OUTCOMES)))
+                .group_by(
+                    col(Comparison.llm_id_a),
+                    col(Comparison.llm_id_b),
+                    col(Turn.choice),
+                )
+            )
+        ).all()
+
+        tallies = tally_votes(votes)
+        if not tallies:
+            return empty
+
+        names = dict(
+            (
+                await session.exec(
+                    select(LLMData.id, LLMData.name).where(
+                        col(LLMData.id).in_(list(tallies))
+                    )
+                )
+            ).all()
+        )
+
+    general_ranks = _general_ranks()
+    for llm_id, tally in tallies.items():
+        tally.name = names.get(llm_id, "")
+        tally.general_rank = general_ranks.get(llm_id)
+
+    return PersonalRanking(
+        rows=rank_personal_models(tallies.values()),
+        votes_count=sum(count for *_, count in votes),
+    )

--- a/frontend/locales/messages/da.json
+++ b/frontend/locales/messages/da.json
@@ -631,6 +631,28 @@
         }
     },
     "ranking": {
+        "personal": {
+            "cols": {
+                "battles": "Sammenligninger",
+                "general_rank": "Generel rang",
+                "record": "Resultat (S-N-U)",
+                "score": "Min score"
+            },
+            "loading": "Indlæser din rangliste…",
+            "noVotes": "Stem i en sammenligning for at starte din rangering.",
+            "signedOut": "Log ind for at se rangeringen bygget på dine stemmer.",
+            "title": "Min rangering",
+            "tooltips": {
+                "score": "En model, du kun har sammenlignet få gange, trækkes mod dit eget gennemsnit i stedet for at vise en ekstrem score."
+            },
+            "totalModels": "Rangerede modeller:",
+            "totalVotes": "Mine stemmer:"
+        },
+        "views": {
+            "general": "Generel",
+            "legend": "Visning af rangering",
+            "personal": "Min rangering"
+        },
         "energy": {
             "desc": "Denne graf viser for hver model sammenhængen mellem tilfredshedsscore (Bradley Terry-score) og det estimerede gennemsnitlige energiforbrug pr. 1000 tokens. Energiforbruget estimeres ved hjælp af <a {linkProps}>Ecologits</a>-metodologien, som tager højde for to faktorer: modellernes <strong>størrelse</strong> (antal parametre) og deres <strong>arkitektur</strong>. Da <strong>proprietære modeller</strong> ikke offentliggør disse oplysninger - eller kun gør det delvist - er de ikke medtaget i grafen nedenfor.",
             "tabLabel": "Energi fokus",
@@ -730,6 +752,18 @@
                     },
                     "title": "Rangordning efter sejrsrate"
                 }
+            },
+            "personal": {
+                "choices": {
+                    "both_bad": "<strong>Ingen er gode</strong>: 0 point til hver model — din utilfredshed tæller, ikke kun din relative præference.",
+                    "both_good": "<strong>Begge er gode</strong>: 0,5 point til hver model.",
+                    "idk": "<strong>Ved ikke</strong>: udelukkes fra beregningen, tæller ikke for nogen af modellerne."
+                },
+                "desc": {
+                    "1": "Bradley-Terry kræver et sammenhængende netværk af sammenligninger: dine stemmer danner mest spredte, usammenhængende par, så metoden virker ikke for en enkelt konto. Den personlige score er en <strong>udjævnet vinderrate</strong>:",
+                    "2": "<strong>points</strong> er dit samlede antal point på modellen, <strong>battles</strong> antallet af scorede sammenligninger med den, og <strong>m</strong> dit gennemsnitlige antal point pr. sammenligning på tværs af alle modeller. Udjævningen trækker en sjældent sammenlignet model mod dette gennemsnit: én sejr viser 0,667 og ikke 100 %, og en model sammenlignet tyve gange rangerer over en sammenlignet én gang ved samme rate."
+                },
+                "title": "Din personlige rangering: sådan beregnes din score"
             },
             "tabLabel": "Metodologi",
             "title": "Hvordan vælger man metoden til rangordning af modeller?"

--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -794,6 +794,28 @@
         }
     },
     "ranking": {
+        "personal": {
+            "cols": {
+                "battles": "Comparisons",
+                "general_rank": "General rank",
+                "record": "Record (W-L-T)",
+                "score": "My score"
+            },
+            "loading": "Loading your ranking…",
+            "noVotes": "Vote in a comparison to start your ranking.",
+            "signedOut": "Sign in to see the ranking built from your votes.",
+            "title": "My ranking",
+            "tooltips": {
+                "score": "A model you have compared only a few times is pulled toward your own average rather than showing an extreme score."
+            },
+            "totalModels": "Models ranked:",
+            "totalVotes": "My votes:"
+        },
+        "views": {
+            "general": "General",
+            "legend": "Ranking view",
+            "personal": "My ranking"
+        },
         "energy": {
             "desc": "This graph represents the satisfaction score (Bradley Terry score) for each model as a function of the estimated average energy consumption per 1000 tokens. Energy consumption is estimated using the Ecologits methodology and is based on two parameters: the size of the models (number of parameters) and their architecture. For proprietary models, this information is either not provided or only partially available. Therefore, they are excluded from the graph below.",
             "tabLabel": "Energy focus",
@@ -893,6 +915,18 @@
                     },
                     "title": "Ranking by win rate"
                 }
+            },
+            "personal": {
+                "choices": {
+                    "both_bad": "<strong>Both bad</strong>: 0 points to each model — your dissatisfaction counts, not only your relative preference.",
+                    "both_good": "<strong>Both good</strong>: 0.5 points to each model.",
+                    "idk": "<strong>I don't know</strong>: excluded from the count, it does not count for either model."
+                },
+                "desc": {
+                    "1": "Bradley-Terry needs a connected network of comparisons: your votes are mostly scattered, disconnected pairs, so the method does not apply at the scale of a single account. The personal score is a <strong>shrunk win rate</strong>:",
+                    "2": "<strong>points</strong> is your point total on the model, <strong>battles</strong> the number of scored comparisons involving it, and <strong>m</strong> your average points per comparison across every model. Shrinkage pulls a rarely compared model toward that average: a single win shows 0.667 rather than 100%, and a model compared twenty times outranks one compared once at a comparable rate."
+                },
+                "title": "The personal ranking: how your score is worked out"
             },
             "tabLabel": "Methodology",
             "title": "How to choose the model classification method?"

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -1498,6 +1498,28 @@
         }
     },
     "ranking": {
+        "personal": {
+            "cols": {
+                "battles": "Comparaisons",
+                "general_rank": "Rang général",
+                "record": "Bilan (V-D-É)",
+                "score": "Mon score"
+            },
+            "loading": "Chargement de votre classement…",
+            "noVotes": "Votez lors d’une comparaison pour commencer votre classement.",
+            "signedOut": "Connectez-vous pour voir le classement issu de vos votes.",
+            "title": "Mon classement",
+            "tooltips": {
+                "score": "Un modèle comparé peu de fois est rapproché de votre moyenne personnelle plutôt que d’afficher un score extrême."
+            },
+            "totalModels": "Modèles classés :",
+            "totalVotes": "Mes votes :"
+        },
+        "views": {
+            "general": "Général",
+            "legend": "Vue du classement",
+            "personal": "Mon classement"
+        },
         "energy": {
             "desc": "Ce graphique représente pour chaque modèle le score de satisfaction (score Bradley Terry) en fonction de l’estimation de la consommation énergétique moyenne pour 1000 tokens. La consommation énergétique est estimée à partir de la méthodologie <a {linkProps}>Ecologits</a> et repose sur la prise en compte de deux paramètres: la <strong>taille</strong> des modèles (nombre de paramètres) et leur <strong>architecture</strong>. Pour les <strong>modèles propriétaires</strong>, ces informations ne sont pas ou que partiellement communiquées. C’est pourquoi ils sont exclus du graphique ci-dessous.",
             "tabLabel": "Focus énergie",
@@ -1598,6 +1620,18 @@
                     },
                     "title": "Classement par taux de victoire"
                 }
+            },
+            "personal": {
+                "choices": {
+                    "both_bad": "<strong>Aucun des deux ne convient</strong> : 0 point pour chacun des deux modèles — l’insatisfaction compte, pas seulement la préférence relative.",
+                    "both_good": "<strong>Les deux se valent</strong> : 0,5 point pour chacun des deux modèles.",
+                    "idk": "<strong>Je ne sais pas</strong> : le vote est exclu, il ne compte pour aucun des deux modèles."
+                },
+                "desc": {
+                    "1": "Bradley-Terry a besoin d’un réseau de comparaisons connecté : vos votes ne forment qu’un nuage de paires isolées, la méthode ne s’applique donc pas à l’échelle d’un compte. Le score personnel est un <strong>taux de victoire lissé</strong> :",
+                    "2": "<strong>points</strong> est votre total de points sur le modèle, <strong>battles</strong> le nombre de comparaisons scorées le concernant, et <strong>m</strong> votre moyenne de points par comparaison, tous modèles confondus. Le lissage rapproche un modèle peu comparé de cette moyenne : une seule victoire affiche donc 0,667 et non 100 %, et un modèle comparé vingt fois dépasse un modèle comparé une fois à taux comparable."
+                },
+                "title": "Le classement personnel : comment est calculé votre score"
             },
             "style": {
                 "coef": {

--- a/frontend/locales/messages/lt.json
+++ b/frontend/locales/messages/lt.json
@@ -163,6 +163,44 @@
         },
         "title": "Platformos statistika"
     },
+    "ranking": {
+        "personal": {
+            "cols": {
+                "battles": "Palyginimai",
+                "general_rank": "Bendras rangas",
+                "record": "Rezultatas (L-P-Ly)",
+                "score": "Mano įvertis"
+            },
+            "loading": "Įkeliamas jūsų reitingas…",
+            "noVotes": "Balsuokite palyginime, kad pradėtumėte savo reitingą.",
+            "signedOut": "Prisijunkite, kad pamatytumėte reitingą, sudarytą iš jūsų balsų.",
+            "title": "Mano reitingas",
+            "tooltips": {
+                "score": "Modelis, kurį palyginote vos kelis kartus, priartinamas prie jūsų vidurkio, o ne rodo kraštutinį įvertį."
+            },
+            "totalModels": "Įvertinti modeliai:",
+            "totalVotes": "Mano balsai:"
+        },
+        "views": {
+            "general": "Bendras",
+            "legend": "Reitingo rodinys",
+            "personal": "Mano reitingas"
+        },
+        "methodo": {
+            "personal": {
+                "choices": {
+                    "both_bad": "<strong>Nė vienas neteko</strong>: po 0 taškų kiekvienam modeliui — skaičiuojamas jūsų nepasitenkinimas, o ne tik santykinis pasirinkimas.",
+                    "both_good": "<strong>Abu geri</strong>: po 0,5 taško kiekvienam modeliui.",
+                    "idk": "<strong>Nežinau</strong>: neįtraukiama į skaičiavimą, neįskaitoma nė vienam modeliui."
+                },
+                "desc": {
+                    "1": "Bradley-Terry metodui reikia sujungto palyginimų tinklo: jūsų balsai daugiausia sudaro išsibarsčiusias, nesusijusias poras, todėl metodas netinka vienai paskyrai. Asmeninis įvertis yra <strong>sumažintas laimėjimų rodiklis</strong>:",
+                    "2": "<strong>points</strong> – jūsų taškų suma už modelį, <strong>battles</strong> – įvertintų palyginimų su juo skaičius, o <strong>m</strong> – jūsų vidutinis taškų skaičius už palyginimą visuose modeliuose. Sumažinimas retai lyginamą modelį priartina prie šio vidurkio: vienas laimėjimas rodo 0,667, o ne 100 %, o dvidešimt kartų lygintas modelis lenkia vieną kartą lygintą modelį esant panašiam santykiui."
+                },
+                "title": "Asmeninis reitingas: kaip apskaičiuojamas jūsų įvertis"
+            }
+        }
+    },
     "reveal": {
         "impacts": {
             "summary": {

--- a/frontend/locales/messages/sv.json
+++ b/frontend/locales/messages/sv.json
@@ -362,6 +362,28 @@
         }
     },
     "ranking": {
+        "personal": {
+            "cols": {
+                "battles": "Jämförelser",
+                "general_rank": "Allmän rang",
+                "record": "Resultat (V-F-O)",
+                "score": "Mina poäng"
+            },
+            "loading": "Laddar din rankning…",
+            "noVotes": "Rösta i en jämförelse för att starta din rankning.",
+            "signedOut": "Logga in för att se rankningen som byggts av dina röster.",
+            "title": "Min rankning",
+            "tooltips": {
+                "score": "En modell du bara jämfört några gånger dras mot ditt eget genomsnitt i stället för att visa en extrem poäng."
+            },
+            "totalModels": "Rankade modeller:",
+            "totalVotes": "Mina röster:"
+        },
+        "views": {
+            "general": "Allmän",
+            "legend": "Rankningsvy",
+            "personal": "Min rankning"
+        },
         "energy": {
             "views": {
                 "graph": {
@@ -421,6 +443,18 @@
                     },
                     "title": "Rankning efter vinstfrekvens"
                 }
+            },
+            "personal": {
+                "choices": {
+                    "both_bad": "<strong>Ingen är bra</strong>: 0 poäng till vardera modell — ditt missnöje räknas, inte bara din relativa preferens.",
+                    "both_good": "<strong>Båda är bra</strong>: 0,5 poäng till vardera modell.",
+                    "idk": "<strong>Vet inte</strong>: utesluts från beräkningen, räknas inte för någon av modellerna."
+                },
+                "desc": {
+                    "1": "Bradley-Terry kräver ett sammanhängande nätverk av jämförelser: dina röster bildar mestadels spridda, osammanhängande par, så metoden fungerar inte för ett enskilt konto. Den personliga poängen är en <strong>utjämnad vinstandel</strong>:",
+                    "2": "<strong>points</strong> är din totala poäng på modellen, <strong>battles</strong> antalet poängsatta jämförelser den ingår i, och <strong>m</strong> ditt genomsnittliga antal poäng per jämförelse över alla modeller. Utjämningen drar en sällan jämförd modell mot detta genomsnitt: en vinst visar 0,667 och inte 100 %, och en modell jämförd tjugo gånger rankas över en jämförd en gång vid liknande andel."
+                },
+                "title": "Din personliga rankning: så beräknas din poäng"
             },
             "tabLabel": "Metodik",
             "title": "Hur väljer man metod för att klassificera modeller?"

--- a/frontend/src/lib/components/dsfr/Segmented.svelte
+++ b/frontend/src/lib/components/dsfr/Segmented.svelte
@@ -1,4 +1,7 @@
-<script lang="ts" generics="Value extends string, Option extends { value: Value, label: string }">
+<script
+  lang="ts"
+  generics="Value extends string, Option extends { value: Value, label: string, icon?: string }"
+>
   import type { ClassValue, HTMLFieldsetAttributes } from 'svelte/elements'
 
   let {
@@ -44,6 +47,10 @@
           bind:group={value}
         />
         <label class={['fr-label', labelClass]} for={`${id}-${option.value}`}>
+          {#if option.icon}
+            <!-- Decorative: the label already says which view this is. -->
+            <span aria-hidden="true" class="me-2">{option.icon}</span>
+          {/if}
           {option.label ?? option.value}
         </label>
       </div>

--- a/frontend/src/lib/components/dsfr/Tabs.svelte
+++ b/frontend/src/lib/components/dsfr/Tabs.svelte
@@ -15,6 +15,7 @@
     tabs,
     label,
     initialId = tabs[0].id,
+    currentTabId = $bindable(untrack(() => initialId)),
     noBorders = false,
     panelClass = '',
     kind = 'tab',
@@ -24,13 +25,12 @@
     tabs: Readonly<T[]>
     label: string
     initialId?: T['id']
+    currentTabId?: T['id']
     noBorders?: boolean
     panelClass?: ClassValue
     kind?: 'tab' | 'nav'
     tab?: Snippet<[T]>
   } & SvelteHTMLElements['div'] = $props()
-
-  let currentTabId = $state(untrack(() => initialId))
 
   function selectTab(index: number) {
     const tab = tabs[index]

--- a/frontend/src/lib/generated/backend.ts
+++ b/frontend/src/lib/generated/backend.ts
@@ -329,6 +329,34 @@ export interface CurrencyInfo {
   source: "base" | "frankfurter" | "manual";
   [k: string]: unknown;
 }
+/**
+ * The signed-in user's own ranking, already scored, ordered and numbered.
+ *
+ * Rows carry no model metadata beyond the identity: the client joins them on
+ * the model list it already holds.
+ */
+export interface PersonalRanking {
+  rows: PersonalRankingRow[];
+  votes_count: number;
+}
+/**
+ * One model in a user's own ranking, scored, ordered and numbered.
+ *
+ * Carries the model name as well as its id: a model the user voted on can have
+ * left the arena since, and is then missing from the model list the client
+ * holds.
+ */
+export interface PersonalRankingRow {
+  llm_id: string;
+  name: string;
+  rank: number;
+  score: number;
+  battles: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  [k: string]: unknown;
+}
 export interface PublicLegalDocument {
   version: string;
   content_hash: string;

--- a/frontend/src/lib/models.test.ts
+++ b/frontend/src/lib/models.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { assignRankClasses, MAX_RANK_CLASS, rankClassSpans } from './models'
+import type { PersonalRankingRow } from '$lib/generated/backend'
+import {
+  assignRankClasses,
+  joinPersonalRanking,
+  MAX_RANK_CLASS,
+  rankClassSpans,
+  type BotModel
+} from './models'
 
 /** A model is only its two confidence bounds as far as class assignment cares. */
 const ci = (low: number, high: number) => ({ score_p2_5: low, score_p97_5: high })
@@ -55,5 +62,62 @@ describe('rankClassSpans', () => {
         { rank: 2, rankClass: '1' }
       ])
     ).toEqual({ '1': { min: 1, max: 2 }, '2': { min: 3, max: 3 } })
+  })
+})
+
+describe('joinPersonalRanking', () => {
+  /** Only the fields the join reads. */
+  const model = (id: string, human_id: string) =>
+    ({ id, human_id, search: `${human_id} lab` }) as BotModel
+
+  const personalRow = (llm_id: string, name: string, rank: number): PersonalRankingRow => ({
+    llm_id,
+    name,
+    rank,
+    score: 0.667,
+    battles: 1,
+    wins: 1,
+    losses: 0,
+    ties: 0
+  })
+
+  it('attaches the model and its place in the general ranking', () => {
+    const [row] = joinPersonalRanking(
+      [personalRow('a', 'Mistral Large', 1)],
+      [model('a', 'mistral-large')],
+      { a: 4 }
+    )
+
+    expect(row.model?.human_id).toBe('mistral-large')
+    expect(row.generalRank).toBe(4)
+    expect(row.search).toBe('mistral-large lab')
+  })
+
+  it('keeps a model that has left the arena, under the name the server sent', () => {
+    const [row] = joinPersonalRanking([personalRow('gone', 'Retired model', 1)], [], {})
+
+    expect(row.model).toBeNull()
+    expect(row.name).toBe('Retired model')
+    expect(row.search).toBe('Retired model')
+  })
+
+  it('gives no general rank to a model the general ranking does not hold', () => {
+    const [row] = joinPersonalRanking(
+      [personalRow('a', 'Mistral Large', 1)],
+      [model('a', 'mistral-large')],
+      {}
+    )
+
+    expect(row.generalRank).toBeNull()
+  })
+
+  it('keeps the order the server sent', () => {
+    const rows = joinPersonalRanking(
+      [personalRow('b', 'B', 1), personalRow('a', 'A', 2)],
+      [model('a', 'a'), model('b', 'b')],
+      { a: 1, b: 2 }
+    )
+
+    expect(rows.map((row) => row.id)).toEqual(['b', 'a'])
   })
 })

--- a/frontend/src/lib/models.ts
+++ b/frontend/src/lib/models.ts
@@ -1,5 +1,11 @@
 import { formatCurrencyFromEuro } from '$lib/currency'
-import type { APILLMData, DatasetData, LLMList, PreferencesData } from '$lib/generated/backend'
+import type {
+  APILLMData,
+  DatasetData,
+  LLMList,
+  PersonalRankingRow,
+  PreferencesData
+} from '$lib/generated/backend'
 import type { Archs, EnergyClasses, MaybeArchs } from '$lib/generated/constants'
 import { MAYBE_ARCHS } from '$lib/generated/constants'
 import { propsToAttrs } from '$lib/utils/commons'
@@ -61,6 +67,13 @@ export type BotModel = ReturnType<typeof parseModel>
 export type BotModelWithData = BotModel & {
   data: DatasetData
   prefs: PreferencesData
+}
+export type PersonalRow = PersonalRankingRow & {
+  id: string
+  // Missing when the user voted on a model that has since left the arena.
+  model: BotModel | null
+  generalRank: number | null
+  search: string
 }
 export type ModelCardSize = 'xxs' | 'xs' | 'sm' | 'md'
 
@@ -444,4 +457,31 @@ export function applyStyleControl(models: BotModelWithData[]): BotModelWithData[
     ...m,
     data: { ...m.data, rank: i + 1, rankClass: classes[i].toString() as RankClass }
   }))
+}
+
+/**
+ * Attach each personal ranking row to the model it is about.
+ *
+ * The rows come from the server already scored, ordered and numbered, so the
+ * order is kept as it arrives. A row whose model is gone from the arena keeps
+ * its place with the name the server sent, and a model missing from the general
+ * ranking gets no general rank rather than a zero.
+ */
+export function joinPersonalRanking(
+  rows: PersonalRankingRow[],
+  models: BotModel[],
+  generalRanks: Record<string, number>
+): PersonalRow[] {
+  const byId = new Map(models.map((model) => [model.id, model]))
+
+  return rows.map((row) => {
+    const model = byId.get(row.llm_id) ?? null
+    return {
+      ...row,
+      id: row.llm_id,
+      model,
+      generalRank: generalRanks[row.llm_id] ?? null,
+      search: model?.search ?? row.name
+    }
+  })
 }

--- a/frontend/src/routes/(arena)/ranking/+page.svelte
+++ b/frontend/src/routes/(arena)/ranking/+page.svelte
@@ -283,7 +283,7 @@
               options={viewOptions}
               bind:value={view}
               onchange={onViewChange}
-              class="mb-6!"
+              class="mb-10!"
             />
 
             {#if view === 'general'}

--- a/frontend/src/routes/(arena)/ranking/+page.svelte
+++ b/frontend/src/routes/(arena)/ranking/+page.svelte
@@ -1,12 +1,25 @@
 <script lang="ts">
-  import { Icon, Tabs, Toggle, Tooltip } from '$components/dsfr'
+  import { goto, invalidateAll } from '$app/navigation'
+  import { resolve } from '$app/paths'
+  import { Button, Icon, Link, Segmented, Tabs, Toggle, Tooltip } from '$components/dsfr'
   import PageLayout from '$components/PageLayout.svelte'
+  import { getAuthContext, openSignInModal } from '$lib/auth.svelte'
+  import { getVotesContext } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
-  import { applyStyleControl, getModelsWithDataContext } from '$lib/models'
+  import {
+    applyStyleControl,
+    getModelsContext,
+    getModelsWithDataContext,
+    joinPersonalRanking,
+    rankClassSpans
+  } from '$lib/models'
   import { styleControl } from '$lib/styleControl.svelte'
   import { sanitize } from '$lib/utils/commons'
   import { downloadTextFile, sortIfDefined } from '$lib/utils/data'
-  import { Energy, Methodology, RankingTable } from './components'
+  import { Energy, Methodology, PersonalTable, RankingTable } from './components'
+  import type { RankingView } from './+page'
+
+  let { data } = $props()
 
   const tabs = (
     [
@@ -20,13 +33,75 @@
     label: m[`ranking.${tab.id}.tabLabel`]()
   }))
 
-  const { lastUpdateDate, models: modelsData } = getModelsWithDataContext()
+  const viewIcons = { general: '🌐', personal: '🙋' }
+  const viewOptions = (['general', 'personal'] as const).map((value) => ({
+    value,
+    label: m[`ranking.views.${value}`](),
+    icon: viewIcons[value]
+  }))
+
+  const { lastUpdateDate, commons, models: modelsData } = getModelsWithDataContext()
+  // The full list, not only the ranked models: a model the user voted on can
+  // have dropped out of the general ranking and still needs its size and
+  // architecture.
+  const { models: allModels } = getModelsContext()
+  const votesData = getVotesContext()
+  const auth = getAuthContext()
+
+  let currentTabId = $state<(typeof tabs)[number]['id']>(tabs[0].id)
+  // The switcher writes to it, the address bar overrules it, so back and
+  // forward move between the two views.
+  let view: RankingView = $derived(data.view)
+
+  function onViewChange() {
+    goto(
+      view === 'personal' ? `${resolve('/ranking')}?view=personal` : resolve('/ranking'),
+      {
+        noScroll: true,
+        keepFocus: true
+      }
+    )
+  }
 
   // Local mirror the DSFR Toggle binds to, pushed to the shared singleton that
   // every ranking view reads (RankingTable, EnergyGraph, the CSV export).
   let styleEnabled = $state(styleControl.enabled)
   $effect(() => {
     styleControl.enabled = styleEnabled
+  })
+
+  const rankingRows = $derived(applyStyleControl(modelsData))
+  // Turning style control off is a different fit of the same votes, with its
+  // own classes, so the spans handed to the table follow whichever rows it
+  // is about to render rather than the ones the layout fetched at load time.
+  const rankingCommons = $derived({
+    ...commons,
+    rankClasses: rankClassSpans(rankingRows.map((m) => m.data))
+  })
+
+  // Personal rows arrive with an identifier and nothing else, so the model list
+  // supplies the metadata and the rows of the general view supply the ranks the
+  // user sees on the other side of the switcher.
+  const personalRows = $derived(
+    joinPersonalRanking(
+      data.personal?.rows ?? [],
+      allModels,
+      Object.fromEntries(rankingRows.map((model) => [model.id, model.data.rank]))
+    )
+  )
+  // Style control is a property of the global fit, with no personal
+  // counterpart.
+  const showStyleControl = $derived(!(currentTabId === 'ranking' && view === 'personal'))
+
+  // The sign-in form mutates auth.user in place, client-side, with no
+  // navigation and no reload. The personal ranking still needs fetching, so
+  // catch the transition here rather than teaching the shared sign-in modal
+  // about this one page.
+  const personalPending = $derived(
+    view === 'personal' && !!auth.user && !data.personal && !data.personalFailed
+  )
+  $effect(() => {
+    if (personalPending) invalidateAll()
   })
 
   function onDownloadData(kind: 'ranking' | 'energy') {
@@ -91,6 +166,52 @@
     downloadTextFile(data, `comparia_model-${kind}-${lastUpdateDate}-license_Etalab_2_0`)
   }
 
+  // A user's own votes, live rather than snapshotted, so the filename is
+  // dated today rather than tied to the general ranking's last update.
+  function onDownloadPersonalData() {
+    if (personalRows.length === 0) return
+
+    const csvCols = [
+      { key: 'rank' as const, label: 'Rank' },
+      { key: 'name' as const, label: 'Model' },
+      { key: 'score' as const, label: 'Score' },
+      { key: 'battles' as const, label: 'Battles' },
+      { key: 'record' as const, label: 'Record (W-L-T)' },
+      { key: 'general_rank' as const, label: 'General rank' },
+      { key: 'size' as const, label: 'Size' },
+      { key: 'arch' as const, label: 'Architecture' }
+    ]
+    const csvData = [
+      csvCols.map((col) => col.label).join(','),
+      ...personalRows.map((row) =>
+        csvCols
+          .map((col) => {
+            switch (col.key) {
+              case 'rank':
+                return row.rank
+              case 'name':
+                return row.model?.human_id ?? row.name
+              case 'score':
+                return row.score
+              case 'battles':
+                return row.battles
+              case 'record':
+                return `${row.wins}-${row.losses}-${row.ties}`
+              case 'general_rank':
+                return row.generalRank ?? ''
+              case 'size':
+                return row.model?.size_class ?? 'N/A'
+              case 'arch':
+                return row.model?.arch ?? 'N/A'
+            }
+          })
+          .join(',')
+      )
+    ].join('\n')
+
+    downloadTextFile(csvData, `comparia_personal-ranking-${new Date().toLocaleDateString()}`)
+  }
+
   // function onDownloadPrefsData() {
   //   const csvCols = [
   //     { key: 'id' as const, label: 'id' },
@@ -136,27 +257,113 @@
 >
   {#if lastUpdateDate}
     <div class="relative">
-      <div class="mb-4 gap-2 md:absolute md:top-4 md:right-0 md:mb-0 z-10 flex items-center">
-        <Toggle
-          id="style-control"
-          bind:value={styleEnabled}
-          label={m['ranking.styleControl.label']()}
-          hideCheckLabel
-          class="mb-0! pr-13! font-medium text-[14px]! whitespace-nowrap"
-        />
-        <Tooltip id="style-control-help" size="sm">
-          {@html sanitize(m['ranking.styleControl.help']())}
-        </Tooltip>
-      </div>
+      {#if showStyleControl}
+        <div class="mb-4 gap-2 md:absolute md:top-4 md:right-0 md:mb-0 z-10 flex items-center">
+          <Toggle
+            id="style-control"
+            bind:value={styleEnabled}
+            label={m['ranking.styleControl.label']()}
+            hideCheckLabel
+            class="mb-0! pr-13! font-medium text-[14px]! whitespace-nowrap"
+          />
+          <Tooltip id="style-control-help" size="sm">
+            {@html sanitize(m['ranking.styleControl.help']())}
+          </Tooltip>
+        </div>
+      {/if}
 
-      <Tabs {tabs} label={m['seo.titles.ranking']()} noBorders kind="nav">
+      <Tabs {tabs} label={m['seo.titles.ranking']()} noBorders kind="nav" bind:currentTabId>
         {#snippet tab({ id })}
           {#if id === 'ranking'}
-            <p class="mb-12! text-dark-grey text-[14px]!">
-              {@html sanitize(m['ranking.ranking.desc']())}
-            </p>
+            <Segmented
+              id="ranking-view"
+              legend={m['ranking.views.legend']()}
+              hideLegend
+              size="sm"
+              options={viewOptions}
+              bind:value={view}
+              onchange={onViewChange}
+              class="mb-6!"
+            />
 
-            <RankingTable id="ranking-table" onDownloadData={() => onDownloadData('ranking')} />
+            {#if view === 'general'}
+              <p class="mb-8! text-dark-grey text-[14px]!">
+                {@html sanitize(m['ranking.ranking.desc']())}
+              </p>
+
+              <RankingTable
+                id="ranking-table"
+                models={rankingRows}
+                commons={rankingCommons}
+                {lastUpdateDate}
+                totalVotes={votesData.count}
+                onDownloadData={() => onDownloadData('ranking')}
+              />
+            {:else if !auth.user}
+              <!-- Real ranking data, blurred: the pitch for signing in is what
+                   the feature looks like, not a mock-up of it. -->
+              <div class="rounded-xl relative h-[34rem] overflow-hidden">
+                <div inert aria-hidden="true" class="blur-sm pointer-events-none select-none">
+                  <RankingTable
+                    id="ranking-table-preview"
+                    models={rankingRows}
+                    commons={rankingCommons}
+                    {lastUpdateDate}
+                    totalVotes={votesData.count}
+                    onDownloadData={() => {}}
+                  />
+                </div>
+                <div class="inset-0 absolute flex items-center justify-center">
+                  <section
+                    aria-labelledby="personal-signin-title"
+                    class="cg-border bg-white shadow-lg mx-4 max-w-md rounded-xl px-6 py-8 text-center"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="bg-light-primary mb-4 size-14 mx-auto flex items-center justify-center rounded-full"
+                    >
+                      <Icon icon="lock-line" size="lg" class="text-primary" />
+                    </span>
+                    <h2 id="personal-signin-title" class="fr-h5 mb-2!">
+                      {m['ranking.personal.title']()}
+                    </h2>
+                    <p class="mb-4! text-grey">{m['ranking.personal.signedOut']()}</p>
+                    <Button text={m['auth.discussions.signIn']()} onclick={openSignInModal} />
+                  </section>
+                </div>
+              </div>
+            {:else if personalPending}
+              <!-- Signing in mutates auth.user straight away, but the ranking
+                   only arrives once the reload below finishes. Without this the
+                   old signed-out panel stays on screen in between, telling
+                   someone who just signed in to sign in. -->
+              {@render emptyCard(
+                'personal-loading-title',
+                m['ranking.personal.title'](),
+                m['ranking.personal.loading']()
+              )}
+            {:else if personalRows.length > 0}
+              <PersonalTable
+                id="personal-ranking-table"
+                rows={personalRows}
+                commons={rankingCommons}
+                votesCount={data.personal!.votes_count}
+                onDownloadData={onDownloadPersonalData}
+              />
+            {:else if data.personalFailed}
+              {@render emptyCard(
+                'personal-empty-title',
+                m['ranking.personal.title'](),
+                m['ranking.no_data']()
+              )}
+            {:else}
+              {@render emptyCard(
+                'personal-empty-title',
+                m['ranking.personal.title'](),
+                m['ranking.personal.noVotes'](),
+                { href: resolve('/'), text: m['header.chatbot.newDiscussion']() }
+              )}
+            {/if}
           {:else if id === 'energy'}
             <Energy onDownloadData={() => onDownloadData('energy')} />
             <!-- {:else if id === 'preferences'}
@@ -168,18 +375,32 @@
       </Tabs>
     </div>
   {:else}
-    <section
-      aria-labelledby="ranking-empty-title"
-      class="cg-border bg-very-light-grey mt-8 max-w-2xl rounded-xl px-6 py-12 mx-auto text-center"
-    >
-      <span
-        aria-hidden="true"
-        class="bg-light-primary mb-5 size-16 mx-auto flex items-center justify-center rounded-full"
-      >
-        <Icon icon="trophy-line" size="lg" class="text-primary" />
-      </span>
-      <h2 id="ranking-empty-title" class="fr-h4 mb-3!">{m['seo.titles.ranking']()}</h2>
-      <p class="mb-0! text-grey">{m['ranking.no_data']()}</p>
-    </section>
+    <div class="mt-8">
+      {@render emptyCard('ranking-empty-title', m['seo.titles.ranking'](), m['ranking.no_data']())}
+    </div>
   {/if}
 </PageLayout>
+
+{#snippet emptyCard(
+  titleId: string,
+  title: string,
+  body: string,
+  cta?: { href: string; text: string }
+)}
+  <section
+    aria-labelledby={titleId}
+    class="cg-border bg-very-light-grey max-w-2xl rounded-xl px-6 py-12 mx-auto text-center"
+  >
+    <span
+      aria-hidden="true"
+      class="bg-light-primary mb-5 size-16 mx-auto flex items-center justify-center rounded-full"
+    >
+      <Icon icon="trophy-line" size="lg" class="text-primary" />
+    </span>
+    <h2 id={titleId} class="fr-h4 mb-3!">{title}</h2>
+    <p class={[cta ? 'mb-5!' : 'mb-0!', 'text-grey']}>{body}</p>
+    {#if cta}
+      <Link button href={cta.href} text={cta.text} />
+    {/if}
+  </section>
+{/snippet}

--- a/frontend/src/routes/(arena)/ranking/+page.ts
+++ b/frontend/src/routes/(arena)/ranking/+page.ts
@@ -1,0 +1,27 @@
+import { api } from '$lib/fastapi-client'
+import type { PersonalRanking } from '$lib/generated/backend'
+
+export type RankingView = 'general' | 'personal'
+
+export async function load({ fetch, url, parent }) {
+  const { auth } = await parent()
+  const view: RankingView = url.searchParams.get('view') === 'personal' ? 'personal' : 'general'
+
+  // The layout's model data is the same for everyone, so it cannot carry a
+  // ranking built from one account's votes. Fetched here, and only when that
+  // view is open, so it is as fresh as the user's last vote.
+  if (view !== 'personal' || !auth.user) return { view, personal: null, personalFailed: false }
+
+  // A wobbling backend should cost the personal panel, not the whole route:
+  // api.request throws on a non-OK response, which SvelteKit turns into an
+  // error page for the general ranking too.
+  try {
+    return {
+      view,
+      personal: await api.request<PersonalRanking>('/ranking/personal', { fetch }),
+      personalFailed: false
+    }
+  } catch {
+    return { view, personal: null, personalFailed: true }
+  }
+}

--- a/frontend/src/routes/(arena)/ranking/components/Energy.svelte
+++ b/frontend/src/routes/(arena)/ranking/components/Energy.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
   import { Icon } from '$components/dsfr'
+  import { getVotesContext } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
+  import { applyStyleControl, getModelsWithDataContext, rankClassSpans } from '$lib/models'
   import { externalLinkProps, sanitize } from '$lib/utils/commons'
   import { EnergyGraph, RankingTable } from '.'
 
   let { onDownloadData }: { onDownloadData: () => void } = $props()
+
+  const { lastUpdateDate, commons, models: modelsData } = getModelsWithDataContext()
+  const votesData = getVotesContext()
+  const rankingRows = $derived(applyStyleControl(modelsData))
+  const rankingCommons = $derived({
+    ...commons,
+    rankClasses: rankClassSpans(rankingRows.map((m) => m.data))
+  })
 </script>
 
 <div id="ranking-energy">
@@ -85,6 +95,10 @@
       <RankingTable
         id="energy-table"
         caption={m['ranking.energy.views.table.title']()}
+        models={rankingRows}
+        commons={rankingCommons}
+        {lastUpdateDate}
+        totalVotes={votesData.count}
         initialOrderCol="consumption"
         initialOrderMethod="ascending"
         includedCols={['name', 'elo', 'consumption', 'size', 'arch', 'organisation', 'license']}

--- a/frontend/src/routes/(arena)/ranking/components/Methodology.svelte
+++ b/frontend/src/routes/(arena)/ranking/components/Methodology.svelte
@@ -246,4 +246,30 @@
       </div>
     </div>
   </section>
+
+  <section class="mt-16">
+    <h3 class="fr-h6 mb-4!">{m['ranking.methodo.personal.title']()}</h3>
+    <p class="mb-6! text-dark-grey text-[14px]!">
+      {@html sanitize(m['ranking.methodo.personal.desc.1']())}
+    </p>
+
+    <div class="cg-border rounded-sm! bg-white p-6 max-w-[640px]">
+      <p class="mb-3! font-mono font-bold text-[15px]!">score = (points + 2m) / (battles + 2)</p>
+      <p class="mb-0! text-dark-grey text-[13px]!">
+        {@html sanitize(m['ranking.methodo.personal.desc.2']())}
+      </p>
+    </div>
+
+    <ul class="mt-6! m-0! p-0! max-w-[640px] list-none!">
+      {#each ['both_good', 'both_bad', 'idk'] as const as choice (choice)}
+        <li
+          class="not-last:mb-3 pb-3 p-0! not-last:border-b not-last:border-[--border-default-grey]"
+        >
+          <span class="text-[14px]"
+            >{@html sanitize(m[`ranking.methodo.personal.choices.${choice}`]())}</span
+          >
+        </li>
+      {/each}
+    </ul>
+  </section>
 </div>

--- a/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte
+++ b/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  import AILogo from '$components/AILogo.svelte'
+  import { Link, Table } from '$components/dsfr'
+  import ModelInfoModal from '$components/ModelInfoModal.svelte'
+  import { m } from '$lib/i18n/messages'
+  import { getLocale } from '$lib/i18n/runtime'
+  import { isMaybeArch, type BotModel, type Commons, type PersonalRow } from '$lib/models'
+
+  type ColKind = 'rank' | 'name' | 'score' | 'battles' | 'record' | 'general_rank' | 'size' | 'arch'
+
+  let {
+    id,
+    rows,
+    commons,
+    votesCount,
+    onDownloadData
+  }: {
+    // Scored, ordered and numbered by the server: nothing here re-ranks them.
+    rows: PersonalRow[]
+    id: string
+    commons: Commons
+    votesCount: number
+    onDownloadData: () => void
+  } = $props()
+
+  // Proprietary models publish no architecture, and neither do the ones we
+  // only have a guess for.
+  const archKey = (model: BotModel) =>
+    model.license.kind === 'proprietary' || isMaybeArch(model.arch) ? 'na' : model.arch
+
+  const scoreFormatter = new Intl.NumberFormat(getLocale(), {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3
+  })
+  const votesLabel = $derived(new Intl.NumberFormat(getLocale()).format(votesCount))
+
+  let selectedModel = $state<string>()
+  const selectedModelData = $derived(
+    rows.find((row) => row.id === selectedModel)?.model ?? undefined
+  )
+
+  const cols = $derived(
+    (
+      [
+        { id: 'rank', label: m['ranking.table.data.cols.rank_number']() },
+        { id: 'name', label: m['ranking.table.data.cols.name']() },
+        {
+          id: 'score',
+          label: m['ranking.personal.cols.score'](),
+          tooltip: m['ranking.personal.tooltips.score']()
+        },
+        { id: 'battles', label: m['ranking.personal.cols.battles']() },
+        { id: 'record', label: m['ranking.personal.cols.record']() },
+        { id: 'general_rank', label: m['ranking.personal.cols.general_rank']() },
+        { id: 'size', label: m['ranking.table.data.cols.size']() },
+        { id: 'arch', label: m['ranking.table.data.cols.arch']() }
+      ] as const
+    ).map((col) => ({ ...col, orderable: true }))
+  )
+
+  let orderingCol = $state<ColKind | undefined>('score')
+  let orderingMethod = $state<'ascending' | 'descending'>('descending')
+  let search = $state('')
+
+  $effect(() => {
+    if (orderingCol === undefined) {
+      orderingCol = 'score'
+      orderingMethod = 'descending'
+    }
+  })
+
+  const sortedRows = $derived.by(() => {
+    const _search = search.toLowerCase()
+
+    return rows
+      .filter((row) => (!_search ? true : row.search.toLowerCase().includes(_search)))
+      .sort((ra, rb) => {
+        const [a, b] = orderingMethod === 'ascending' ? [rb, ra] : [ra, rb]
+
+        switch (orderingCol) {
+          case 'name':
+            return (a.model?.human_id ?? a.name).localeCompare(b.model?.human_id ?? b.name)
+          case 'score':
+            return b.score - a.score
+          case 'battles':
+            return b.battles - a.battles
+          case 'record':
+            return b.wins - a.wins
+          case 'general_rank':
+            // A model the general ranking does not hold sits at the end either
+            // way round: it has no position to compare.
+            return (a.generalRank ?? Infinity) - (b.generalRank ?? Infinity)
+          case 'size':
+            return (b.model?.params ?? 0) - (a.model?.params ?? 0)
+          case 'arch':
+            return (a.model?.arch ?? '').localeCompare(b.model?.arch ?? '')
+          default:
+            return a.rank - b.rank
+        }
+      })
+  })
+</script>
+
+<Table
+  {id}
+  {cols}
+  rows={sortedRows}
+  bind:orderingCol
+  bind:orderingMethod
+  bind:search
+  searchLabel={m['actions.searchModel']()}
+  caption={m['ranking.personal.title']()}
+  hideCaption
+>
+  {#snippet headerLeft()}
+    <div class="gap-5 flex">
+      <div class="cg-border rounded-sm! bg-white px-4 py-2">
+        <strong>{m['ranking.personal.totalModels']()}</strong>
+        <span class="text-grey">{rows.length}</span>
+      </div>
+
+      <div class="cg-border rounded-sm! bg-white px-4 py-2">
+        <strong>{m['ranking.personal.totalVotes']()}</strong>
+        <span class="text-grey">{votesLabel}</span>
+      </div>
+    </div>
+
+    <div class="fr-table__detail mb-0!">
+      <Link
+        href="#"
+        download="true"
+        text={m['actions.downloadData']()}
+        icon="download-line"
+        iconPos="right"
+        class="text-[14px]!"
+        onclick={() => onDownloadData()}
+      />
+    </div>
+  {/snippet}
+
+  {#snippet cell(row, col)}
+    {#if col.id === 'rank'}
+      <span class="font-medium">{row.rank}</span>
+    {:else if col.id === 'name'}
+      <div
+        class="sm:max-w-none sm:overflow-visible max-w-[205px] overflow-hidden overflow-ellipsis"
+      >
+        {#if row.model}
+          <AILogo
+            logo={row.model.lab.logo}
+            alt={row.model.lab.name}
+            class="me-1 inline-block align-middle"
+          />
+          <a
+            href="#{row.model.human_id}"
+            data-fr-opened="false"
+            aria-controls="{id}-modal-model"
+            class="text-black!"
+            onclick={() => (selectedModel = row.id)}>{row.model.human_id}</a
+          >
+        {:else}
+          <!-- Voted on, then dropped from the catalogue, so there is no model
+               card to open. Still listed: it is part of the user's record. -->
+          <span>{row.name}</span>
+        {/if}
+      </div>
+    {:else if col.id === 'score'}
+      <span class="font-bold">{scoreFormatter.format(row.score)}</span>
+    {:else if col.id === 'battles'}
+      {row.battles}
+    {:else if col.id === 'record'}
+      {row.wins}-{row.losses}-{row.ties}
+    {:else if col.id === 'general_rank'}
+      <!-- Blank, not zero: the model can be missing from the general ranking
+           and still be in the user's own. -->
+      {#if row.generalRank !== null}{row.generalRank}{/if}
+    {:else if col.id === 'size'}
+      {#if row.model}
+        <strong>{row.model.size_class}</strong> -
+        {#if row.model.license.kind === 'proprietary'}
+          <span class="text-xs">{m['ranking.table.data.estimation']()}</span>
+        {:else}
+          {m['ranking.table.data.billions']({ count: row.model.params })}
+        {/if}
+      {:else}
+        <span class="text-xs text-[--grey-625-425]">{m['words.NA']()}</span>
+      {/if}
+    {:else if col.id === 'arch'}
+      {#if row.model}
+        {m[`generated.archs.${archKey(row.model)}.name`]()}
+      {:else}
+        <span class="text-xs text-[--grey-625-425]">{m['words.NA']()}</span>
+      {/if}
+    {/if}
+  {/snippet}
+</Table>
+
+<ModelInfoModal {commons} model={selectedModelData} modalId="{id}-modal-model" />

--- a/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte
+++ b/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte
@@ -86,10 +86,16 @@
             return b.battles - a.battles
           case 'record':
             return b.wins - a.wins
-          case 'general_rank':
+          case 'general_rank': {
             // A model the general ranking does not hold sits at the end either
-            // way round: it has no position to compare.
-            return (a.generalRank ?? Infinity) - (b.generalRank ?? Infinity)
+            // way round: it has no position to compare. Decided on the rows as
+            // given rather than the swapped pair, so reversing the column does
+            // not carry the missing ones to the top with it.
+            const aMissing = ra.generalRank === null
+            const bMissing = rb.generalRank === null
+            if (aMissing || bMissing) return aMissing === bMissing ? 0 : aMissing ? 1 : -1
+            return a.generalRank! - b.generalRank!
+          }
           case 'size':
             return (b.model?.params ?? 0) - (a.model?.params ?? 0)
           case 'arch':

--- a/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte.test.ts
+++ b/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte.test.ts
@@ -1,0 +1,122 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import type { BotModel, Commons, PersonalRow } from '$lib/models'
+import PersonalTable from './PersonalTable.svelte'
+
+const commons = { modelsCount: 2, currency: { code: 'EUR' }, rankClasses: {} } as Commons
+
+/** Only the fields the table reads. */
+const model = {
+  id: 'a',
+  human_id: 'mistral-large',
+  size_class: 'L',
+  params: 123,
+  arch: 'dense',
+  license: { kind: 'open-source' },
+  lab: { name: 'Mistral', logo: 'mistral' }
+} as BotModel
+
+const rows: PersonalRow[] = [
+  {
+    id: 'a',
+    llm_id: 'a',
+    name: 'Mistral Large',
+    rank: 1,
+    score: 0.866,
+    battles: 20,
+    wins: 18,
+    losses: 2,
+    ties: 0,
+    model,
+    generalRank: 4,
+    search: 'mistral-large'
+  },
+  {
+    id: 'gone',
+    llm_id: 'gone',
+    name: 'Retired model',
+    rank: 2,
+    score: 0.667,
+    battles: 1,
+    wins: 1,
+    losses: 0,
+    ties: 0,
+    model: null,
+    generalRank: null,
+    search: 'Retired model'
+  },
+  {
+    id: 'c',
+    llm_id: 'c',
+    name: 'Third model',
+    rank: 3,
+    score: 0.5,
+    battles: 50,
+    wins: 25,
+    losses: 25,
+    ties: 0,
+    model: { ...model, id: 'c', human_id: 'third-model' },
+    generalRank: 2,
+    search: 'third-model'
+  }
+]
+
+const ranks = (container: HTMLElement) =>
+  [...container.querySelectorAll('tbody tr td:first-child')].map((cell) => cell.textContent?.trim())
+
+describe('personal ranking table', () => {
+  it('shows the record beside the score, and nothing where there is no general rank', () => {
+    const { container } = render(PersonalTable, {
+      id: 'personal-ranking-table',
+      rows,
+      commons,
+      votesCount: 21,
+      onDownloadData: () => {}
+    })
+
+    const cells = [...container.querySelectorAll('tbody tr')].map((row) =>
+      [...row.querySelectorAll('td')].map((cell) => cell.textContent?.trim())
+    )
+
+    expect(cells[0].slice(0, 6)).toEqual(['1', 'mistral-large', '0,866', '20', '18-2-0', '4'])
+    expect(cells[1].slice(2, 6)).toEqual(['0,667', '1', '1-0-0', ''])
+  })
+
+  it('keeps a model that has left the arena, without a link to its card', () => {
+    const { getByText } = render(PersonalTable, {
+      id: 'personal-ranking-table',
+      rows,
+      commons,
+      votesCount: 21,
+      onDownloadData: () => {}
+    })
+
+    const name = getByText('Retired model')
+    expect(name).toBeTruthy()
+    expect(name.closest('a')).toBeNull()
+  })
+
+  it('sorts by score descending, and comes back to it once a column is cycled through', async () => {
+    const { container } = render(PersonalTable, {
+      id: 'personal-ranking-table',
+      rows,
+      commons,
+      votesCount: 21,
+      onDownloadData: () => {}
+    })
+
+    expect(ranks(container)).toEqual(['1', '2', '3'])
+
+    const battles = container.querySelectorAll('thead th')[3].querySelector('button')!
+
+    await fireEvent.click(battles)
+    expect(ranks(container)).toEqual(['3', '1', '2'])
+
+    await fireEvent.click(battles)
+    expect(ranks(container)).toEqual(['2', '1', '3'])
+
+    await fireEvent.click(battles)
+    expect(ranks(container)).toEqual(['1', '2', '3'])
+    expect(container.querySelectorAll('thead th')[2]).toHaveAttribute('aria-sort', 'descending')
+  })
+})

--- a/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte.test.ts
+++ b/frontend/src/routes/(arena)/ranking/components/PersonalTable.svelte.test.ts
@@ -82,6 +82,27 @@ describe('personal ranking table', () => {
     expect(cells[1].slice(2, 6)).toEqual(['0,667', '1', '1-0-0', ''])
   })
 
+  it('keeps a model with no general rank last, whichever way that column is sorted', async () => {
+    const { container } = render(PersonalTable, {
+      id: 'personal-ranking-table',
+      rows,
+      commons,
+      votesCount: 21,
+      onDownloadData: () => {}
+    })
+
+    const generalRank = container.querySelectorAll('thead th')[5].querySelector('button')!
+
+    // Best general rank first, and the model the general ranking does not hold
+    // brings up the rear.
+    await fireEvent.click(generalRank)
+    expect(ranks(container)).toEqual(['3', '1', '2'])
+
+    // Reversing the column must not carry it to the top.
+    await fireEvent.click(generalRank)
+    expect(ranks(container)).toEqual(['1', '3', '2'])
+  })
+
   it('keeps a model that has left the arena, without a link to its card', () => {
     const { getByText } = render(PersonalTable, {
       id: 'personal-ranking-table',

--- a/frontend/src/routes/(arena)/ranking/components/RankingTable.svelte
+++ b/frontend/src/routes/(arena)/ranking/components/RankingTable.svelte
@@ -3,15 +3,9 @@
   import { Badge, Link, Table, Toggle, Tooltip } from '$components/dsfr'
   import ModelInfoModal from '$components/ModelInfoModal.svelte'
   import type { Archs } from '$lib/generated/constants'
-  import { getVotesContext } from '$lib/global.svelte'
   import { m } from '$lib/i18n/messages'
   import { getLocale } from '$lib/i18n/runtime'
-  import {
-    applyStyleControl,
-    getModelsWithDataContext,
-    rankClassLabel,
-    rankClassSpans
-  } from '$lib/models'
+  import { rankClassLabel, type BotModelWithData, type Commons } from '$lib/models'
   import { sortIfDefined } from '$lib/utils/data'
 
   type ColKind =
@@ -30,6 +24,10 @@
   let {
     id,
     caption,
+    models: data,
+    commons,
+    lastUpdateDate,
+    totalVotes,
     initialOrderCol = 'elo',
     initialOrderMethod = 'descending',
     includedCols,
@@ -41,6 +39,12 @@
     id: string
     /** Two of these render on the ranking page; each needs its own title. */
     caption?: string
+    // Handed over ready to render — style control applied, ranks and classes
+    // assigned — so the table has no opinion on where the rows came from.
+    models: BotModelWithData[]
+    commons: Commons
+    lastUpdateDate: string | null
+    totalVotes: number
     initialOrderCol?: ColKind
     initialOrderMethod?: 'ascending' | 'descending'
     includedCols?: ColKind[]
@@ -52,18 +56,9 @@
 
   const NumberFormater = new Intl.NumberFormat(getLocale(), { maximumSignificantDigits: 3 })
 
-  const votesData = getVotesContext()
-  const totalVotes = $derived(NumberFormater.format(votesData.count))
-  const { lastUpdateDate, commons, models: baseModels } = getModelsWithDataContext()
-  const data = $derived(applyStyleControl(baseModels))
+  const totalVotesLabel = $derived(NumberFormater.format(totalVotes))
   let selectedModel = $state<string>()
   const selectedModelData = $derived(data.find((m) => m.id === selectedModel))
-  // The class spans in the context describe the style-controlled fit. The
-  // modal has to describe the fit on screen, so they are derived from it.
-  const activeCommons = $derived({
-    ...commons,
-    rankClasses: rankClassSpans(data.map((m) => m.data))
-  })
 
   // Escape hatch back to numbered ranks. Deliberately not persisted: classes
   // are the honest default and a sticky toggle would quietly undo that.
@@ -223,7 +218,7 @@
 
         <div class="cg-border rounded-sm! bg-white px-4 py-2">
           <strong>{m['ranking.table.totalVotes']()}</strong>
-          <span class="text-grey">{totalVotes}</span>
+          <span class="text-grey">{totalVotesLabel}</span>
         </div>
       </div>
     {/if}
@@ -276,7 +271,7 @@
           <span class="fr-sr-only"
             >{m['ranking.table.data.cols.rank']()}
             {roman(model.data.rankClass)}, {rankClassLabel(
-              activeCommons.rankClasses[model.data.rankClass]
+              commons.rankClasses[model.data.rankClass]
             )}</span
           >
         </span>
@@ -353,4 +348,4 @@
   {/snippet}
 </Table>
 
-<ModelInfoModal commons={activeCommons} model={selectedModelData} modalId="{id}-modal-model" />
+<ModelInfoModal {commons} model={selectedModelData} modalId="{id}-modal-model" />

--- a/frontend/src/routes/(arena)/ranking/components/index.ts
+++ b/frontend/src/routes/(arena)/ranking/components/index.ts
@@ -1,6 +1,7 @@
 export { default as Energy } from './Energy.svelte'
 export { default as EnergyGraph } from './EnergyGraph.svelte'
 export { default as Methodology } from './Methodology.svelte'
+export { default as PersonalTable } from './PersonalTable.svelte'
 export { default as Preferences } from './Preferences.svelte'
 export { default as PreferencesTable } from './PreferencesTable.svelte'
 export { default as RankingTable } from './RankingTable.svelte'

--- a/frontend/src/routes/(arena)/ranking/page.svelte.test.ts
+++ b/frontend/src/routes/(arena)/ranking/page.svelte.test.ts
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/svelte'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Commons } from '$lib/models'
+import Page from './+page.svelte'
+
+const auth = vi.hoisted(() => ({ user: null as { email: string } | null, config: {} }))
+const mocks = vi.hoisted(() => ({
+  goto: vi.fn(),
+  invalidateAll: vi.fn(),
+  openSignInModal: vi.fn()
+}))
+
+vi.mock('$app/navigation', () => ({ goto: mocks.goto, invalidateAll: mocks.invalidateAll }))
+
+vi.mock('$lib/auth.svelte', () => ({
+  getAuthContext: () => auth,
+  openSignInModal: mocks.openSignInModal
+}))
+
+vi.mock('$lib/global.svelte', () => ({ getVotesContext: () => ({ count: 42, objective: 1000 }) }))
+
+// The signed-out and empty states don't need real ranking rows, only the two
+// context getters that would otherwise require a `data` context nobody sets
+// up in this test.
+vi.mock('$lib/models', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/models')>()
+  const commons = { modelsCount: 0, currency: { code: 'EUR' }, rankClasses: {} } as Commons
+  return {
+    ...actual,
+    getModelsWithDataContext: () => ({ lastUpdateDate: '01/01/2026', commons, models: [] }),
+    getModelsContext: () => ({ models: [] }),
+    getStyleCoefficients: () => ({})
+  }
+})
+
+describe('ranking page, personal view without data', () => {
+  beforeEach(() => {
+    auth.user = null
+    mocks.goto.mockClear()
+    mocks.invalidateAll.mockClear()
+    mocks.openSignInModal.mockClear()
+  })
+
+  it('blurs the real table behind a sign-in prompt when signed out', () => {
+    const { container, getByRole } = render(Page, {
+      data: { view: 'personal', personal: null } as never
+    })
+
+    const preview = container.querySelector('#ranking-table-preview')
+    expect(preview).toBeTruthy()
+    expect(preview?.closest('[inert]')).toBeTruthy()
+
+    getByRole('button', { name: 'Se connecter' }).click()
+    expect(mocks.openSignInModal).toHaveBeenCalled()
+  })
+
+  it('offers to start a comparison instead of an empty table when signed in with no votes', () => {
+    auth.user = { email: 'personne@example.org' }
+    const { container, getByRole, queryByRole } = render(Page, {
+      data: { view: 'personal', personal: { rows: [], votes_count: 0 } } as never
+    })
+
+    expect(container.querySelector('#personal-ranking-table')).toBeNull()
+    expect(container.querySelector('#ranking-table-preview')).toBeNull()
+    expect(queryByRole('button', { name: 'Se connecter' })).toBeNull()
+    expect(getByRole('link', { name: 'Nouvelle discussion' }).getAttribute('href')).toBe('/')
+  })
+})

--- a/internal/typescript/backend_types.py
+++ b/internal/typescript/backend_types.py
@@ -1,4 +1,5 @@
 from backend.llms.data import LLMList
+from backend.ranking.models import PersonalRanking
 from backend.settings.router import PublicLegalDocument
 from utils.database.models import ComparisonPublic
 from utils.database.models.vote_tag import PublicVoteTag, PublicVoteTagsResponse

--- a/tests/ranking/test_personal.py
+++ b/tests/ranking/test_personal.py
@@ -1,0 +1,174 @@
+"""
+Tests for the personal ranking scoring rule (utils/ranking/personal).
+
+Deterministic and DB-free. Runnable either way:
+    uv run python tests/ranking/test_personal.py
+    pytest tests/ranking/test_personal.py
+"""
+
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from utils.ranking.personal import (  # noqa: E402
+    PersonalTally,
+    rank_personal_models,
+    tally_votes,
+)
+
+
+def model_id(name: str) -> uuid.UUID:
+    return uuid.uuid5(uuid.NAMESPACE_DNS, name)
+
+
+def tally(name, wins=0, losses=0, ties=0, general_rank=None) -> PersonalTally:
+    return PersonalTally(
+        llm_id=model_id(name),
+        name=name,
+        wins=wins,
+        losses=losses,
+        ties=ties,
+        general_rank=general_rank,
+    )
+
+
+def ranked(*tallies) -> dict[str, tuple[int, float]]:
+    return {row.name: (row.rank, row.score) for row in rank_personal_models(tallies)}
+
+
+def order(*tallies) -> list[str]:
+    return [row.name for row in rank_personal_models(tallies)]
+
+
+def test_no_votes_is_an_empty_ranking():
+    assert rank_personal_models([]) == []
+
+
+def test_a_single_win_is_not_a_perfect_score():
+    ranking = ranked(tally("winner", wins=1), tally("loser", losses=1))
+
+    assert ranking["winner"] == (1, 0.667)
+    assert ranking["loser"] == (2, 0.333)
+
+
+def test_a_long_record_outranks_a_lone_win():
+    ranking = ranked(
+        tally("veteran", wins=18, losses=2),
+        tally("veteran_rivals", wins=2, losses=18),
+        tally("newcomer", wins=1),
+        tally("newcomer_rival", losses=1),
+    )
+
+    assert ranking["veteran"] == (1, 0.864)
+    assert ranking["newcomer"][1] == 0.667
+    assert ranking["veteran"][0] < ranking["newcomer"][0]
+
+
+def test_one_battle_each_keeps_the_preferred_models_on_top():
+    assert order(
+        tally("liked", wins=1),
+        tally("disliked", losses=1),
+        tally("also_liked", wins=1),
+        tally("also_disliked", losses=1),
+    ) == ["also_liked", "liked", "also_disliked", "disliked"]
+
+
+def test_both_good_is_half_a_point_each_and_both_bad_is_none():
+    ranking = ranked(
+        tally("shared_good", ties=1),
+        tally("shared_good_rival", ties=1),
+        tally("shared_bad", losses=1),
+        tally("shared_bad_rival", losses=1),
+    )
+
+    # mean points per battle is 0.25 here, so the anchor sits below 0.5
+    assert ranking["shared_good"] == (1, 0.333)
+    assert ranking["shared_good_rival"] == (1, 0.333)
+    assert ranking["shared_bad"] == (3, 0.167)
+
+
+def test_i_dont_know_produces_no_battle():
+    a, b = model_id("a"), model_id("b")
+
+    assert tally_votes([(a, b, "idk", 4)]) == {}
+    assert set(tally_votes([(a, b, "idk", 4), (a, b, "a_better", 1)])) == {a, b}
+
+
+def test_choices_become_wins_losses_and_ties():
+    a, b = model_id("a"), model_id("b")
+    tallies = tally_votes(
+        [
+            (a, b, "a_better", 3),
+            (a, b, "b_better", 1),
+            (a, b, "both_good", 2),
+            (a, b, "both_bad", 4),
+        ]
+    )
+
+    assert (tallies[a].wins, tallies[a].losses, tallies[a].ties) == (3, 5, 2)
+    assert (tallies[b].wins, tallies[b].losses, tallies[b].ties) == (1, 7, 2)
+    assert tallies[a].battles == 10
+    assert tallies[a].points == 4.0
+
+
+def test_equal_scores_share_a_rank_and_the_next_one_skips():
+    ranking = ranked(
+        tally("won_1", wins=1),
+        tally("won_2", wins=1),
+        tally("won_3", wins=1),
+        tally("lost_1", losses=1),
+        tally("lost_2", losses=1),
+        tally("lost_3", losses=1),
+    )
+
+    assert sorted(rank for rank, _score in ranking.values()) == [1, 1, 1, 4, 4, 4]
+
+
+def test_tied_rows_are_ordered_by_battles_then_by_general_rank():
+    rows = rank_personal_models(
+        [
+            tally("few_battles_unranked", wins=1, losses=1),
+            tally("many_battles", wins=2, losses=2),
+            tally("few_battles_20th", wins=1, losses=1, general_rank=20),
+            tally("few_battles_3rd", wins=1, losses=1, general_rank=3),
+        ]
+    )
+
+    assert {row.rank for row in rows} == {1}
+    assert [row.name for row in rows] == [
+        "many_battles",
+        "few_battles_3rd",
+        "few_battles_20th",
+        "few_battles_unranked",
+    ]
+
+
+def test_both_bad_votes_pull_every_score_down_without_breaking_the_order():
+    ranking = ranked(
+        tally("preferred", wins=1),
+        tally("passed_over", losses=1),
+        tally("bad_1", losses=1),
+        tally("bad_2", losses=1),
+    )
+
+    # the mean anchor is 0.25 rather than 0.5, so a 1-0 record scores below 0.667
+    assert ranking["preferred"] == (1, 0.5)
+    assert ranking["passed_over"][0] == 2
+    assert ranking["passed_over"] == ranking["bad_1"] == ranking["bad_2"]
+
+
+def test_a_row_carries_the_record_behind_its_score():
+    (row,) = rank_personal_models([tally("solo", wins=3, losses=2, ties=1)])
+
+    assert (row.wins, row.losses, row.ties) == (3, 2, 1)
+    assert row.battles == 6
+    assert row.llm_id == model_id("solo")
+    assert row.name == "solo"
+
+
+if __name__ == "__main__":
+    for name, test in sorted(dict(globals()).items()):
+        if name.startswith("test_"):
+            test()

--- a/tests/ranking/test_personal_endpoint.py
+++ b/tests/ranking/test_personal_endpoint.py
@@ -1,0 +1,72 @@
+"""
+Access control on the personal ranking endpoint (no DB, no Redis).
+
+Run with pytest, or directly:
+    uv run python tests/ranking/test_personal_endpoint.py
+"""
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
+os.environ.setdefault("LOG_FORMAT", "JSON")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+import backend.ranking.router as ranking_router  # noqa: E402
+import utils.database.models  # noqa: E402,F401 needed before importing the router
+from backend.auth.dependencies import require_user  # noqa: E402
+from backend.ranking.models import PersonalRanking  # noqa: E402
+from utils.database.models.auth import User  # noqa: E402
+
+
+def client(user: User | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(ranking_router.router)
+    if user:
+        app.dependency_overrides[require_user] = lambda: user
+    return TestClient(app)
+
+
+@contextlib.contextmanager
+def ranking_of(asked_for: list):
+    async def get_personal_ranking(user_id):
+        asked_for.append(user_id)
+        return PersonalRanking(rows=[], votes_count=0)
+
+    original = ranking_router.get_personal_ranking
+    ranking_router.get_personal_ranking = get_personal_ranking
+    try:
+        yield
+    finally:
+        ranking_router.get_personal_ranking = original
+
+
+def test_a_signed_out_visitor_is_refused_rather_than_given_an_empty_ranking():
+    response = client().get("/ranking/personal")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "auth_required"
+
+
+def test_a_signed_in_user_is_ranked_on_their_own_votes():
+    user = User(email="personne@example.test")
+    asked_for: list = []
+
+    with ranking_of(asked_for):
+        response = client(user).get("/ranking/personal")
+
+    assert response.status_code == 200
+    assert response.json() == {"rows": [], "votes_count": 0}
+    assert asked_for == [user.id]
+
+
+if __name__ == "__main__":
+    for name, test in sorted(dict(globals()).items()):
+        if name.startswith("test_"):
+            test()

--- a/utils/ranking/personal.py
+++ b/utils/ranking/personal.py
@@ -1,0 +1,169 @@
+"""
+Personal ranking: scores one user's own votes, with no Bradley-Terry fit.
+
+A single user's votes form a scatter of mostly disconnected pairs, which the
+global solver cannot fit, so each model is scored on its own record shrunk
+towards the user's average.
+
+Note that a personal battle is *any* scored turn, ties included, which is wider
+than the ``battle`` of ``utils.ranking.compute``, where ties are dropped before
+the fit. The two must not share a helper.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+# Two phantom battles at the user's own average, so a 1-0 record cannot top the
+# table and twenty battles outweigh one at comparable rates.
+SHRINKAGE_BATTLES = 2
+# Points per battle assumed for a user who has not voted at all.
+DEFAULT_MEAN_POINTS = 0.5
+
+Outcome = Literal["win", "loss", "tie"]
+
+# What a vote does to each side. "both_bad" counts against both models rather
+# than being neutral: it reports dissatisfaction, not a draw. "idk" is absent on
+# purpose, it is not a battle for either side.
+OUTCOMES: dict[str, tuple[Outcome, Outcome]] = {
+    "a_better": ("win", "loss"),
+    "b_better": ("loss", "win"),
+    "both_good": ("tie", "tie"),
+    "both_bad": ("loss", "loss"),
+}
+
+
+@dataclass
+class PersonalTally:
+    llm_id: UUID
+    name: str
+    wins: int = 0
+    losses: int = 0
+    ties: int = 0
+    # Position in the general ranking, used only to break ties. None when the
+    # model is missing from the last computed ranking.
+    general_rank: int | None = None
+
+    @property
+    def battles(self) -> int:
+        return self.wins + self.losses + self.ties
+
+    @property
+    def points(self) -> float:
+        return self.wins + self.ties / 2
+
+
+class PersonalRankingRow(BaseModel):
+    """
+    One model in a user's own ranking, scored, ordered and numbered.
+
+    Carries the model name as well as its id: a model the user voted on can have
+    left the arena since, and is then missing from the model list the client
+    holds.
+    """
+
+    llm_id: UUID
+    name: str
+    rank: int
+    score: float
+    battles: int
+    wins: int
+    losses: int
+    ties: int
+
+
+def tally_votes(
+    votes: Iterable[tuple[UUID, UUID, str | None, int]],
+) -> dict[UUID, PersonalTally]:
+    """Fold grouped ``(model a, model b, choice, count)`` rows into per-model tallies."""
+    tallies: dict[UUID, PersonalTally] = {}
+    for llm_id_a, llm_id_b, choice, count in votes:
+        outcomes = OUTCOMES.get(choice or "")
+        if not outcomes:
+            continue
+        for llm_id, outcome in zip((llm_id_a, llm_id_b), outcomes):
+            tally = tallies.setdefault(llm_id, PersonalTally(llm_id=llm_id, name=""))
+            if outcome == "win":
+                tally.wins += count
+            elif outcome == "loss":
+                tally.losses += count
+            else:
+                tally.ties += count
+    return tallies
+
+
+def rank_personal_models(
+    tallies: Iterable[PersonalTally],
+) -> list[PersonalRankingRow]:
+    """
+    Score, order and number a user's models from their per-model tallies.
+
+    The score is the model's points shrunk towards the user's own mean points
+    per battle, ``(points + 2m) / (battles + 2)``. Anchoring on the observed
+    mean rather than on 0.5 keeps the score independent of the tie rule: because
+    "both bad" awards nothing to either side, points do not sum to 1 per battle
+    and the mean drifts below 0.5 on its own.
+
+    Two properties are load-bearing: models with equal battle counts never
+    reorder under shrinkage, and models with more battles beat models with fewer
+    at comparable rates.
+    """
+    tallies = list(tallies)
+    battles = sum(tally.battles for tally in tallies)
+    mean = (
+        sum(tally.points for tally in tallies) / battles
+        if battles
+        else DEFAULT_MEAN_POINTS
+    )
+
+    # Rounded before ordering and numbering, so two models the table shows as
+    # 0.866 share a rank instead of being split by a digit the user cannot see.
+    scored = [
+        (
+            tally,
+            round(
+                (tally.points + SHRINKAGE_BATTLES * mean)
+                / (tally.battles + SHRINKAGE_BATTLES),
+                3,
+            ),
+        )
+        for tally in tallies
+    ]
+    scored.sort(
+        key=lambda scored_tally: (
+            -scored_tally[1],
+            -scored_tally[0].battles,
+            (
+                scored_tally[0].general_rank
+                if scored_tally[0].general_rank is not None
+                else math.inf
+            ),
+            scored_tally[0].name,
+        )
+    )
+
+    rows = []
+    rank = 0
+    previous_score = None
+    for position, (tally, score) in enumerate(scored, 1):
+        # Competition ranking: equal scores share a number, the next distinct
+        # score skips ahead (1, 1, 1, 4).
+        if score != previous_score:
+            rank = position
+            previous_score = score
+        rows.append(
+            PersonalRankingRow(
+                llm_id=tally.llm_id,
+                name=tally.name,
+                rank=rank,
+                score=score,
+                battles=tally.battles,
+                wins=tally.wins,
+                losses=tally.losses,
+                ties=tally.ties,
+            )
+        )
+    return rows


### PR DESCRIPTION
Adds a ranking built from the signed-in user's own votes, beside the general one on the same page.

Bradley-Terry cannot fit a single person's votes: they form a scatter of mostly disconnected pairs, and the global solver drops any model that never won or never lost. Each model is scored on its own record instead, shrunk towards the user's mean: `score = (points + 2m) / (battles + 2)`. The two phantom battles keep a 1-0 record off the top (0.667) while an 18-2 record holds it (0.864), and models with equal battle counts never reorder, so a first session still sorts winners above losers. A win scores 1, a loss 0, "both good" a half to each side and "both bad" nothing to either; "I don't know" is not a battle at all. The server ranks and numbers the rows, the client only renders them.

The table shows the win-loss-tie record next to the score so the arithmetic reads off the page, plus the model's general rank to spot where personal taste diverges from the crowd. Models that have left the catalogue stay listed, without a link to their card and without a general rank. Signed out, the tab shows the general ranking blurred behind an invitation to sign in.

Tested with 13 backend tests (11 on the scoring function, 2 on endpoint access), 9 frontend tests, and a browser pass over both views, sorting, search, CSV export, and the empty and signed-out states.

<img width="1142" height="818" alt="1-personal-ranking" src="https://github.com/user-attachments/assets/73a5c67b-9303-4b33-bb49-e16f3055f38c" />
<img width="1142" height="939" alt="3-general-ranking" src="https://github.com/user-attachments/assets/cec4872e-594c-48dc-a21e-d97cf97bea1c" />
<img width="1142" height="640" alt="4-signed-out" src="https://github.com/user-attachments/assets/8bec5cfc-f6b4-4492-aaa5-5725b3ac217b" />
