### PR TITLE
fix(vote): put "B est meilleur" back on the right

### DIFF
--- a/frontend/e2e/a11y.test.ts
+++ b/frontend/e2e/a11y.test.ts
@@ -227,7 +227,9 @@ async function reachVote(page: Page) {
  */
 async function reachResults(page: Page) {
   await reachVote(page)
-  await page.locator('button[data-choice="a_better"]').click()
+  // Two vote grids, one per breakpoint, and the one that does not apply is
+  // display:none — so match on the visible one rather than the first.
+  await page.locator('button[data-choice="a_better"]:visible').click()
 
   // The reveal button stays aria-disabled until the vote has registered, and
   // Playwright treats aria-disabled as not actionable.
@@ -241,7 +243,7 @@ test('voting hands focus to the controls it just revealed', async ({ page }) => 
   await reachVote(page)
 
   // Keyboard, because that is who this is for.
-  await page.locator('button[data-choice="a_better"]').focus()
+  await page.locator('button[data-choice="a_better"]:visible').focus()
   await page.keyboard.press('Enter')
 
   // Voting unmounts the fieldset holding the focused button. The annotation box

--- a/frontend/src/routes/(arena)/components/VoteSelect.svelte
+++ b/frontend/src/routes/(arena)/components/VoteSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Icon } from '$components/dsfr'
-  import { type TurnChoice } from '$lib/chatService.svelte'
+  import { TURN_CHOICES, type TurnChoice } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
   import { propsToAttrs, sanitize } from '$lib/utils/commons'
   import { onDestroy } from 'svelte'
@@ -18,14 +18,12 @@
     both_good: 'i-ri-thumb-up-line',
     idk: ''
   }
-  // Display order, not TURN_CHOICES order. The grid used to be reordered in CSS
-  // for narrow screens, which left the tab order zigzagging across it: second
-  // stop bottom-right, fourth stop top-right. One order everywhere instead.
-  const choices = (['a_better', 'b_better', 'both_bad', 'both_good'] as const).map((value) => ({
-    value,
-    label: value,
-    icon: choiceIcons[value]
-  }))
+  // Two orders: A and B at the ends on desktop, paired on the first row once the
+  // grid folds to two columns. Reordering one grid in CSS would leave the tab
+  // order zigzagging across it, so each width gets its own grid and the other is
+  // display:none, which keeps it out of the tab order.
+  const desktopOrder = TURN_CHOICES.filter((v) => v !== 'idk')
+  const mobileOrder = ['a_better', 'b_better', 'both_bad', 'both_good'] as const
 
   let pickedChoice = $state<TurnChoice | null>(null)
   let voteTimeout: ReturnType<typeof setTimeout> | undefined
@@ -49,24 +47,36 @@
   >
     <legend id="{id}-legend" class="sr-only">{m['vote.title']()}</legend>
 
-    <div class="gap-1 md:gap-2 md:grid-cols-4 grid grid-cols-2">
-      {#each choices as choice (choice.value)}
-        <button
-          type="submit"
-          class={[
-            'cl-vote-choice rounded-lg px-1 py-2 md:p-2 text-xs! bg-white cg-border flex items-center',
-            { 'cl-vote-picked': pickedChoice === choice.value }
-          ]}
-          data-choice={choice.value}
-          disabled={pickedChoice !== null && pickedChoice !== choice.value}
-        >
-          <span class={['gap-1 m-auto flex', { 'flex-row-reverse': choice.value === 'b_better' }]}>
-            <Icon icon={choice.icon} block size="xs" class="text-primary" />
-            {m[`vote.turn.choices.${choice.value}`]()}
-          </span>
-        </button>
-      {/each}
-    </div>
+    {#snippet grid(order: readonly TurnChoice[], layout: string)}
+      <div class="gap-1 md:gap-2 {layout}">
+        {#each order as choice (choice)}
+          {@const label = m[`vote.turn.choices.${choice}`]()}
+          <button
+            type="submit"
+            class={[
+              'cl-vote-choice rounded-lg px-1 py-2 md:p-2 text-xs! bg-white cg-border flex items-center',
+              { 'cl-vote-picked': pickedChoice === choice }
+            ]}
+            data-choice={choice}
+            disabled={pickedChoice !== null && pickedChoice !== choice}
+          >
+            <!-- The icon flows with the text rather than sitting beside it in a
+                 flex row: a label that wraps to two lines fills the row, which
+                 left the icon stranded against the button edge. -->
+            <span class="cl-vote-label m-auto text-center">
+              {#if choice === 'b_better'}
+                {label}<Icon icon={choiceIcons[choice]} size="xs" class="text-primary ml-1" />
+              {:else}
+                <Icon icon={choiceIcons[choice]} size="xs" class="text-primary mr-1" />{label}
+              {/if}
+            </span>
+          </button>
+        {/each}
+      </div>
+    {/snippet}
+
+    {@render grid(mobileOrder, 'grid grid-cols-2 md:hidden')}
+    {@render grid(desktopOrder, 'md:grid md:grid-cols-4 hidden')}
 
     <div class="order-last flex justify-center">
       <button type="submit" class="text-dark-grey text-xs bg-transparent!" data-choice="idk">
@@ -96,6 +106,11 @@
     &:disabled {
       filter: grayscale(100%);
     }
+  }
+
+  /* The glyph is inline now, so nudge it off the baseline onto the text. */
+  .cl-vote-label :global(span) {
+    vertical-align: -0.2em;
   }
 
   .cl-vote-choice {

--- a/frontend/src/routes/(arena)/components/VoteSelect.svelte.test.ts
+++ b/frontend/src/routes/(arena)/components/VoteSelect.svelte.test.ts
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/svelte'
+import { describe, expect, it, vi } from 'vitest'
+import VoteSelect from './VoteSelect.svelte'
+
+// Reached through chatService, and it wants the runtime env at import time.
+vi.mock('$lib/fastapi-client', () => ({ api: { request: vi.fn() } }))
+
+/**
+ * The desktop order has slipped once already, so it is pinned here. jsdom does
+ * not apply the breakpoint, so both grids render and each is found by the class
+ * that shows it.
+ */
+describe('VoteSelect', () => {
+  const orderOf = (grid: Element) =>
+    [...grid.querySelectorAll('button')].map((b) => b.dataset.choice)
+
+  it('puts A and B at the ends on desktop and pairs them on the first row on mobile', () => {
+    const { container } = render(VoteSelect, { id: 'vote-select-1', onVote: vi.fn() })
+    const [mobile, desktop] = container.querySelectorAll('fieldset > div[class*="grid"]')
+
+    expect(mobile.className).toContain('md:hidden')
+    expect(orderOf(mobile)).toEqual(['a_better', 'b_better', 'both_bad', 'both_good'])
+
+    expect(desktop.className).toContain('md:grid')
+    expect(orderOf(desktop)).toEqual(['a_better', 'both_good', 'both_bad', 'b_better'])
+  })
+})


### PR DESCRIPTION
The vote row read A / B / both bad / both good. B belongs at the far right, opposite A.

Desktop and mobile each render their own grid now, one hidden per breakpoint, so the DOM order matches the visual order at both widths and nothing is reordered in CSS.

Also fixes the choice icon, which was stranded against the button edge when the label wrapped to two lines. It flows inline with the text now, and the group stays centred.

Checked from 320px to 1280px.