### PR TITLE
add missing env vars to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,14 +28,15 @@ export LINKUP_API_KEY=
 # whether they log, warn or block, is configured at /admin/prompt-checks.
 export MISTRAL_API_KEY=
 
-# Development
-# export MOCK_RESPONSE=true
-# export LANGUIA_DEBUG=true
-
+# Mailing
 export SMTP_HOST=smtp-relay.brevo.com
 export SMTP_PORT=587
 export SMTP_USERNAME="<brevo account email>"
 export SMTP_PASSWORD="<SMTP key from Brevo Settings - SMTP & API>"
+export EMAIL_FROM=
+
+# Frontend base URL, used to build links in emails (e.g. login code)
+# export COMPARIA_APP_URL="http://localhost:5173/"
 
 # Auth
 # "anonymous_first" (default) or "sign_in_required"
@@ -46,3 +47,9 @@ export SMTP_PASSWORD="<SMTP key from Brevo Settings - SMTP & API>"
 # Admin
 # Comma-separated list of emails to promote to admin role on startup (created if absent)
 # export ADMIN_EMAILS='["admin@example.com"]'
+
+
+# Development
+# export MOCK_RESPONSE=true
+# export LANGUIA_DEBUG=true
+# export LOG_FORMAT="RAW"


### PR DESCRIPTION
## Summary
- add EMAIL_FROM, COMPARIA_APP_URL and LOG_FORMAT to .env.example, they were used by the app but missing from the example file