### PR TITLE
Only export survey answers given under the current terms

### DIFF
--- a/tests/dataset/test_survey_consent.py
+++ b/tests/dataset/test_survey_consent.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for the consent gate on survey answers in the dataset export.
+
+Run with pytest, or directly:
+    uv run python tests/dataset/test_survey_consent.py
+
+No DB: the rule is tested as a pure function and the SQL it produces is
+inspected to confirm the consent gate (and the published/archived filters)
+are applied at the query.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("COMPARIA_DB_URI", "postgresql://x/y")
+os.environ.setdefault("LOG_FORMAT", "JSON")
+
+from utils.database.models import LEGACY_PARTICIPATION_TERMS_VERSION  # noqa: E402
+from utils.dataset import compute  # noqa: E402
+
+
+def test_current_terms_version_is_publishable():
+    assert compute.publishable_survey_terms_versions("2026.07") == {"2026.07"}
+
+
+def test_legacy_marker_is_not_publishable():
+    # "legacy-pre-versioning" is stamped when NO terms document was published:
+    # nothing was accepted, so nothing may be published.
+    assert (
+        LEGACY_PARTICIPATION_TERMS_VERSION
+        not in compute.publishable_survey_terms_versions("2026.07")
+    )
+
+
+def test_null_terms_version_is_not_publishable():
+    # Old rows predate version recording; no proof of consent, so exclude.
+    assert compute.publishable_survey_terms_versions(None) == set()
+
+
+def _compiled_sql(active_version: str | None) -> str:
+    statement = compute._survey_answers_query(
+        compute.publishable_survey_terms_versions(active_version)
+    )
+    return str(statement.compile(compile_kwargs={"literal_binds": True}))
+
+
+def test_query_filters_on_the_active_version():
+    sql = _compiled_sql("2026.07")
+    assert "terms_version IN ('2026.07')" in sql
+
+
+def test_query_excludes_null_and_legacy_versions():
+    sql = _compiled_sql("2026.07")
+    assert LEGACY_PARTICIPATION_TERMS_VERSION not in sql
+    # NULL terms_version can't match an IN list, so old rows are excluded too.
+
+
+def test_query_with_no_active_version_admits_nothing():
+    sql = _compiled_sql(None)
+    assert "terms_version IN (NULL)" in sql
+
+
+def test_query_still_excludes_unpublished_and_archived_questions():
+    sql = _compiled_sql("2026.07")
+    assert "published" in sql
+    assert "archived_at IS NULL" in sql
+
+
+if __name__ == "__main__":
+    test_current_terms_version_is_publishable()
+    test_legacy_marker_is_not_publishable()
+    test_null_terms_version_is_not_publishable()
+    test_query_filters_on_the_active_version()
+    test_query_excludes_null_and_legacy_versions()
+    test_query_with_no_active_version_admits_nothing()
+    test_query_still_excludes_unpublished_and_archived_questions()

--- a/utils/dataset/compute.py
+++ b/utils/dataset/compute.py
@@ -27,6 +27,7 @@ from sqlmodel import and_, col, select
 from backend.arena.web_search import merge_web_search_with_content
 from backend.config import settings
 from backend.llms.models import APILLMDataBase
+from backend.settings.legal import DEFAULT_LEGAL_LANGUAGE, get_active_legal_document
 from backend.vote_tags.services import get_all_vote_tags
 from utils.database.models import (
     LEGACY_PARTICIPATION_TERMS_VERSION,
@@ -86,6 +87,59 @@ def _respondent_key(
     return None
 
 
+def publishable_survey_terms_versions(active_version: str | None) -> set[str]:
+    """
+    The SurveyAnswer.terms_version values whose answers may be published in
+    the public dataset. This is THE place to edit when the terms are bumped:
+    add a version here only if its consent text covers research publication
+    of survey answers to the same extent as the current one.
+
+    - active published "terms" document version: IN. It is what
+      backend.auth.services.get_current_terms_acceptance_version() stamps on
+      every answer (see backend/survey/router.py), so it is the only version
+      whose text we know the respondent actually accepted.
+    - LEGACY_PARTICIPATION_TERMS_VERSION ("legacy-pre-versioning"): OUT.
+      get_current_terms_acceptance_version() returns that marker when NO terms
+      document is published at all, i.e. the respondent accepted nothing —
+      and backend/auth/services.py:erase_user_account explicitly notes survey
+      answers were never offered for publication under the research terms.
+    - NULL: OUT. Old rows predate version recording, so no proof of consent
+      exists; when unsure, do not publish.
+    - Any other (retired or unknown) version: OUT, for the same reason.
+
+    If nothing is currently published, nothing is publishable.
+    """
+    return {active_version} if active_version else set()
+
+
+def _survey_answers_query(publishable_versions: set[str]):
+    """
+    Published, non-archived questions joined to answers whose consent version
+    is publishable (see `publishable_survey_terms_versions`). The consent gate
+    lives here, in the WHERE clause: NULL (not matched by IN) and
+    legacy/retired versions never leave the database.
+    """
+    return (
+        select(
+            SurveyQuestion.key,
+            SurveyQuestion.input_type,
+            SurveyAnswer.user_id,
+            SurveyAnswer.anonymous_user_hash,
+            SurveyAnswer.option_key,
+        )
+        .join(
+            SurveyAnswer,
+            col(SurveyAnswer.question_id) == col(SurveyQuestion.id),
+        )
+        .where(
+            col(SurveyQuestion.published) == True,
+            col(SurveyQuestion.archived_at).is_(None),
+            col(SurveyAnswer.terms_version).in_(publishable_versions),
+        )
+        .order_by(col(SurveyAnswer.answered_at))
+    )
+
+
 @alru_cache
 async def get_survey_respondent_answers() -> dict[str, RespondentAnswers]:
     """
@@ -100,6 +154,10 @@ async def get_survey_respondent_answers() -> dict[str, RespondentAnswers]:
     their answers never enter the returned mapping and so never reach the
     dataset, regardless of what a Comparison's row later looks up.
 
+    Answers are also filtered on consent: only those recorded under a terms
+    version listed in `publishable_survey_terms_versions` (see that function
+    for which versions qualify and why) enter the dataset.
+
     Answers are stored replace-in-place (see
     utils/database/models/survey.py), so whatever is in the table now IS the
     respondent's current answer; there is no history to reconcile. Rows are
@@ -108,26 +166,11 @@ async def get_survey_respondent_answers() -> dict[str, RespondentAnswers]:
     most recently answered one wins deterministically.
     """
     async with get_session() as session:
-        rows = (
-            await session.exec(
-                select(
-                    SurveyQuestion.key,
-                    SurveyQuestion.input_type,
-                    SurveyAnswer.user_id,
-                    SurveyAnswer.anonymous_user_hash,
-                    SurveyAnswer.option_key,
-                )
-                .join(
-                    SurveyAnswer,
-                    col(SurveyAnswer.question_id) == col(SurveyQuestion.id),
-                )
-                .where(
-                    col(SurveyQuestion.published) == True,
-                    col(SurveyQuestion.archived_at).is_(None),
-                )
-                .order_by(col(SurveyAnswer.answered_at))
-            )
-        ).all()
+        active_terms = await get_active_legal_document("terms", DEFAULT_LEGAL_LANGUAGE)
+        publishable_versions = publishable_survey_terms_versions(
+            active_terms.version if active_terms else None
+        )
+        rows = (await session.exec(_survey_answers_query(publishable_versions))).all()
 
     answers: dict[str, RespondentAnswers] = {}
     for question_key, input_type, user_id, anonymous_user_hash, option_key in rows:


### PR DESCRIPTION
The export attached every survey answer to a respondent, whatever terms version it was accepted under. Now only answers recorded under the currently active published terms make it into the dataset; legacy and unversioned rows stay out.

Tests in `tests/dataset/test_survey_consent.py`.