### PR TITLE
fix(survey): keep answers on close and label blank selects

### DIFF
--- a/frontend/locales/messages/en.json
+++ b/frontend/locales/messages/en.json
@@ -2368,7 +2368,11 @@
             "description": "Your answers are optional, anonymous, and help us better understand who uses compar:IA.",
             "dismiss": "Later",
             "submit": "Send my answers",
+            "submitFailed": "Sending failed. Your answers were not saved, you can try again.",
             "title": "A few questions to get to know you"
+        },
+        "question": {
+            "chooseOption": "Select an option"
         },
         "profile": {
             "title": "Your survey answers",
@@ -2431,6 +2435,7 @@
         "reset": "Reset",
         "restart": "Start again",
         "retry": "Start again",
+        "save": "Save",
         "search": "Search",
         "send": "Send",
         "tooltip": "Tooltip",

--- a/frontend/locales/messages/fr.json
+++ b/frontend/locales/messages/fr.json
@@ -3264,7 +3264,11 @@
             "description": "Vos réponses sont facultatives, anonymes et nous aident à mieux comprendre qui utilise compar:IA.",
             "dismiss": "Plus tard",
             "submit": "Envoyer mes réponses",
+            "submitFailed": "L’envoi a échoué. Vos réponses n’ont pas été enregistrées, vous pouvez réessayer.",
             "title": "Quelques questions pour mieux vous connaître"
+        },
+        "question": {
+            "chooseOption": "Sélectionnez une option"
         },
         "profile": {
             "title": "Vos réponses au questionnaire",

--- a/frontend/src/lib/components/SignInForm.svelte
+++ b/frontend/src/lib/components/SignInForm.svelte
@@ -73,7 +73,7 @@
     }
   }
 
-  async function loadSurveyQuestions() {
+  async function loadSurveyQuestions(locale: string) {
     surveyLoading = true
     try {
       const data = await api.request<{ questions: SurveyQuestion[] }>(
@@ -91,7 +91,13 @@
 
   onMount(() => {
     readConsent()
-    loadSurveyQuestions()
+  })
+
+  // Re-fetch the questions when the language changes while the form is open:
+  // getLocale() is reactive, so tracking it here keeps the labels in step
+  // with the rest of the page.
+  $effect(() => {
+    void loadSurveyQuestions(getLocale())
   })
 
   $effect(() => {

--- a/frontend/src/lib/components/SignInForm.svelte.test.ts
+++ b/frontend/src/lib/components/SignInForm.svelte.test.ts
@@ -1,4 +1,5 @@
 import { resetConsent } from '$lib/consent'
+import { getTestLocale, setTestLocale } from '$lib/testing/reactive-locale.svelte'
 import { fireEvent, render, waitFor } from '@testing-library/svelte'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SignInForm from './SignInForm.svelte'
@@ -28,7 +29,7 @@ vi.mock('$lib/fastapi-client', () => ({
 
 vi.mock('$lib/i18n/runtime', async (importOriginal) => ({
   ...(await importOriginal<typeof import('$lib/i18n/runtime')>()),
-  getLocale: () => 'fr'
+  getLocale: () => getTestLocale()
 }))
 
 const terms = {
@@ -171,5 +172,59 @@ describe('SignInForm consent', () => {
 
     await waitFor(() => expect(container.querySelector('#login-consent')).not.toBeNull())
     expect(container.querySelector('#login-merge')).toBeNull()
+  })
+
+  it('re-fetches the signup questions when the language changes', async () => {
+    setTestLocale('fr')
+    const { unmount } = render(SignInForm)
+
+    await waitFor(() =>
+      expect(paths().filter((path) => path.startsWith('/survey/questions'))).toEqual([
+        '/survey/questions?trigger=signup&locale=fr'
+      ])
+    )
+
+    setTestLocale('en')
+    await waitFor(() =>
+      expect(paths().filter((path) => path.startsWith('/survey/questions'))).toEqual([
+        '/survey/questions?trigger=signup&locale=fr',
+        '/survey/questions?trigger=signup&locale=en'
+      ])
+    )
+    unmount()
+    setTestLocale('fr')
+  })
+
+  it('labels the blank entry of a required select question for everyone', async () => {
+    servesTerms()
+    mocks.request.mockImplementation((path: string) => {
+      if (path.startsWith('/settings/legal/terms')) return Promise.resolve(terms)
+      if (path === '/auth/consent/anonymous') return Promise.resolve({ terms: null })
+      if (path === '/survey/questions?trigger=signup&locale=fr')
+        return Promise.resolve({
+          questions: [
+            {
+              id: 'q1',
+              key: 'age',
+              required: true,
+              input_type: 'select',
+              label: 'Tranche d’âge',
+              revision: 1,
+              options: [{ key: '18_25', label: '18–25 ans' }]
+            }
+          ]
+        })
+      return Promise.reject(new Error(`Unexpected request: ${path}`))
+    })
+    const { container } = render(SignInForm)
+
+    const select = await waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>('#survey-question-q1')!
+      expect(element).not.toBeNull()
+      return element
+    })
+    expect(select.getAttribute('aria-required')).toBe('true')
+    const blankOption = select.querySelector<HTMLOptionElement>('option[value=""]')!
+    expect(blankOption.textContent).toBe('Sélectionnez une option')
   })
 })

--- a/frontend/src/lib/components/SurveyQuestionField.svelte
+++ b/frontend/src/lib/components/SurveyQuestionField.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { CheckboxGroup, Select } from '$components/dsfr'
+  import { m } from '$lib/i18n/messages'
 
   export type SurveyOption = { key: string; label: string }
   export type SurveyQuestion = {
@@ -39,8 +40,17 @@
   let selectedKey = $state(value[0] ?? '')
   let selectedKeys = $state<string[]>([...value])
 
+  // The blank first entry of a select needs a visible, spoken label: an empty
+  // one reads as a broken control. Required questions ask to be answered,
+  // optional ones offer the explicit way out.
+  const emptyOptionLabel = $derived(
+    placeholder ||
+      (question.required
+        ? m['survey.question.chooseOption']()
+        : m['survey.profile.noAnswerOption']())
+  )
   const selectOptions = $derived([
-    { value: '', label: placeholder },
+    { value: '', label: emptyOptionLabel },
     ...question.options.map((option) => ({ value: option.key, label: option.label }))
   ])
   const checkboxOptions = $derived(
@@ -67,6 +77,7 @@
     {label}
     onchange={onSelectChange}
     {disabled}
+    aria-required={question.required || undefined}
     class="mb-4!"
   />
 {:else}

--- a/frontend/src/lib/testing/reactive-locale.svelte.ts
+++ b/frontend/src/lib/testing/reactive-locale.svelte.ts
@@ -1,0 +1,11 @@
+// Test-only stand-in for the paraglide locale signal: lets tests flip the
+// locale reactively the way the real runtime does when the language changes.
+let locale = $state('fr')
+
+export function getTestLocale(): string {
+  return locale
+}
+
+export function setTestLocale(value: string): void {
+  locale = value
+}

--- a/frontend/src/routes/arene/components/SurveyModal.svelte
+++ b/frontend/src/routes/arene/components/SurveyModal.svelte
@@ -43,8 +43,12 @@
   // would burn one of the visitor's three chances to be asked again for
   // nothing.
   let handled = $state(false)
+  let submitFailed = $state(false)
 
-  async function recordShowing(): Promise<void> {
+  // One recording pass for the whole popup: whatever was selected goes to
+  // /survey/answers, whatever was left blank counts as shown-and-declined.
+  // Returns whether everything was recorded.
+  async function recordShowing(): Promise<boolean> {
     const answered = questions
       .map((question) => ({ question_id: question.id, option_keys: answers[question.id] ?? [] }))
       .filter((answer) => answer.option_keys.length > 0)
@@ -67,42 +71,40 @@
           body: JSON.stringify({ question_ids: blankIds })
         })
       }
+      submitFailed = false
+      return true
     } catch (error) {
-      // The popup already closed from the visitor's point of view; losing
-      // this one showing to a network blip isn't worth an error toast.
       console.error(`Unable to record survey response: ${(error as Error).message}`)
+      submitFailed = true
+      return false
     }
   }
 
-  async function declineAll(): Promise<void> {
-    try {
-      await api.request('/survey/dismiss', {
-        method: 'POST',
-        body: JSON.stringify({ question_ids: questions.map((question) => question.id) })
-      })
-    } catch (error) {
-      console.error(`Unable to record survey dismissal: ${(error as Error).message}`)
-    }
-  }
-
-  // Closing the popup and declining it are the same action on purpose: both
-  // paths lead here, and there is exactly one place that calls
-  // /survey/dismiss for every question that was on screen.
+  // Closing the popup without submitting is declining on purpose, but only
+  // for the questions left blank. Selections that exist are real answers and
+  // go through the same path as a submit; only blanks are recorded as
+  // dismissed. There is exactly one recording pass per popup, whichever of
+  // close or submit fires first.
   function onClose() {
     if (handled) return
     handled = true
-    void declineAll()
+    void recordShowing()
   }
 
   // Deliberately not wired to aria-controls: DSFR closes the modal on its own
   // click listener, and the close reaches onClose before this handler would
   // run, so onClose would win the `handled` race and throw the answers away.
-  // Record first, then close by flipping the attribute back.
-  function onSubmit() {
+  // Record first, then close by flipping the attribute back, and stay open
+  // with an error notice when recording fails, so nothing is lost silently.
+  async function onSubmit() {
     if (handled) return
     handled = true
-    void recordShowing()
-    opened = false
+    if (await recordShowing()) {
+      opened = false
+    } else {
+      // Let the visitor retry: the next submit or close records again.
+      handled = false
+    }
   }
 </script>
 
@@ -126,11 +128,14 @@
       {#each questions as question (question.id)}
         <SurveyQuestionField
           {question}
-          placeholder={m['survey.profile.noAnswerOption']()}
           onchange={(option_keys) => (answers[question.id] = option_keys)}
         />
       {/each}
     </div>
+
+    {#if submitFailed}
+      <p class="fr-error-text" role="alert">{m['survey.afterVote.submitFailed']()}</p>
+    {/if}
 
     <div class="gap-3 flex flex-wrap items-center justify-end">
       <Button

--- a/frontend/src/routes/arene/components/SurveyModal.svelte.test.ts
+++ b/frontend/src/routes/arene/components/SurveyModal.svelte.test.ts
@@ -1,0 +1,109 @@
+import { fireEvent, render, waitFor } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SurveyModal from './SurveyModal.svelte'
+
+const mocks = vi.hoisted(() => ({
+  request: vi.fn(),
+  questions: [] as Array<Record<string, unknown>>
+}))
+
+vi.mock('$lib/fastapi-client', () => ({
+  api: { request: mocks.request }
+}))
+
+vi.mock('$lib/survey', () => ({
+  getSurveyQuestionsContext: () => mocks.questions,
+  hasShownSurveyThisSession: () => false,
+  markSurveyShownThisSession: vi.fn()
+}))
+
+const question = (id: string) => ({
+  id,
+  key: `q-${id}`,
+  required: false,
+  input_type: 'select',
+  label: `Question ${id}`,
+  revision: 1,
+  options: [
+    { key: `${id}-a`, label: 'Option A' },
+    { key: `${id}-b`, label: 'Option B' }
+  ]
+})
+
+const paths = () => mocks.request.mock.calls.map(([path]) => path)
+
+// The DSFR script is what discloses and conceals the dialog in the browser;
+// in tests a conceal event stands in for Escape, the backdrop or the close
+// button, all of which reach onClose the same way.
+function conceal(container: HTMLElement) {
+  fireEvent(container.querySelector('dialog')!, new Event('dsfr.conceal', { bubbles: true }))
+}
+
+async function openModal() {
+  const result = render(SurveyModal)
+  // The popup waits four seconds after mounting before it lands.
+  await waitFor(() => expect(result.container.querySelector('dialog')).not.toBeNull(), {
+    timeout: 6000
+  })
+  return result
+}
+
+describe('SurveyModal recording', () => {
+  beforeEach(() => {
+    mocks.questions = [question('q1'), question('q2')]
+    mocks.request.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    mocks.questions = []
+  })
+
+  it('submits selections and only dismisses blanks when closed without submitting', async () => {
+    const { container } = await openModal()
+
+    const first = container.querySelector<HTMLSelectElement>('#survey-question-q1')!
+    await fireEvent.change(first, { target: { value: 'q1-b' } })
+    conceal(container)
+
+    await waitFor(() => expect(paths()).toContain('/survey/answers'))
+    const answersCall = mocks.request.mock.calls.find(([path]) => path === '/survey/answers')
+    expect(JSON.parse((answersCall![1] as RequestInit).body as string)).toEqual({
+      answers: [{ question_id: 'q1', option_keys: ['q1-b'] }]
+    })
+    const dismissCall = mocks.request.mock.calls.find(([path]) => path === '/survey/dismiss')
+    expect(JSON.parse((dismissCall![1] as RequestInit).body as string)).toEqual({
+      question_ids: ['q2']
+    })
+
+    // One recording pass total even if close fires again.
+    conceal(container)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(paths().filter((path) => path === '/survey/dismiss')).toHaveLength(1)
+  }, 10000)
+
+  it('keeps the popup open with an error notice when submit fails, then retries', async () => {
+    const { container } = await openModal()
+
+    mocks.request.mockImplementation((path: string) =>
+      path === '/survey/dismiss' ? Promise.resolve(undefined) : Promise.reject(new Error('offline'))
+    )
+
+    const first = container.querySelector<HTMLSelectElement>('#survey-question-q1')!
+    await fireEvent.change(first, { target: { value: 'q1-b' } })
+
+    const submit = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+      (button) => button.textContent?.trim() === 'Envoyer mes réponses'
+    )!
+    await fireEvent.click(submit)
+    await waitFor(() => expect(container.querySelector('[role="alert"]')).not.toBeNull())
+    // Still open for another try.
+    expect(container.querySelector('dialog')).not.toBeNull()
+    expect(paths()).not.toContain('/survey/dismiss')
+
+    mocks.request.mockResolvedValue(undefined)
+    await fireEvent.click(submit)
+    await waitFor(() => expect(paths()).toContain('/survey/answers'))
+    expect(paths()).toContain('/survey/dismiss')
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  }, 10000)
+})


### PR DESCRIPTION
A few fixes found while going over the survey popup and signup form.

Closing the after-vote popup used to dismiss every question, wiping answers the visitor had already picked. It now submits selections like a normal submit and only records the blank questions as dismissed. A failed submit also keeps the popup open with an error notice instead of losing everything silently.

On the signup form, required select questions opened on a visually empty entry; the blank option now says "Sélectionnez une option" (and optional ones keep the explicit no-answer choice). The form also re-fetches its questions when the language changes while it's open, and words.save is back in en.json.