### PR TITLE
Fix frontend Docker build

### DIFF
--- a/devops/docker/Dockerfile.front
+++ b/devops/docker/Dockerfile.front
@@ -1,8 +1,8 @@
 # Multi-stage build optimisé avec buildx
-FROM public.ecr.aws/docker/library/node:24.4 AS builder
+FROM public.ecr.aws/docker/library/node:24.19 AS builder
 
 WORKDIR /app
-COPY package.json yarn.lock ./
+COPY package.json yarn.lock .dsfr.yml ./
 RUN yarn install --frozen-lockfile
 
 COPY . .
@@ -11,7 +11,7 @@ ENV PUBLIC_API_URL=$PUBLIC_API_URL MATOMO_ID=$MATOMO_ID MATOMO_URL=$MATOMO_URL P
 
 RUN yarn build && yarn install --production --ignore-scripts
 
-FROM public.ecr.aws/docker/library/node:24.4-alpine AS runtime
+FROM public.ecr.aws/docker/library/node:24.19-alpine AS runtime
 WORKDIR /app
 
 # Copier le build et les dépendances de production


### PR DESCRIPTION
Building frontend/ with devops/docker/Dockerfile.front fails at yarn install: jsdom 30.0.1 wants node ^24.15.0 but the image pins 24.4, and once past that, the preinstall script @gouvfr/dsfr added in 1.15 exits 1 because .dsfr.yml is never copied into the build context. Bumped node to 24.19 and added .dsfr.yml to the COPY. Checked by building the image from a clean next.