### PR TITLE
fix(back): prod-readiness fixes before release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ export EMAIL_FROM=
 # Frontend base URL, used to build links in emails (e.g. login code)
 # export COMPARIA_APP_URL="http://localhost:5173/"
 
+# Extra CORS origins allowed in production (comma-separated)
+# export COMPARIA_CORS_ORIGINS='["https://comparia.beta.gouv.fr"]'
+
 # Auth
 # "anonymous_first" (default) or "sign_in_required"
 # export AUTH_ACCESS_POLICY=anonymous_first

--- a/backend/arena/services.py
+++ b/backend/arena/services.py
@@ -76,7 +76,7 @@ async def read_comparison(
         else:
             query = query.where(Comparison.anonymous_user_hash == anonymous_user_hash)
 
-        db_comparison = (await session.exec(query)).one()
+        db_comparison = (await session.exec(query)).first()
         if not db_comparison:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from typing import Literal, get_args
@@ -82,6 +83,10 @@ class Settings(BaseSettings):
     # Public app origin, used to build absolute links in emails (e.g. invite links)
     COMPARIA_APP_URL: str = "http://localhost:5173"
 
+    # Extra CORS origins allowed in production (e.g. "https://comparia.beta.gouv.fr").
+    # Localhost origins are always allowed for development.
+    COMPARIA_CORS_ORIGINS: list[str] = []
+
     @field_validator("COMPARIA_APP_URL")
     @classmethod
     def _strip_trailing_slash(cls, value: str) -> str:
@@ -128,11 +133,18 @@ class Settings(BaseSettings):
 
 settings = Settings()
 
-# Generate a random HMAC key if not configured (dev mode)
+# Generate a random HMAC key if not configured (dev mode). A random key breaks
+# CAPTCHA verification whenever more than one process serves the app, since the
+# process issuing a challenge is not the one verifying it.
 if not settings.ALTCHA_HMAC_KEY:
     import secrets
 
     settings.ALTCHA_HMAC_KEY = secrets.token_hex(32)
+    logging.getLogger(__name__).warning(
+        "ALTCHA_HMAC_KEY is not set: using a random per-process key. "
+        "CAPTCHA verification will fail with multiple workers or replicas. "
+        "Set ALTCHA_HMAC_KEY in production (see devops/standalone_docker_install/DOCKER_INSTALL.md)."
+    )
 
 # Create directory for JSON backup files
 os.makedirs(settings.LOGDIR, exist_ok=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -62,7 +62,7 @@ origins = [
     "http://localhost:8001",
     "http://localhost:8002",
     "http://localhost:8008",
-]
+] + settings.COMPARIA_CORS_ORIGINS
 
 app.middleware("http")(auth_middleware)
 app.middleware("http")(anonymous_middleware)


### PR DESCRIPTION
Three small fixes I hit while reviewing next before the release.

`read_comparison` called `.one()`, so requesting a comparison that doesn't exist (or belongs to someone else) raised `NoResultFound` and returned a 500 instead of the intended 404. CORS origins were hardcoded to localhost, so real deployments had no way to allow their frontend origin without touching source; they now come from a `COMPARIA_CORS_ORIGINS` env var. Finally, when `ALTCHA_HMAC_KEY` is unset we fall back to a random per-process key, which silently breaks CAPTCHA verification the day the app runs more than one worker or replica; there's now a startup warning explaining this.

I kept it as a warning rather than a hard failure because current deployments run a single uvicorn process and making the key mandatory would break local dev and CI, which don't set it.