### PR TITLE
add self-hosting Helm chart for ComparIA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-backend install-frontend test test-backend test-frontend test-dataset dev dev-redis dev-backend dev-frontend dev-controller build-frontend db-generate-init-old db db-prd-local docker-app-up docker-app-down docker-app-logs clean redis models-doc up-fr down-fr logs-fr display-env-fr up-da down-da logs-da display-env-da dataset-export dataset-export-dry-run
+.PHONY: help install install-backend install-frontend test test-backend test-frontend test-dataset dev dev-redis dev-backend dev-frontend dev-controller build-frontend db-generate-init-old db db-prd-local docker-app-up docker-app-down docker-app-logs clean redis models-doc up-fr down-fr logs-fr display-env-fr up-da down-da logs-da display-env-da dataset-export dataset-export-dry-run helm-lint helm-test
 
 # Variables
 PYTHON := python3
@@ -7,6 +7,7 @@ NPM := yarn
 BACKEND_PORT := 8008
 FRONTEND_PORT := 5173
 CONTROLLER_PORT := 21001
+HELM_CHART := devops/helm/comparia
 
 COMPARIA_REDIS_HOST ?= localhost
 export COMPARIA_REDIS_HOST
@@ -218,3 +219,12 @@ dataset-export-dry-run: ## Build the datasets locally and send them nowhere (req
 		exit 1; \
 	fi
 	$(UV) run python -m utils.dataset.run --dry-run
+
+###################################
+# Helm chart (devops/helm/comparia)
+###################################
+helm-lint: ## Lint the self-hosting Helm chart
+	helm lint $(HELM_CHART) -f $(HELM_CHART)/ci/values-lint.yaml
+
+helm-test: ## Run the Helm chart's helm-unittest suite
+	helm unittest $(HELM_CHART)

--- a/devops/docker/Dockerfile
+++ b/devops/docker/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 
 # Copier le venv et le code
 COPY --from=builder /app/.venv /app/.venv
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml uv.lock alembic.ini ./
 COPY controller.py /app/
 COPY backend /app/backend
 COPY utils /app/utils

--- a/devops/helm/comparia/.helmignore
+++ b/devops/helm/comparia/.helmignore
@@ -1,0 +1,5 @@
+.git/
+.gitignore
+tests/
+*.md
+!README.md

--- a/devops/helm/comparia/Chart.yaml
+++ b/devops/helm/comparia/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: comparia
+description: Self-hosted ComparIA (backend + frontend) on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/betagouv/ComparIA
+sources:
+  - https://github.com/betagouv/ComparIA

--- a/devops/helm/comparia/README.md
+++ b/devops/helm/comparia/README.md
@@ -1,0 +1,197 @@
+# comparia Helm chart
+
+Installs ComparIA (backend + frontend) on a Kubernetes cluster. This is the
+Kubernetes-native alternative to the single-machine Docker Compose setup at
+[`devops/standalone_docker_install/DOCKER_INSTALL.md`](../standalone_docker_install/DOCKER_INSTALL.md);
+if you only need one server behind Caddy, that path is simpler.
+
+The chart deploys:
+
+- separate backend and frontend Deployments/Services
+- a `Secret` (chart-rendered from values, or a pre-existing one you point it
+  at) carrying API keys and DB/Redis connection info
+- a pre-install/pre-upgrade Job that runs the app's Alembic migrations
+- three optional CronJobs (ranking computation, dataset export, LLM-based
+  analysis)
+- an optional Ingress
+
+It does not include a Postgres or Redis instance, an S3 log-archival sidecar,
+or any blue-green deployment mechanism. Bring your own Postgres and Redis;
+point the chart at them via `secrets.dbUri` / `secrets.redisHost`.
+
+## Install
+
+```bash
+helm install comparia devops/helm/comparia \
+  --set secrets.dbUri=postgresql://user:pass@host:5432/comparia \
+  --set secrets.redisHost=redis.example.svc.cluster.local \
+  --set secrets.altchaHmacKey=$(openssl rand -hex 32) \
+  --set secrets.openrouterApiKey=sk-or-...
+```
+
+`helm install`/`helm template` fails with a named error if a required value
+is missing: `secrets.dbUri`, `secrets.redisHost`, `secrets.altchaHmacKey`, and
+at least one LLM provider key, unless `secrets.existingSecret` is set (see
+[Secrets](#secrets) below).
+
+## Values
+
+### Images
+
+| Value                    | Default                             | Description                                       |
+| ------------------------ | ------------------------------------ | -------------------------------------------------- |
+| `image.backend.repository` | `ghcr.io/betagouv/comparia-backend` | Backend image                                     |
+| `image.backend.tag`        | `.Chart.AppVersion`                 | Backend image tag, independent of the chart version |
+| `image.frontend.repository` | `ghcr.io/betagouv/comparia-frontend` | Frontend image                                   |
+| `image.frontend.tag`       | `.Chart.AppVersion`                 | Frontend image tag, independent of the chart version |
+| `image.pullPolicy`         | `IfNotPresent`                      | Applied to every container                        |
+| `image.pullSecrets`        | `[]`                                 | List of `imagePullSecrets` names                  |
+
+### Workloads
+
+| Value                    | Default | Description                          |
+| ------------------------- | ------- | ------------------------------------- |
+| `replicaCount.backend`    | `1`     | Backend replica count                 |
+| `replicaCount.frontend`   | `1`     | Frontend replica count                |
+| `service.backend.port`    | `80`    | Backend Service port                  |
+| `service.frontend.port`   | `80`    | Frontend Service port                 |
+| `resources.backend`       | see `values.yaml` | Backend requests/limits    |
+| `resources.frontend`      | see `values.yaml` | Frontend requests/limits   |
+| `resources.migration`     | see `values.yaml` | Migration Job requests/limits |
+| `resources.cronjobs`      | see `values.yaml` | Applied to all three CronJobs |
+| `serviceAccount.create`   | `true`  | Create a ServiceAccount for the release |
+| `serviceAccount.name`     | `""`    | Name to use; defaults to the release fullname |
+| `serviceAccount.annotations` | `{}` | Annotations on the created ServiceAccount |
+| `backend.extraEnv`        | `[]`    | Extra env vars for the backend container (SMTP\_\*, `ADMIN_EMAILS`, `AUTH_DOMAIN_ALLOWLIST`, ...), same shape as a container's `env:` list |
+| `frontend.extraEnv`       | `[]`    | Extra env vars for the frontend container, same shape |
+| `frontend.publicApiUrl`   | `""`    | Public URL the frontend is served at; empty means same-origin |
+| `frontend.disabledLocales`| `""`    | Comma-separated locales to hide from the language switcher |
+
+### Non-secret app config (`config.*`)
+
+| Value                     | Default            | Description                                          |
+| -------------------------- | ------------------- | ----------------------------------------------------- |
+| `config.instanceName`      | `fr`                | Redis key namespace / default locale. Also the name used the one time the migration hook seeds a HuggingFace destination — see [Dataset export](#dataset-export) |
+| `config.authAccessPolicy`  | `anonymous_first`   | `anonymous_first` or `sign_in_required`               |
+| `config.logFormat`         | `JSON`              | `JSON` or `RAW`                                       |
+| `config.votesObjective`    | `300000`            | Displayed vote-count target                           |
+| `config.cache.enabled`     | `true`              | LLM response cache                                    |
+| `config.cache.probability` | `0.75`              | Probability of serving a cached response on hit       |
+| `config.cache.ttl`         | `172800`            | Cache TTL in seconds                                  |
+| `config.cache.maxResponses`| `5`                 | Max cached responses per (model, prompt) pair         |
+| `config.sentryDsn`         | `""`                | Left empty, errors are not sent anywhere              |
+| `config.sentryEnvironment` | `prod`              |                                                        |
+
+### Secrets
+
+`secrets.existingSecret`, when set, takes precedence: the chart points every
+workload's `envFrom` at that Secret and renders no `Secret` of its own. Use
+this if you manage secrets externally (Vault, sealed-secrets, ...) — your
+Secret should provide whichever of the keys below your setup needs
+(`COMPARIA_DB_URI`, `COMPARIA_REDIS_HOST`, `ALTCHA_HMAC_KEY`,
+`OPENROUTER_API_KEY`, `ALBERT_KEY`, `HF_INFERENCE_KEY`, `ORDBOGEN_API_KEY`,
+`LINKUP_API_KEY`, and `HF_PUSH_DATASET_PATH`/`HF_PUSH_DATASET_KEY` if you use
+dataset export). In this mode the chart cannot validate that a required key
+is present — that is your Secret's responsibility.
+
+Otherwise, the chart renders a `Secret` from these values:
+
+| Value                       | Required | Description                              |
+| ----------------------------- | -------- | ----------------------------------------- |
+| `secrets.dbUri`                | yes      | `COMPARIA_DB_URI`, e.g. `postgresql://user:pass@host:5432/db` |
+| `secrets.redisHost`            | yes      | `COMPARIA_REDIS_HOST`                     |
+| `secrets.altchaHmacKey`        | yes      | `ALTCHA_HMAC_KEY`, e.g. `openssl rand -hex 32` |
+| `secrets.openrouterApiKey`     | at least one of these four | `OPENROUTER_API_KEY` |
+| `secrets.albertKey`            | at least one of these four | `ALBERT_KEY` |
+| `secrets.hfInferenceKey`       | at least one of these four | `HF_INFERENCE_KEY` |
+| `secrets.ordbogenApiKey`       | at least one of these four | `ORDBOGEN_API_KEY` |
+| `secrets.linkupApiKey`         | no       | `LINKUP_API_KEY`, enables web search      |
+
+### Automatic database migrations
+
+A Job runs `alembic upgrade head` against the backend image, wired to the
+same Secret as the rest of the release. It is annotated
+`helm.sh/hook: pre-install,pre-upgrade` with
+`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`, so it runs
+and is replaced automatically on every install and upgrade. It is not
+toggleable.
+
+### Maintenance cronjobs (`cronjobs.*`)
+
+Each of the three is independently toggleable — there is no combined switch.
+
+| Value                              | Default | Description |
+| ------------------------------------ | ------- | ------------ |
+| `cronjobs.ranking.enabled`           | `true`  | Recomputes the leaderboard. No external side effects. |
+| `cronjobs.ranking.schedule`          | `"17 * * * *"` | |
+| `cronjobs.exportDataset.enabled`     | `false` | Exports datasets to HuggingFace. Off by default so no instance pushes data anywhere until deliberately configured. |
+| `cronjobs.exportDataset.schedule`    | `"15 4 * * *"` | |
+| `cronjobs.exportDataset.hfRepo`      | `""`    | `{organisation}/{repo_prefix}` on HuggingFace. Required when enabled. |
+| `cronjobs.exportDataset.hfToken`     | `""`    | HuggingFace token with write access to `hfRepo`. Required when enabled. |
+| `cronjobs.analyze.enabled`           | `false` | LLM-based moderation/data-quality pass, consumes `OPENROUTER_API_KEY`. Off by default so enabling it — and paying for the LLM calls — is deliberate. |
+| `cronjobs.analyze.schedule`          | `"35 3 * * *"` | |
+
+#### Dataset export
+
+The export destination (HuggingFace repo path + token) is stored in the
+database and configured through the admin panel, not read by the export
+CronJob itself. `cronjobs.exportDataset.hfRepo`/`hfToken` are only consumed
+once: the pre-install/pre-upgrade migration hook seeds an initial destination
+row from them the first time it runs against a fresh database. After that,
+manage the destination from the admin panel; changing `hfRepo`/`hfToken` in
+values has no further effect.
+
+### Ingress (`ingress.*`)
+
+Off by default — a working Ingress controller/TLS setup cannot be safely
+assumed.
+
+| Value                | Default | Description |
+| ---------------------- | ------- | ------------ |
+| `ingress.enabled`      | `false` | |
+| `ingress.host`         | `""`    | Required when enabled |
+| `ingress.className`    | `""`    | |
+| `ingress.annotations`  | `{}`    | Passed through as-is, e.g. for cert-manager |
+| `ingress.tls`          | `[]`    | Passed through as-is |
+
+Routes `/counter`, `/models/`, and `/arena/` to the backend Service and
+everything else to the frontend Service, mirroring
+[`devops/standalone_docker_install/Caddyfile`](../standalone_docker_install/Caddyfile).
+Other backend endpoints (auth, admin, ...) are called server-side by the
+frontend over the cluster-internal `PUBLIC_API_LOCAL_URL`, not through this
+Ingress.
+
+## Upgrading
+
+Two upgrade shapes, do not mix them:
+
+**Image-only upgrade** — bumps the app version without touching anything
+else you've set (cron job toggles, Ingress, ...):
+
+```bash
+helm upgrade comparia devops/helm/comparia \
+  --reuse-values \
+  --set image.backend.tag=1.4.0 \
+  --set image.frontend.tag=1.4.0
+```
+
+**Full-state upgrade** — explicit, complete desired state, for scripted
+deploys against a values file:
+
+```bash
+helm upgrade comparia devops/helm/comparia -f values-prod.yaml
+```
+
+`--reuse-values` and `-f` do not combine reliably across Helm versions.
+Mixing them on the same command can silently drop or resurrect toggles you
+did not intend to change — pick one shape per pipeline.
+
+## Development
+
+```bash
+make helm-lint   # helm lint, against devops/helm/comparia/ci/values-lint.yaml
+make helm-test   # helm-unittest, see devops/helm/comparia/tests/
+```
+
+Requires the [helm-unittest](https://github.com/helm-unittest/helm-unittest)
+plugin: `helm plugin install https://github.com/helm-unittest/helm-unittest`.

--- a/devops/helm/comparia/README.md
+++ b/devops/helm/comparia/README.md
@@ -62,7 +62,7 @@ at least one LLM provider key, unless `secrets.existingSecret` is set (see
 | `serviceAccount.create`   | `true`  | Create a ServiceAccount for the release |
 | `serviceAccount.name`     | `""`    | Name to use; defaults to the release fullname |
 | `serviceAccount.annotations` | `{}` | Annotations on the created ServiceAccount |
-| `backend.extraEnv`        | `[]`    | Extra env vars for the backend container (SMTP\_\*, `ADMIN_EMAILS`, `AUTH_DOMAIN_ALLOWLIST`, ...), same shape as a container's `env:` list |
+| `backend.extraEnv`        | `[]`    | Extra env vars for the backend container, for anything not covered by `config.*`/`secrets.*` below, same shape as a container's `env:` list |
 | `frontend.extraEnv`       | `[]`    | Extra env vars for the frontend container, same shape |
 | `frontend.publicApiUrl`   | `""`    | Public URL the frontend is served at; empty means same-origin |
 | `frontend.disabledLocales`| `""`    | Comma-separated locales to hide from the language switcher |
@@ -81,6 +81,18 @@ at least one LLM provider key, unless `secrets.existingSecret` is set (see
 | `config.cache.maxResponses`| `5`                 | Max cached responses per (model, prompt) pair         |
 | `config.sentryDsn`         | `""`                | Left empty, errors are not sent anywhere              |
 | `config.sentryEnvironment` | `prod`              |                                                        |
+| `config.appUrl`            | `""`                | `COMPARIA_APP_URL`, public origin used to build absolute links in emails (login codes). Left empty, falls back to the app's own dev default — set this for a real install |
+| `config.adminEmails`       | `[]`                | `ADMIN_EMAILS`, promoted to the admin role on startup, created if absent. Left empty, nobody can reach `/admin` |
+| `config.auth.domainAllowlist` | `[]`             | `AUTH_DOMAIN_ALLOWLIST`. If non-empty, only emails from these domains can request a login code |
+| `config.auth.sessionLengthDays` | `30`           | `AUTH_SESSION_LENGTH_DAYS`                            |
+| `config.currency.display`  | `EUR`               | `DISPLAY_CURRENCY`, ISO 4217 code models prices are converted to for display |
+| `config.currency.rateFromEur` | `null`            | `DISPLAY_CURRENCY_RATE_FROM_EUR`, manual EUR conversion rate. Set to enable a currency unavailable from the rate API, run fully offline, or avoid the EUR fallback if the rate service is unreachable at startup |
+| `config.currency.exchangeApiUrl` | `https://api.frankfurter.dev/v2` | `EXCHANGE_RATE_API_URL`                |
+| `config.currency.exchangeCacheSeconds` | `86400`  | `EXCHANGE_RATE_CACHE_SECONDS`                         |
+| `config.emailFrom`         | `""`                | `EMAIL_FROM`. Left empty, falls back to the app's own default |
+| `config.emailFromName`     | `ComparIA`          | `EMAIL_FROM_NAME`                                     |
+| `config.smtp.host`         | `""`                | `SMTP_HOST`. Left empty, login codes are logged to console instead of being sent by email |
+| `config.smtp.port`         | `587`               | `SMTP_PORT`. Only rendered when `config.smtp.host` is set |
 
 ### Secrets
 
@@ -90,9 +102,10 @@ this if you manage secrets externally (Vault, sealed-secrets, ...) — your
 Secret should provide whichever of the keys below your setup needs
 (`COMPARIA_DB_URI`, `COMPARIA_REDIS_HOST`, `ALTCHA_HMAC_KEY`,
 `OPENROUTER_API_KEY`, `ALBERT_KEY`, `HF_INFERENCE_KEY`, `ORDBOGEN_API_KEY`,
-`LINKUP_API_KEY`, and `HF_PUSH_DATASET_PATH`/`HF_PUSH_DATASET_KEY` if you use
-dataset export). In this mode the chart cannot validate that a required key
-is present — that is your Secret's responsibility.
+`LINKUP_API_KEY`, `MISTRAL_API_KEY`, `SMTP_USERNAME`, `SMTP_PASSWORD`, and
+`HF_PUSH_DATASET_PATH`/`HF_PUSH_DATASET_KEY` if you use dataset export). In
+this mode the chart cannot validate that a required key is present — that is
+your Secret's responsibility.
 
 Otherwise, the chart renders a `Secret` from these values:
 
@@ -106,6 +119,9 @@ Otherwise, the chart renders a `Secret` from these values:
 | `secrets.hfInferenceKey`       | at least one of these four | `HF_INFERENCE_KEY` |
 | `secrets.ordbogenApiKey`       | at least one of these four | `ORDBOGEN_API_KEY` |
 | `secrets.linkupApiKey`         | no       | `LINKUP_API_KEY`, enables web search      |
+| `secrets.mistralApiKey`        | no       | `MISTRAL_API_KEY`, Mistral moderation API. Left empty, prompt checks (content safety, personal data) no-op |
+| `secrets.smtpUsername`         | no       | `SMTP_USERNAME`. Only relevant when `config.smtp.host` is set |
+| `secrets.smtpPassword`         | no       | `SMTP_PASSWORD`. Only relevant when `config.smtp.host` is set |
 
 ### Automatic database migrations
 

--- a/devops/helm/comparia/ci/values-lint.yaml
+++ b/devops/helm/comparia/ci/values-lint.yaml
@@ -1,0 +1,8 @@
+## Dummy values satisfying every `required` check, used by `make helm-lint`
+## and as the base values for the helm-unittest suite. Not meant to be used
+## for a real install.
+secrets:
+  dbUri: postgresql://comparia:changeme@postgres:5432/comparia
+  redisHost: redis
+  altchaHmacKey: 0000000000000000000000000000000000000000000000000000000000000000
+  openrouterApiKey: dummy-openrouter-key

--- a/devops/helm/comparia/templates/_helpers.tpl
+++ b/devops/helm/comparia/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{- define "comparia.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "comparia.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "comparia.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "comparia.labels" -}}
+helm.sh/chart: {{ include "comparia.chart" . }}
+{{ include "comparia.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "comparia.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "comparia.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "comparia.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "comparia.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the Secret every workload reads its DB/Redis/API-key env vars from:
+either the chart-rendered one, or a pre-existing Secret the caller points at.
+*/}}
+{{- define "comparia.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secret" (include "comparia.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "comparia.backendImage" -}}
+{{- printf "%s:%s" .Values.image.backend.repository (.Values.image.backend.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+
+{{- define "comparia.frontendImage" -}}
+{{- printf "%s:%s" .Values.image.frontend.repository (.Values.image.frontend.tag | default .Chart.AppVersion) -}}
+{{- end -}}

--- a/devops/helm/comparia/templates/backend-deployment.yaml
+++ b/devops/helm/comparia/templates/backend-deployment.yaml
@@ -83,6 +83,38 @@ spec:
             - name: SENTRY_ENVIRONMENT
               value: {{ .Values.config.sentryEnvironment | quote }}
             {{- end }}
+            - name: ADMIN_EMAILS
+              value: {{ .Values.config.adminEmails | toJson | quote }}
+            - name: AUTH_DOMAIN_ALLOWLIST
+              value: {{ .Values.config.auth.domainAllowlist | toJson | quote }}
+            - name: AUTH_SESSION_LENGTH_DAYS
+              value: {{ .Values.config.auth.sessionLengthDays | quote }}
+            - name: DISPLAY_CURRENCY
+              value: {{ .Values.config.currency.display | quote }}
+            {{- if .Values.config.currency.rateFromEur }}
+            - name: DISPLAY_CURRENCY_RATE_FROM_EUR
+              value: {{ .Values.config.currency.rateFromEur | quote }}
+            {{- end }}
+            - name: EXCHANGE_RATE_API_URL
+              value: {{ .Values.config.currency.exchangeApiUrl | quote }}
+            - name: EXCHANGE_RATE_CACHE_SECONDS
+              value: {{ .Values.config.currency.exchangeCacheSeconds | quote }}
+            {{- if .Values.config.appUrl }}
+            - name: COMPARIA_APP_URL
+              value: {{ .Values.config.appUrl | quote }}
+            {{- end }}
+            {{- if .Values.config.emailFrom }}
+            - name: EMAIL_FROM
+              value: {{ .Values.config.emailFrom | quote }}
+            {{- end }}
+            - name: EMAIL_FROM_NAME
+              value: {{ .Values.config.emailFromName | quote }}
+            {{- if .Values.config.smtp.host }}
+            - name: SMTP_HOST
+              value: {{ .Values.config.smtp.host | quote }}
+            - name: SMTP_PORT
+              value: {{ .Values.config.smtp.port | quote }}
+            {{- end }}
             {{- with .Values.backend.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/devops/helm/comparia/templates/backend-deployment.yaml
+++ b/devops/helm/comparia/templates/backend-deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comparia.fullname" . }}-backend
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.replicaCount.backend }}
+  selector:
+    matchLabels:
+      {{- include "comparia.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "comparia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: {{ include "comparia.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: {{ include "comparia.backendImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - uv
+            - run
+            - uvicorn
+            - backend.main:app
+            - --host
+            - "0.0.0.0"
+            - --port
+            - "80"
+            - --timeout-graceful-shutdown
+            - "60"
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /docs
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          envFrom:
+            - secretRef:
+                name: {{ include "comparia.secretName" . }}
+          env:
+            - name: COMPARIA_INSTANCE_NAME
+              value: {{ .Values.config.instanceName | quote }}
+            - name: AUTH_ACCESS_POLICY
+              value: {{ .Values.config.authAccessPolicy | quote }}
+            - name: LOG_FORMAT
+              value: {{ .Values.config.logFormat | quote }}
+            - name: LOGDIR
+              value: "/data"
+            - name: VOTES_OBJECTIVE
+              value: {{ .Values.config.votesObjective | quote }}
+            - name: CACHE_ENABLED
+              value: {{ .Values.config.cache.enabled | quote }}
+            - name: CACHE_PROBABILITY
+              value: {{ .Values.config.cache.probability | quote }}
+            - name: CACHE_TTL
+              value: {{ .Values.config.cache.ttl | quote }}
+            - name: CACHE_MAX_RESPONSES
+              value: {{ .Values.config.cache.maxResponses | quote }}
+            {{- if .Values.config.sentryDsn }}
+            - name: SENTRY_DSN
+              value: {{ .Values.config.sentryDsn | quote }}
+            - name: SENTRY_ENVIRONMENT
+              value: {{ .Values.config.sentryEnvironment | quote }}
+            {{- end }}
+            {{- with .Values.backend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources.backend | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/devops/helm/comparia/templates/backend-service.yaml
+++ b/devops/helm/comparia/templates/backend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comparia.fullname" . }}-backend
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.backend.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "comparia.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend

--- a/devops/helm/comparia/templates/cronjob-analyze.yaml
+++ b/devops/helm/comparia/templates/cronjob-analyze.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.cronjobs.analyze.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "comparia.fullname" . }}-analyze
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: analyze
+spec:
+  schedule: {{ .Values.cronjobs.analyze.schedule | quote }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            {{- include "comparia.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: analyze
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "comparia.serviceAccountName" . }}
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- range . }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+          containers:
+            - name: analyze
+              image: {{ include "comparia.backendImage" . | quote }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["./comparia-cli", "db", "lint", "--fix", "--with-llm-analyze"]
+              envFrom:
+                - secretRef:
+                    name: {{ include "comparia.secretName" . }}
+              env:
+                - name: COMPARIA_INSTANCE_NAME
+                  value: {{ .Values.config.instanceName | quote }}
+              resources:
+                {{- toYaml .Values.resources.cronjobs | nindent 16 }}
+{{- end }}

--- a/devops/helm/comparia/templates/cronjob-export-dataset.yaml
+++ b/devops/helm/comparia/templates/cronjob-export-dataset.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.cronjobs.exportDataset.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "comparia.fullname" . }}-export-dataset
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: export-dataset
+spec:
+  schedule: {{ .Values.cronjobs.exportDataset.schedule | quote }}
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            {{- include "comparia.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: export-dataset
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "comparia.serviceAccountName" . }}
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- range . }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+          containers:
+            - name: export-dataset
+              image: {{ include "comparia.backendImage" . | quote }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              # The target repo/token are not read here: they are only consumed once, by
+              # the pre-install/pre-upgrade migration hook, to seed the HuggingFace
+              # destination row that this run then reads from the database.
+              command: ["uv", "run", "python", "-m", "utils.dataset.run", "--record"]
+              envFrom:
+                - secretRef:
+                    name: {{ include "comparia.secretName" . }}
+              env:
+                - name: COMPARIA_INSTANCE_NAME
+                  value: {{ .Values.config.instanceName | quote }}
+              resources:
+                {{- toYaml .Values.resources.cronjobs | nindent 16 }}
+{{- end }}

--- a/devops/helm/comparia/templates/cronjob-ranking.yaml
+++ b/devops/helm/comparia/templates/cronjob-ranking.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.cronjobs.ranking.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "comparia.fullname" . }}-ranking
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ranking
+spec:
+  schedule: {{ .Values.cronjobs.ranking.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 10800
+      template:
+        metadata:
+          labels:
+            {{- include "comparia.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: ranking
+        spec:
+          restartPolicy: Never
+          serviceAccountName: {{ include "comparia.serviceAccountName" . }}
+          {{- with .Values.image.pullSecrets }}
+          imagePullSecrets:
+            {{- range . }}
+            - name: {{ . }}
+            {{- end }}
+          {{- end }}
+          containers:
+            - name: ranking
+              image: {{ include "comparia.backendImage" . | quote }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["uv", "run", "python", "-m", "utils.ranking.run"]
+              envFrom:
+                - secretRef:
+                    name: {{ include "comparia.secretName" . }}
+              env:
+                - name: COMPARIA_INSTANCE_NAME
+                  value: {{ .Values.config.instanceName | quote }}
+              resources:
+                {{- toYaml .Values.resources.cronjobs | nindent 16 }}
+{{- end }}

--- a/devops/helm/comparia/templates/frontend-deployment.yaml
+++ b/devops/helm/comparia/templates/frontend-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "comparia.fullname" . }}-frontend
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.replicaCount.frontend }}
+  selector:
+    matchLabels:
+      {{- include "comparia.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "comparia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      serviceAccountName: {{ include "comparia.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ include "comparia.frontendImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          envFrom:
+            - secretRef:
+                name: {{ include "comparia.secretName" . }}
+          env:
+            - name: PORT
+              value: "80"
+            - name: PUBLIC_API_URL
+              value: {{ .Values.frontend.publicApiUrl | quote }}
+            - name: PUBLIC_API_LOCAL_URL
+              value: "http://{{ include "comparia.fullname" . }}-backend:{{ .Values.service.backend.port }}"
+            - name: PUBLIC_DISABLED_LOCALES
+              value: {{ .Values.frontend.disabledLocales | quote }}
+            {{- with .Values.frontend.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources.frontend | nindent 12 }}

--- a/devops/helm/comparia/templates/frontend-service.yaml
+++ b/devops/helm/comparia/templates/frontend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "comparia.fullname" . }}-frontend
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  sessionAffinity: ClientIP
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.frontend.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "comparia.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend

--- a/devops/helm/comparia/templates/ingress.yaml
+++ b/devops/helm/comparia/templates/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "comparia.fullname" . }}
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled is true" .Values.ingress.host | quote }}
+      http:
+        paths:
+          # Routes called directly by the browser, mirroring
+          # devops/standalone_docker_install/Caddyfile. Everything else (auth,
+          # admin, SSR data loading, ...) is called server-side by the
+          # frontend over PUBLIC_API_LOCAL_URL, inside the cluster.
+          - path: /counter
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "comparia.fullname" . }}-backend
+                port:
+                  number: {{ .Values.service.backend.port }}
+          - path: /models/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "comparia.fullname" . }}-backend
+                port:
+                  number: {{ .Values.service.backend.port }}
+          - path: /arena/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "comparia.fullname" . }}-backend
+                port:
+                  number: {{ .Values.service.backend.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "comparia.fullname" . }}-frontend
+                port:
+                  number: {{ .Values.service.frontend.port }}
+{{- end }}

--- a/devops/helm/comparia/templates/migration-job.yaml
+++ b/devops/helm/comparia/templates/migration-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "comparia.fullname" . }}-migrate
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "comparia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migrate
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "comparia.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: migrate
+          image: {{ include "comparia.backendImage" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["uv", "run", "alembic", "upgrade", "head"]
+          envFrom:
+            - secretRef:
+                name: {{ include "comparia.secretName" . }}
+          env:
+            - name: COMPARIA_INSTANCE_NAME
+              value: {{ .Values.config.instanceName | quote }}
+          resources:
+            {{- toYaml .Values.resources.migration | nindent 12 }}

--- a/devops/helm/comparia/templates/secret.yaml
+++ b/devops/helm/comparia/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.secrets.existingSecret }}
+{{- if not (or .Values.secrets.openrouterApiKey .Values.secrets.albertKey .Values.secrets.hfInferenceKey .Values.secrets.ordbogenApiKey) }}
+{{- fail "At least one of secrets.openrouterApiKey, secrets.albertKey, secrets.hfInferenceKey or secrets.ordbogenApiKey must be set (or point secrets.existingSecret at a Secret that provides one)." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "comparia.secretName" . }}
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  COMPARIA_DB_URI: {{ required "secrets.dbUri is required when secrets.existingSecret is not set" .Values.secrets.dbUri | quote }}
+  COMPARIA_REDIS_HOST: {{ required "secrets.redisHost is required when secrets.existingSecret is not set" .Values.secrets.redisHost | quote }}
+  ALTCHA_HMAC_KEY: {{ required "secrets.altchaHmacKey is required when secrets.existingSecret is not set" .Values.secrets.altchaHmacKey | quote }}
+  OPENROUTER_API_KEY: {{ .Values.secrets.openrouterApiKey | quote }}
+  ALBERT_KEY: {{ .Values.secrets.albertKey | quote }}
+  HF_INFERENCE_KEY: {{ .Values.secrets.hfInferenceKey | quote }}
+  ORDBOGEN_API_KEY: {{ .Values.secrets.ordbogenApiKey | quote }}
+  LINKUP_API_KEY: {{ .Values.secrets.linkupApiKey | quote }}
+  {{- if .Values.cronjobs.exportDataset.enabled }}
+  HF_PUSH_DATASET_PATH: {{ required "cronjobs.exportDataset.hfRepo is required when cronjobs.exportDataset.enabled is true" .Values.cronjobs.exportDataset.hfRepo | quote }}
+  HF_PUSH_DATASET_KEY: {{ required "cronjobs.exportDataset.hfToken is required when cronjobs.exportDataset.enabled is true" .Values.cronjobs.exportDataset.hfToken | quote }}
+  {{- end }}
+{{- end }}

--- a/devops/helm/comparia/templates/secret.yaml
+++ b/devops/helm/comparia/templates/secret.yaml
@@ -18,6 +18,9 @@ stringData:
   HF_INFERENCE_KEY: {{ .Values.secrets.hfInferenceKey | quote }}
   ORDBOGEN_API_KEY: {{ .Values.secrets.ordbogenApiKey | quote }}
   LINKUP_API_KEY: {{ .Values.secrets.linkupApiKey | quote }}
+  MISTRAL_API_KEY: {{ .Values.secrets.mistralApiKey | quote }}
+  SMTP_USERNAME: {{ .Values.secrets.smtpUsername | quote }}
+  SMTP_PASSWORD: {{ .Values.secrets.smtpPassword | quote }}
   {{- if .Values.cronjobs.exportDataset.enabled }}
   HF_PUSH_DATASET_PATH: {{ required "cronjobs.exportDataset.hfRepo is required when cronjobs.exportDataset.enabled is true" .Values.cronjobs.exportDataset.hfRepo | quote }}
   HF_PUSH_DATASET_KEY: {{ required "cronjobs.exportDataset.hfToken is required when cronjobs.exportDataset.enabled is true" .Values.cronjobs.exportDataset.hfToken | quote }}

--- a/devops/helm/comparia/templates/serviceaccount.yaml
+++ b/devops/helm/comparia/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "comparia.serviceAccountName" . }}
+  labels:
+    {{- include "comparia.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true
+{{- end }}

--- a/devops/helm/comparia/tests/cronjobs_test.yaml
+++ b/devops/helm/comparia/tests/cronjobs_test.yaml
@@ -1,0 +1,83 @@
+suite: optional maintenance cronjobs
+templates:
+  - cronjob-ranking.yaml
+  - cronjob-export-dataset.yaml
+  - cronjob-analyze.yaml
+values:
+  - ../ci/values-lint.yaml
+tests:
+  - it: renders the ranking CronJob by default
+    template: cronjob-ranking.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+
+  - it: omits the ranking CronJob when disabled
+    template: cronjob-ranking.yaml
+    set:
+      cronjobs.ranking.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: omits the export-dataset CronJob by default
+    template: cronjob-export-dataset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the export-dataset CronJob when enabled with a target repo
+    template: cronjob-export-dataset.yaml
+    set:
+      cronjobs.exportDataset.enabled: true
+      cronjobs.exportDataset.hfRepo: my-org/my-comparia-dataset
+      cronjobs.exportDataset.hfToken: hf_dummy
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["uv", "run", "python", "-m", "utils.dataset.run", "--record"]
+
+  - it: fails to render when export-dataset is enabled without a target repo
+    template: cronjob-export-dataset.yaml
+    set:
+      cronjobs.exportDataset.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: cronjobs.exportDataset.hfRepo is required when cronjobs.exportDataset.enabled is true
+
+  - it: omits the analyze CronJob by default
+    template: cronjob-analyze.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the analyze CronJob when enabled
+    template: cronjob-analyze.yaml
+    set:
+      cronjobs.analyze.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["./comparia-cli", "db", "lint", "--fix", "--with-llm-analyze"]
+
+  - it: toggles each cronjob independently of the other two
+    template: cronjob-ranking.yaml
+    set:
+      cronjobs.ranking.enabled: true
+      cronjobs.exportDataset.enabled: true
+      cronjobs.exportDataset.hfRepo: my-org/my-comparia-dataset
+      cronjobs.exportDataset.hfToken: hf_dummy
+      cronjobs.analyze.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/devops/helm/comparia/tests/ingress_test.yaml
+++ b/devops/helm/comparia/tests/ingress_test.yaml
@@ -1,0 +1,67 @@
+suite: optional ingress
+templates:
+  - ingress.yaml
+values:
+  - ../ci/values-lint.yaml
+tests:
+  - it: is absent by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when enabled with a host
+    set:
+      ingress.enabled: true
+      ingress.host: comparia.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].host
+          value: comparia.example.com
+
+  - it: fails when enabled without a host
+    set:
+      ingress.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress.host is required when ingress.enabled is true
+
+  - it: renders the given className, annotations and tls
+    set:
+      ingress.enabled: true
+      ingress.host: comparia.example.com
+      ingress.className: nginx
+      ingress.annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      ingress.tls:
+        - hosts:
+            - comparia.example.com
+          secretName: comparia-tls
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt
+      - equal:
+          path: spec.tls[0].secretName
+          value: comparia-tls
+
+  - it: routes backend paths to the backend Service and everything else to the frontend Service
+    set:
+      ingress.enabled: true
+      ingress.host: comparia.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-comparia-backend
+      - equal:
+          path: spec.rules[0].http.paths[2].backend.service.name
+          value: RELEASE-NAME-comparia-backend
+      - equal:
+          path: spec.rules[0].http.paths[3].backend.service.name
+          value: RELEASE-NAME-comparia-frontend

--- a/devops/helm/comparia/tests/migration_test.yaml
+++ b/devops/helm/comparia/tests/migration_test.yaml
@@ -1,0 +1,45 @@
+suite: automatic database migrations
+templates:
+  - migration-job.yaml
+values:
+  - ../ci/values-lint.yaml
+tests:
+  - it: renders the migration Job as a pre-install/pre-upgrade hook
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["uv", "run", "alembic", "upgrade", "head"]
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/betagouv/comparia-backend:latest
+
+  - it: resolves DB env from the chart-rendered Secret by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: RELEASE-NAME-comparia-secret
+
+  - it: resolves DB env from existingSecret when set
+    set:
+      secrets.existingSecret: my-external-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: my-external-secret
+
+  - it: is present on every render regardless of other toggles
+    set:
+      cronjobs.ranking.enabled: false
+      ingress.enabled: true
+      ingress.host: comparia.example.com
+    asserts:
+      - isKind:
+          of: Job

--- a/devops/helm/comparia/tests/secrets_test.yaml
+++ b/devops/helm/comparia/tests/secrets_test.yaml
@@ -1,0 +1,78 @@
+suite: secrets - dual mode
+templates:
+  - secret.yaml
+  - backend-deployment.yaml
+  - frontend-deployment.yaml
+values:
+  - ../ci/values-lint.yaml
+tests:
+  - it: renders a Secret from values by default
+    template: secret.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-comparia-secret
+      - equal:
+          path: stringData.COMPARIA_DB_URI
+          value: postgresql://comparia:changeme@postgres:5432/comparia
+
+  - it: wires the backend to the chart-rendered Secret by default
+    template: backend-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: RELEASE-NAME-comparia-secret
+
+  - it: does not render a Secret when existingSecret is set
+    template: secret.yaml
+    set:
+      secrets.existingSecret: my-external-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: wires every workload to the existingSecret name
+    template: backend-deployment.yaml
+    set:
+      secrets.existingSecret: my-external-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: my-external-secret
+
+  - it: wires the frontend to the existingSecret name too
+    template: frontend-deployment.yaml
+    set:
+      secrets.existingSecret: my-external-secret
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: my-external-secret
+
+  - it: fails when secrets.dbUri is missing in inline mode
+    template: secret.yaml
+    set:
+      secrets.dbUri: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: secrets.dbUri is required when secrets.existingSecret is not set
+
+  - it: fails when no LLM provider key is set in inline mode
+    template: secret.yaml
+    set:
+      secrets.openrouterApiKey: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: At least one of secrets.openrouterApiKey, secrets.albertKey, secrets.hfInferenceKey or secrets.ordbogenApiKey must be set (or point secrets.existingSecret at a Secret that provides one).
+
+  - it: does not require secrets.* values at all when existingSecret is set
+    template: secret.yaml
+    set:
+      secrets.existingSecret: my-external-secret
+      secrets.dbUri: ""
+      secrets.openrouterApiKey: ""
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/devops/helm/comparia/tests/secrets_test.yaml
+++ b/devops/helm/comparia/tests/secrets_test.yaml
@@ -17,6 +17,12 @@ tests:
       - equal:
           path: stringData.COMPARIA_DB_URI
           value: postgresql://comparia:changeme@postgres:5432/comparia
+      - exists:
+          path: stringData.MISTRAL_API_KEY
+      - exists:
+          path: stringData.SMTP_USERNAME
+      - exists:
+          path: stringData.SMTP_PASSWORD
 
   - it: wires the backend to the chart-rendered Secret by default
     template: backend-deployment.yaml

--- a/devops/helm/comparia/tests/workloads_test.yaml
+++ b/devops/helm/comparia/tests/workloads_test.yaml
@@ -1,0 +1,92 @@
+suite: backend and frontend workloads
+templates:
+  - backend-deployment.yaml
+  - frontend-deployment.yaml
+  - backend-service.yaml
+  - frontend-service.yaml
+  - serviceaccount.yaml
+values:
+  - ../ci/values-lint.yaml
+tests:
+  - it: renders the backend Deployment with the configured image and probes
+    template: backend-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-comparia-backend
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/betagouv/comparia-backend:latest
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 80
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /docs
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: http
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-comparia
+
+  - it: renders the frontend Deployment with the configured image and probes
+    template: frontend-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-comparia-frontend
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/betagouv/comparia-frontend:latest
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+
+  - it: points the frontend at the backend Service
+    template: frontend-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PUBLIC_API_LOCAL_URL
+            value: http://RELEASE-NAME-comparia-backend:80
+
+  - it: uses distinct chart and app image tags
+    template: backend-deployment.yaml
+    set:
+      image.backend.tag: "1.2.3"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/betagouv/comparia-backend:1.2.3
+
+  - it: renders backend and frontend Services
+    template: backend-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: backend
+
+  - it: creates a ServiceAccount by default
+    template: serviceaccount.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-comparia
+
+  - it: does not create a ServiceAccount when disabled
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/devops/helm/comparia/tests/workloads_test.yaml
+++ b/devops/helm/comparia/tests/workloads_test.yaml
@@ -47,6 +47,46 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /
 
+  - it: sets the admin/auth/currency env vars with their defaults
+    template: backend-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ADMIN_EMAILS
+            value: "[]"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISPLAY_CURRENCY
+            value: EUR
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_HOST
+
+  - it: sets ADMIN_EMAILS and SMTP_HOST/PORT when configured
+    template: backend-deployment.yaml
+    set:
+      config.adminEmails: ["you@example.com"]
+      config.smtp.host: smtp.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ADMIN_EMAILS
+            value: '["you@example.com"]'
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_HOST
+            value: smtp.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SMTP_PORT
+            value: "587"
+
   - it: points the frontend at the backend Service
     template: frontend-deployment.yaml
     asserts:

--- a/devops/helm/comparia/values.yaml
+++ b/devops/helm/comparia/values.yaml
@@ -86,9 +86,36 @@ config:
   sentryDsn: ""
   sentryEnvironment: prod
 
+  ## -- Public origin used to build absolute links in emails (e.g. login codes). Left empty, the
+  ## app falls back to its own dev default (http://localhost:5173) -- set this for a real install.
+  appUrl: ""
+  ## -- Emails promoted to the admin role on startup, created if absent. Left empty, nobody can
+  ## reach /admin. Example: ["you@example.com"].
+  adminEmails: []
+  auth:
+    ## -- If non-empty, only emails from these domains can request a login code. Example: ["example.com"].
+    domainAllowlist: []
+    sessionLengthDays: 30
+  currency:
+    ## -- ISO 4217 code models prices are converted to for display (stored in EUR internally).
+    display: EUR
+    ## -- Manual EUR -> display currency rate. Set this to enable currencies unavailable from the
+    ## rate API, run fully offline, or avoid the EUR fallback if the rate service is unreachable
+    ## at startup. Left null, the rate is fetched from exchangeApiUrl instead.
+    rateFromEur: null
+    exchangeApiUrl: https://api.frankfurter.dev/v2
+    exchangeCacheSeconds: 86400
+  ## -- "From" address/name on outgoing emails (login codes).
+  emailFrom: ""
+  emailFromName: "ComparIA"
+  smtp:
+    ## -- Left empty, login codes are logged to console instead of being sent by email.
+    host: ""
+    port: 587
+
 backend:
-  ## -- Extra env vars for the backend container, e.g. SMTP_*, ADMIN_EMAILS, AUTH_DOMAIN_ALLOWLIST.
-  ## Same shape as a container's `env:` list (name/value or name/valueFrom).
+  ## -- Extra env vars for the backend container, for anything not covered by config.* above
+  ## or secrets.* below. Same shape as a container's `env:` list (name/value or name/valueFrom).
   extraEnv: []
 
 frontend:
@@ -113,6 +140,12 @@ secrets:
   ordbogenApiKey: ""
   linkupApiKey: ""
   altchaHmacKey: ""
+  ## -- Mistral moderation API key, for prompt checks (content safety, personal data). Left
+  ## empty, both checks no-op.
+  mistralApiKey: ""
+  ## -- Only used when config.smtp.host is set.
+  smtpUsername: ""
+  smtpPassword: ""
 
 cronjobs:
   ranking:

--- a/devops/helm/comparia/values.yaml
+++ b/devops/helm/comparia/values.yaml
@@ -1,0 +1,139 @@
+## Default values for the comparia chart.
+## See README.md for a full description of every value.
+
+## -- Overrides for the generated resource names.
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  ## -- Applied to every image below unless overridden per-image.
+  pullPolicy: IfNotPresent
+  ## -- Names to add to imagePullSecrets on every Pod.
+  pullSecrets: []
+  backend:
+    repository: ghcr.io/betagouv/comparia-backend
+    ## -- Defaults to .Chart.AppVersion when unset. Independent of the chart's own version.
+    tag: ""
+  frontend:
+    repository: ghcr.io/betagouv/comparia-frontend
+    ## -- Defaults to .Chart.AppVersion when unset. Independent of the chart's own version.
+    tag: ""
+
+serviceAccount:
+  ## -- Whether a ServiceAccount is created for the release.
+  create: true
+  ## -- Name of the ServiceAccount to use. Defaults to the release's fullname when create is true.
+  name: ""
+  annotations: {}
+
+replicaCount:
+  backend: 1
+  frontend: 1
+
+service:
+  backend:
+    port: 80
+  frontend:
+    port: 80
+
+resources:
+  backend:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  frontend:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  ## -- Applied to the pre-install/pre-upgrade migration Job.
+  migration:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  ## -- Applied to all three maintenance CronJobs.
+  cronjobs:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+## -- Non-secret application settings, passed to the backend/frontend as plain env vars.
+config:
+  ## -- Names the deployment (Redis key namespace, default locale). Also used to seed the
+  ## initial HuggingFace dataset destination on first install; see cronjobs.exportDataset below.
+  instanceName: fr
+  ## -- "anonymous_first" (sign-in optional) or "sign_in_required".
+  authAccessPolicy: anonymous_first
+  logFormat: JSON
+  votesObjective: 300000
+  cache:
+    enabled: true
+    probability: 0.75
+    ttl: 172800
+    maxResponses: 5
+  ## -- Left empty, errors are not sent anywhere.
+  sentryDsn: ""
+  sentryEnvironment: prod
+
+backend:
+  ## -- Extra env vars for the backend container, e.g. SMTP_*, ADMIN_EMAILS, AUTH_DOMAIN_ALLOWLIST.
+  ## Same shape as a container's `env:` list (name/value or name/valueFrom).
+  extraEnv: []
+
+frontend:
+  ## -- Public URL the frontend is served at. Left empty, requests are treated as same-origin.
+  publicApiUrl: ""
+  ## -- Comma-separated locales to hide from the language switcher.
+  disabledLocales: ""
+  ## -- Extra env vars for the frontend container. Same shape as a container's `env:` list.
+  extraEnv: []
+
+## -- Secret material. In existingSecret mode, the values below (other than existingSecret
+## itself) are ignored: point existingSecret at a Secret you manage, containing whichever of
+## the keys documented in README.md your setup needs.
+secrets:
+  ## -- Name of a pre-existing Secret to use instead of the chart-rendered one. Takes precedence.
+  existingSecret: ""
+  dbUri: ""
+  redisHost: ""
+  openrouterApiKey: ""
+  albertKey: ""
+  hfInferenceKey: ""
+  ordbogenApiKey: ""
+  linkupApiKey: ""
+  altchaHmacKey: ""
+
+cronjobs:
+  ranking:
+    enabled: true
+    schedule: "17 * * * *"
+  exportDataset:
+    enabled: false
+    schedule: "15 4 * * *"
+    ## -- '{organisation}/{repo_prefix}' on HuggingFace. Required when enabled. Only read once,
+    ## by the migration hook, to seed the destination row (see README.md).
+    hfRepo: ""
+    ## -- HuggingFace token with write access to hfRepo. Required when enabled.
+    hfToken: ""
+  analyze:
+    enabled: false
+    schedule: "35 3 * * *"
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  ## -- cert-manager-style TLS block, passed through as-is.
+  tls: []


### PR DESCRIPTION
## Summary

- Adds devops/helm/comparia/, a self-contained Helm chart to install backend and frontend on any Kubernetes cluster
- Separate Deployments/Services for backend and frontend, dual-mode secrets (chart-rendered or existingSecret), pre-install/pre-upgrade migration hook, three independently toggleable maintenance cronjobs (ranking, dataset export, analyze), optional Ingress
- No S3 sidecar, no bundled Postgres/Redis, no blue-green machinery
- Fixes the runtime Docker image, which never copied alembic.ini, so the migration hook can actually run alembic
- Adds missing .env.example values used by the chart

## Changes

- `devops/helm/comparia/`: new Helm chart (templates, values, README, helm-unittest tests, ci lint values)
- `devops/docker/Dockerfile`: copy alembic.ini into the runtime image
- `Makefile`: add helm-lint and helm-test targets
- `.env.example`: add missing values referenced by the chart

## Test plan

- helm and the helm-unittest plugin are not installed in this environment, so helm lint / helm-unittest have not been run against this change