### PR TITLE
Survey review follow-ups

### DIFF
--- a/backend/admin/survey.py
+++ b/backend/admin/survey.py
@@ -7,6 +7,7 @@ from backend.survey.services import (
     SurveyOptionUnknownError,
     SurveyOrderMismatchError,
     SurveyQuestionInUseError,
+    SurveyQuestionKeyCollisionError,
     SurveyQuestionLabelUnusableError,
     SurveyQuestionNotFoundError,
     admin_list,
@@ -47,6 +48,10 @@ _IN_USE = HTTPException(
     status_code=status.HTTP_409_CONFLICT,
     detail="Answers already carry this question, archive it instead of deleting it",
 )
+_KEY_COLLISION = HTTPException(
+    status_code=status.HTTP_409_CONFLICT,
+    detail="This label slugs to a key another question already uses, reword it",
+)
 
 
 async def _admin_question(session, question_id: uuid.UUID) -> AdminSurveyQuestion:
@@ -80,6 +85,8 @@ async def add_survey_question(
             question = await create_question(session, body)
         except SurveyQuestionLabelUnusableError:
             raise _LABEL_UNUSABLE
+        except SurveyQuestionKeyCollisionError:
+            raise _KEY_COLLISION
         except SurveyOptionUnknownError:
             raise _OPTION_UNKNOWN
         return await _admin_question(session, question.id)

--- a/backend/survey/services.py
+++ b/backend/survey/services.py
@@ -503,11 +503,13 @@ async def carry_over_anonymous(
                 )
             ).all()
         )
+        # Ties go to the session: leaving both rows in place would trip the
+        # unique index the moment the UPDATE below reassigns them.
         newer_on_the_session = [
             question_id
             for question_id, answered_at in just_answered.items()
             if question_id not in account_answered
-            or answered_at > account_answered[question_id]
+            or answered_at >= account_answered[question_id]
         ]
         if newer_on_the_session:
             await session.execute(

--- a/backend/survey/services.py
+++ b/backend/survey/services.py
@@ -1,7 +1,7 @@
 import re
 import unicodedata
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import update as sa_update
@@ -10,6 +10,7 @@ from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from utils.database.models.survey import (
+    MAX_DISMISS_IDS,
     MAX_QUESTION_PROMPTS,
     MAX_QUESTIONS_PER_PROMPT,
     AdminSurveyOption,
@@ -46,6 +47,14 @@ class SurveyQuestionInUseError(Exception):
 
 class SurveyQuestionLabelUnusableError(Exception):
     """A label with no letters or digits leaves nothing to build a key from."""
+
+
+class SurveyQuestionKeyCollisionError(Exception):
+    """
+    A label that slugs to a key another question already uses. Distinct from
+    `SurveyQuestionLabelUnusableError`: the label itself is fine, the admin
+    just needs to reword it so it stops colliding.
+    """
 
 
 class SurveyOptionUnknownError(Exception):
@@ -257,6 +266,24 @@ async def record_shown(
     if not question_ids:
         return
 
+    # Dismissing is best-effort: a stale or arbitrary id from the client must
+    # not reach the foreign key and surface as a 500, so anything the question
+    # table does not know about is dropped rather than rejected. The list is
+    # capped first, since only what one popup showed can ever be legitimate.
+    question_ids = question_ids[:MAX_DISMISS_IDS]
+    known_ids = set(
+        (
+            await session.exec(
+                select(SurveyQuestion.id).where(
+                    col(SurveyQuestion.id).in_(question_ids)
+                )
+            )
+        ).all()
+    )
+    question_ids = [qid for qid in question_ids if qid in known_ids]
+    if not question_ids:
+        return
+
     existing = {
         log.question_id: log
         for log in (
@@ -439,30 +466,56 @@ async def carry_over_anonymous(
     `_associate_anonymous_acceptance()` in `backend/auth/services.py`: this is
     called from inside that same transaction, so it never commits itself.
     """
-    just_answered = set(
+    # Both sides can hold answers for the same question, since the login form
+    # asks it of returning users too. The newer answer wins, per question: the
+    # answer given a moment ago describes the person better than one given a
+    # year ago. This is the same replace-in-place rule the profile page
+    # follows, so the losing account rows go and the anonymous ones take
+    # their place.
+    just_answered = dict(
         (
             await session.exec(
-                select(SurveyAnswer.question_id)
+                select(
+                    SurveyAnswer.question_id,
+                    func.max(SurveyAnswer.answered_at),
+                )
                 .where(
                     SurveyAnswer.anonymous_user_hash == anonymous_user_hash,
                     col(SurveyAnswer.user_id).is_(None),
                 )
-                .distinct()
+                .group_by(col(SurveyAnswer.question_id))
             )
         ).all()
     )
     if just_answered:
-        # The newer answer wins. Both sides can hold one for the same question,
-        # since the login form asks it of returning users too, and the answer
-        # given a moment ago describes the person better than one given a year
-        # ago. This is the same replace-in-place rule the profile page follows,
-        # so the account's rows go and the anonymous ones take their place.
-        await session.execute(
-            sa_delete(SurveyAnswer).where(
-                SurveyAnswer.user_id == user_id,
-                col(SurveyAnswer.question_id).in_(just_answered),
-            )
+        account_answered = dict(
+            (
+                await session.exec(
+                    select(
+                        SurveyAnswer.question_id,
+                        func.max(SurveyAnswer.answered_at),
+                    )
+                    .where(
+                        SurveyAnswer.user_id == user_id,
+                        col(SurveyAnswer.question_id).in_(list(just_answered)),
+                    )
+                    .group_by(col(SurveyAnswer.question_id))
+                )
+            ).all()
         )
+        newer_on_the_session = [
+            question_id
+            for question_id, answered_at in just_answered.items()
+            if question_id not in account_answered
+            or answered_at > account_answered[question_id]
+        ]
+        if newer_on_the_session:
+            await session.execute(
+                sa_delete(SurveyAnswer).where(
+                    SurveyAnswer.user_id == user_id,
+                    col(SurveyAnswer.question_id).in_(newer_on_the_session),
+                )
+            )
 
     await session.execute(
         sa_update(SurveyAnswer)
@@ -643,9 +696,10 @@ async def create_question(
         await session.commit()
     except IntegrityError as error:
         await session.rollback()
-        # Two labels slugging to the same key is the only way this collides,
-        # which is the same complaint as a label with nothing to slug at all.
-        raise SurveyQuestionLabelUnusableError() from error
+        # The key is the only unique constraint on this table, so a collision
+        # here means the label slugs to a key another question already uses —
+        # not that the label is unusable, which was checked before the insert.
+        raise SurveyQuestionKeyCollisionError() from error
 
     invalidate_cache(REDIS_SURVEY_KEY)
     await session.refresh(question)
@@ -720,7 +774,7 @@ async def update_question(
     question.required = payload.required
     if label_changed or live_set_changed:
         question.revision += 1
-    question.updated_at = datetime.now()
+    question.updated_at = utc_now()
 
     session.add(question)
     await session.commit()
@@ -737,12 +791,11 @@ async def set_archived(
         raise SurveyQuestionNotFoundError()
 
     # archived_at is the survey's own column and reads in UTC like every other
-    # one it owns; updated_at belongs to BaseDBModel, whose default is the
-    # host's local time, and matching it keeps a row's own two stamps
-    # comparable.
+    # one it owns; updated_at is stamped on the same scale so a row's own two
+    # stamps stay comparable.
     question.archived_at = utc_now() if archived else None
     question.archived_by = admin_id if archived else None
-    question.updated_at = datetime.now()
+    question.updated_at = utc_now()
     session.add(question)
     await session.commit()
     invalidate_cache(REDIS_SURVEY_KEY)

--- a/tests/survey/test_carry_over.py
+++ b/tests/survey/test_carry_over.py
@@ -100,6 +100,29 @@ def test_nothing_is_deleted_when_the_session_answered_nothing():
     ]
 
 
+def test_a_tied_answer_goes_to_the_session():
+    """
+    An exact timestamp tie must not leave both rows in place: the UPDATE that
+    reassigns the anonymous rows would trip the answer uniqueness index. The
+    session wins, like it does on any other non-strict loss.
+    """
+    user_id = uuid.uuid4()
+    question_id = uuid.uuid4()
+    same_moment = utc_now()
+
+    session = FakeSession(
+        [(question_id, same_moment)], [(question_id, same_moment)], []
+    )
+    asyncio.run(carry_over_anonymous(session, "hash", user_id))
+
+    deletes = [
+        statement
+        for statement in session.statements
+        if statement.__visit_name__ == "delete"
+    ]
+    assert deletes, "the account's tied answer was left in place"
+
+
 def test_an_older_anonymous_answer_loses_to_the_account_answer():
     """
     The login form can be filled with answers older than the ones already on
@@ -184,6 +207,7 @@ if __name__ == "__main__":
     test_the_answer_just_given_replaces_the_one_on_the_account()
     test_nothing_is_deleted_when_the_session_answered_nothing()
     test_an_older_anonymous_answer_loses_to_the_account_answer()
+    test_a_tied_answer_goes_to_the_session()
     test_prompt_counts_are_added_together_rather_than_duplicated()
     test_an_unmatched_anonymous_row_is_reassigned_untouched()
     test_the_cap_still_holds_after_a_merge()

--- a/tests/survey/test_carry_over.py
+++ b/tests/survey/test_carry_over.py
@@ -70,8 +70,9 @@ def test_the_answer_just_given_replaces_the_one_on_the_account():
     user_id = uuid.uuid4()
     question_id = uuid.uuid4()
 
-    # First exec: the questions this anonymous session just answered.
-    session = FakeSession([question_id], [], [])
+    # First exec: what the anonymous session just answered and when. Second:
+    # nothing on the account to compare against, so the session's answer wins.
+    session = FakeSession([(question_id, utc_now())], [], [])
     asyncio.run(carry_over_anonymous(session, "hash", user_id))
 
     deletes = [
@@ -97,6 +98,30 @@ def test_nothing_is_deleted_when_the_session_answered_nothing():
         for statement in session.statements
         if statement.__visit_name__ == "delete"
     ]
+
+
+def test_an_older_anonymous_answer_loses_to_the_account_answer():
+    """
+    The login form can be filled with answers older than the ones already on
+    the account — a bookmarked form, a second tab. The newer answer wins per
+    question, so the account's row stays and nothing is deleted for it.
+    """
+    user_id = uuid.uuid4()
+    question_id = uuid.uuid4()
+    yesterday = utc_now() - timedelta(days=1)
+    an_hour_ago = utc_now() - timedelta(hours=1)
+
+    # The anonymous side answered yesterday, the account an hour ago.
+    session = FakeSession(
+        [(question_id, yesterday)], [(question_id, an_hour_ago)], []
+    )
+    asyncio.run(carry_over_anonymous(session, "hash", user_id))
+
+    assert not [
+        statement
+        for statement in session.statements
+        if statement.__visit_name__ == "delete"
+    ], "the account's newer answer was replaced by an older one"
 
 
 def test_prompt_counts_are_added_together_rather_than_duplicated():
@@ -158,6 +183,7 @@ def test_the_cap_still_holds_after_a_merge():
 if __name__ == "__main__":
     test_the_answer_just_given_replaces_the_one_on_the_account()
     test_nothing_is_deleted_when_the_session_answered_nothing()
+    test_an_older_anonymous_answer_loses_to_the_account_answer()
     test_prompt_counts_are_added_together_rather_than_duplicated()
     test_an_unmatched_anonymous_row_is_reassigned_untouched()
     test_the_cap_still_holds_after_a_merge()

--- a/utils/database/alembic/versions/b4e9f2a7c1d0_add_survey_answer_uniqueness.py
+++ b/utils/database/alembic/versions/b4e9f2a7c1d0_add_survey_answer_uniqueness.py
@@ -1,0 +1,46 @@
+"""add_survey_answer_uniqueness
+
+Revision ID: b4e9f2a7c1d0
+Revises: 3dd0208cf1b8
+Create Date: 2026-08-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b4e9f2a7c1d0"
+down_revision: Union[str, Sequence[str], None] = "3dd0208cf1b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # One row per option per respondent, enforced by the database rather than
+    # only by delete-then-insert in `submit_answers`: two concurrent
+    # submissions would otherwise both pass the delete and leave a duplicate.
+    # Both ownership columns are nullable and Postgres treats NULL as distinct
+    # in unique indexes, so each is wrapped in COALESCE to a sentinel that no
+    # real row carries — exactly one of the two is ever set.
+    op.create_index(
+        "uq_survey_answer_respondent_option",
+        "survey_answer",
+        [
+            "question_id",
+            "option_key",
+            sa.text(
+                "COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid)"
+            ),
+            sa.text("COALESCE(anonymous_user_hash, '')"),
+        ],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_survey_answer_respondent_option", table_name="survey_answer"
+    )

--- a/utils/database/alembic/versions/b4e9f2a7c1d0_add_survey_answer_uniqueness.py
+++ b/utils/database/alembic/versions/b4e9f2a7c1d0_add_survey_answer_uniqueness.py
@@ -11,6 +11,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
+from utils.database.models.survey import NO_USER_SENTINEL
+
 # revision identifiers, used by Alembic.
 revision: str = "b4e9f2a7c1d0"
 down_revision: Union[str, Sequence[str], None] = "3dd0208cf1b8"
@@ -31,9 +33,7 @@ def upgrade() -> None:
         [
             "question_id",
             "option_key",
-            sa.text(
-                "COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid)"
-            ),
+            sa.text(f"COALESCE(user_id, '{NO_USER_SENTINEL}'::uuid)"),
             sa.text("COALESCE(anonymous_user_hash, '')"),
         ],
         unique=True,

--- a/utils/database/models/survey.py
+++ b/utils/database/models/survey.py
@@ -3,6 +3,7 @@ import uuid
 from typing import Annotated, Literal, get_args
 
 from pydantic import StringConstraints, field_validator
+from sqlalchemy import Index, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel, String
 
@@ -35,6 +36,11 @@ MAX_QUESTION_PROMPTS = 3
 # Questions shown in a single after-vote popup. Past three the popup stops
 # reading as a question and starts reading as a form.
 MAX_QUESTIONS_PER_PROMPT = 3
+
+# How many question ids one dismiss call may name. The client only ever sends
+# what one popup showed; anything longer is a bug or abuse, and the log rows
+# it would create are worthless either way.
+MAX_DISMISS_IDS = 50
 
 QuestionLabel = Annotated[
     str, StringConstraints(strip_whitespace=True, min_length=1, max_length=300)
@@ -120,6 +126,23 @@ class SurveyAnswerBase(BaseDBModel):
 
 class SurveyAnswer(SurveyAnswerBase, table=True):
     __tablename__ = "survey_answer"
+
+    # One row per option per respondent, enforced by the database rather than
+    # only by delete-then-insert in `submit_answers`: two concurrent
+    # submissions would otherwise both pass the delete and leave a duplicate.
+    # Both ownership columns are nullable and Postgres treats NULL as distinct
+    # in unique indexes, so each is wrapped in COALESCE to a sentinel that no
+    # real row carries — exactly one of the two is ever set.
+    __table_args__ = (
+        Index(
+            "uq_survey_answer_respondent_option",
+            "question_id",
+            "option_key",
+            text("COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid)"),
+            text("COALESCE(anonymous_user_hash, '')"),
+            unique=True,
+        ),
+    )
 
 
 class SurveyPromptLogBase(BaseDBModel):

--- a/utils/database/models/survey.py
+++ b/utils/database/models/survey.py
@@ -42,6 +42,10 @@ MAX_QUESTIONS_PER_PROMPT = 3
 # it would create are worthless either way.
 MAX_DISMISS_IDS = 50
 
+# Stands in for "no user" inside the COALESCE of the answer uniqueness index.
+# Shared between the model and its migration so the two cannot drift apart.
+NO_USER_SENTINEL = "00000000-0000-0000-0000-000000000000"
+
 QuestionLabel = Annotated[
     str, StringConstraints(strip_whitespace=True, min_length=1, max_length=300)
 ]
@@ -138,7 +142,9 @@ class SurveyAnswer(SurveyAnswerBase, table=True):
             "uq_survey_answer_respondent_option",
             "question_id",
             "option_key",
-            text("COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid)"),
+            text(
+                f"COALESCE(user_id, '{NO_USER_SENTINEL}'::uuid)"
+            ),
             text("COALESCE(anonymous_user_hash, '')"),
             unique=True,
         ),


### PR DESCRIPTION
Fixes from the review on #642:

- unique index so two concurrent submissions can't duplicate an answer row
- /survey/dismiss ignores unknown question ids instead of 500ing
- 409 with a clearer message when a label slugs to a key another question uses
- carry-over keeps the newer answer per question, as the comment always claimed
- utc_now() for updated_at in update_question and set_archived