### PR TITLE
Personalize authentication email templates

### DIFF
--- a/backend/admin/router.py
+++ b/backend/admin/router.py
@@ -350,7 +350,14 @@ async def invite_user(
 ) -> None:
     token = await create_invite(body.email, invited_by=current_user.id)
     link = f"{settings.COMPARIA_APP_URL}/invite/{token}"
-    await send_invite_link(body.email, link)
+    app_settings = await get_app_settings()
+    await send_invite_link(
+        body.email,
+        link,
+        platform_name=app_settings.platform_name,
+        primary_color=app_settings.primary_color_light,
+        secondary_color=app_settings.secondary_color_light,
+    )
 
 
 @router.delete("/users/{user_id}/invite", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/auth/email.py
+++ b/backend/auth/email.py
@@ -1,45 +1,86 @@
 import asyncio
 import logging
+import re
 import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+from email.message import EmailMessage
+from html import escape
 
 from backend.config import settings
 
 logger = logging.getLogger("languia")
 
-_HTML_TEMPLATE = """\
+_HEX_COLOR_PATTERN = re.compile(r"#[0-9A-Fa-f]{6}\Z")
+_DEFAULT_PLATFORM_NAME = "Compar:IA"
+_DEFAULT_PRIMARY_COLOR = "#6464F3"
+_DEFAULT_SECONDARY_COLOR = "#FF9575"
+
+_EMAIL_SHELL = """\
 <!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"></head>
-<body style="font-family: arial, helvetica, sans-serif; color: #3b3f44; font-size: 16px; line-height: 1.5; max-width: 600px; margin: 0 auto; padding: 20px;">
-  <p>Bonjour,</p>
-  <p>Voici votre code de connexion à ComparIA&nbsp;:</p>
-  <p style="font-size: 32px; font-weight: bold; letter-spacing: 8px; text-align: center; padding: 20px 0;">{code}</p>
-  <p>Ce code est valable 10&nbsp;minutes. Si vous n'avez pas demandé à vous connecter, ignorez cet email.</p>
-  <p>L'équipe ComparIA</p>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title}</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: {canvas_color}; color: #161616; font-family: Marianne, Arial, Helvetica, sans-serif; font-size: 16px; line-height: 1.5;">
+  <div style="display: none; max-height: 0; overflow: hidden; opacity: 0; color: transparent;">{preheader}</div>
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="width: 100%; background-color: {canvas_color};">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" width="600" cellspacing="0" cellpadding="0" border="0" style="width: 100%; max-width: 600px; background-color: #ffffff; border-top: 6px solid {secondary_color};">
+          <tr>
+            <td style="padding: 28px 32px 20px; border-bottom: 1px solid #dddddd;">
+              <p style="margin: 0; color: {primary_color}; font-size: 24px; font-weight: 700; line-height: 1.2;">{platform_name}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 32px;">
+              {content}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 20px 32px; background-color: #eeeeee; color: #666666; font-size: 13px;">
+              <p style="margin: 0;">Message automatique envoyé par {platform_name}.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
 </body>
 </html>
 """
 
-_INVITE_HTML_TEMPLATE = """\
-<!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"></head>
-<body style="font-family: arial, helvetica, sans-serif; color: #3b3f44; font-size: 16px; line-height: 1.5; max-width: 600px; margin: 0 auto; padding: 20px;">
-  <p>Bonjour,</p>
-  <p>Vous avez été invité·e sur ComparIA&nbsp;:</p>
-  <p style="text-align: center; padding: 20px 0;">
-    <a href="{link}" style="background: #000091; color: #fff; text-decoration: none; padding: 12px 24px; border-radius: 4px; display: inline-block;">Rejoindre ComparIA</a>
-  </p>
-  <p>Ce lien est valable 24&nbsp;heures. Si vous n'êtes pas à l'origine de cette invitation, ignorez cet email.</p>
-  <p>L'équipe ComparIA</p>
-</body>
-</html>
+_LOGIN_CONTENT = """\
+<h1 style="margin: 0 0 20px; font-size: 28px; line-height: 1.25;">Votre code de connexion</h1>
+<p style="margin: 0 0 20px;">Bonjour,</p>
+<p style="margin: 0 0 24px;">Saisissez ce code sur {platform_name} pour terminer votre connexion&nbsp;:</p>
+<p style="margin: 0 0 24px; padding: 18px 12px; background-color: {primary_color}; color: #ffffff; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 32px; font-weight: 700; letter-spacing: 8px; line-height: 1.2; text-align: center;">{code}</p>
+<p style="margin: 0 0 12px;"><strong>Ce code expire dans 10&nbsp;minutes.</strong></p>
+<p style="margin: 0; color: #666666; font-size: 14px;">Vous n’avez pas demandé ce code&nbsp;? Vous pouvez ignorer ce message. Ne transmettez jamais ce code à une autre personne.</p>
+"""
+
+_INVITE_CONTENT = """\
+<h1 style="margin: 0 0 20px; font-size: 28px; line-height: 1.25;">Vous êtes invité·e sur {platform_name}</h1>
+<p style="margin: 0 0 20px;">Bonjour,</p>
+<p style="margin: 0 0 24px;">Une personne vous invite à rejoindre l’espace d’administration de {platform_name}.</p>
+<p style="margin: 0 0 24px;">
+  <a href="{link}" style="display: inline-block; padding: 12px 20px; background-color: {primary_color}; color: #ffffff; font-weight: 700; text-decoration: underline;">Accepter l’invitation</a>
+</p>
+<p style="margin: 0 0 12px;"><strong>Cette invitation expire dans 24&nbsp;heures.</strong></p>
+<p style="margin: 0 0 8px; color: #666666; font-size: 14px;">Si le bouton ne fonctionne pas, copiez cette adresse dans votre navigateur&nbsp;:</p>
+<p style="margin: 0 0 20px; overflow-wrap: anywhere; font-size: 14px;"><a href="{link}" style="color: {primary_color}; text-decoration: underline;">{link_text}</a></p>
+<p style="margin: 0; color: #666666; font-size: 14px;">Vous n’attendiez pas cette invitation&nbsp;? Vous pouvez ignorer ce message.</p>
 """
 
 
-async def send_login_code(to_email: str, code: str) -> None:
+async def send_login_code(
+    to_email: str,
+    code: str,
+    platform_name: str = _DEFAULT_PLATFORM_NAME,
+    primary_color: str = _DEFAULT_PRIMARY_COLOR,
+    secondary_color: str = _DEFAULT_SECONDARY_COLOR,
+) -> None:
     if not settings.SMTP_HOST:
         # The code signs someone in on its own, so it belongs in the logs only
         # when a developer is reading them in place of a mailbox.
@@ -48,10 +89,22 @@ async def send_login_code(to_email: str, code: str) -> None:
         else:
             logger.error(f"[AUTH] SMTP is not configured, no code sent to {to_email}")
         return
-    await asyncio.to_thread(_send_smtp, to_email, code)
+    message = _build_login_message(
+        code,
+        platform_name=platform_name,
+        primary_color=primary_color,
+        secondary_color=secondary_color,
+    )
+    await asyncio.to_thread(_send_message, to_email, message)
 
 
-async def send_invite_link(to_email: str, link: str) -> None:
+async def send_invite_link(
+    to_email: str,
+    link: str,
+    platform_name: str = _DEFAULT_PLATFORM_NAME,
+    primary_color: str = _DEFAULT_PRIMARY_COLOR,
+    secondary_color: str = _DEFAULT_SECONDARY_COLOR,
+) -> None:
     if not settings.SMTP_HOST:
         # The link carries the invite token, which is a credential too.
         if settings.LANGUIA_DEBUG:
@@ -59,34 +112,126 @@ async def send_invite_link(to_email: str, link: str) -> None:
         else:
             logger.error(f"[AUTH] SMTP is not configured, no invite sent to {to_email}")
         return
-    await asyncio.to_thread(_send_invite_smtp, to_email, link)
+    message = _build_invite_message(
+        link,
+        platform_name=platform_name,
+        primary_color=primary_color,
+        secondary_color=secondary_color,
+    )
+    await asyncio.to_thread(_send_message, to_email, message)
 
 
-def _send_smtp(to_email: str, code: str) -> None:
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = "Votre code de connexion ComparIA"
-    msg["From"] = f"{settings.EMAIL_FROM_NAME} <{settings.EMAIL_FROM}>"
-    msg["To"] = to_email
-    msg.attach(MIMEText(_HTML_TEMPLATE.format(code=code), "html", "utf-8"))
+def _build_login_message(
+    code: str,
+    platform_name: str = _DEFAULT_PLATFORM_NAME,
+    primary_color: str = _DEFAULT_PRIMARY_COLOR,
+    secondary_color: str = _DEFAULT_SECONDARY_COLOR,
+) -> EmailMessage:
+    primary_color, secondary_color, canvas_color = _email_colors(
+        primary_color, secondary_color
+    )
+    platform_name = _safe_platform_name(platform_name)
+    safe_platform_name = escape(platform_name)
+    safe_code = escape(code)
+    html = _EMAIL_SHELL.format(
+        title=f"Votre code de connexion — {safe_platform_name}",
+        preheader=f"Votre code de connexion à {safe_platform_name} expire dans 10 minutes.",
+        platform_name=safe_platform_name,
+        primary_color=primary_color,
+        secondary_color=secondary_color,
+        canvas_color=canvas_color,
+        content=_LOGIN_CONTENT.format(
+            code=safe_code,
+            platform_name=safe_platform_name,
+            primary_color=primary_color,
+        ),
+    )
+    text = (
+        f"Votre code de connexion — {platform_name}\n\n"
+        f"Votre code : {code}\n\n"
+        "Ce code expire dans 10 minutes.\n"
+        "Vous n’avez pas demandé ce code ? Ignorez ce message et ne transmettez "
+        "jamais ce code à une autre personne."
+    )
+    return _build_message(f"Votre code de connexion — {platform_name}", text, html)
 
-    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as smtp:
+
+def _build_invite_message(
+    link: str,
+    platform_name: str = _DEFAULT_PLATFORM_NAME,
+    primary_color: str = _DEFAULT_PRIMARY_COLOR,
+    secondary_color: str = _DEFAULT_SECONDARY_COLOR,
+) -> EmailMessage:
+    primary_color, secondary_color, canvas_color = _email_colors(
+        primary_color, secondary_color
+    )
+    platform_name = _safe_platform_name(platform_name)
+    safe_platform_name = escape(platform_name)
+    safe_link = escape(link, quote=True)
+    html = _EMAIL_SHELL.format(
+        title=f"Invitation à rejoindre {safe_platform_name}",
+        preheader=f"Vous êtes invité·e à rejoindre l’espace d’administration de {safe_platform_name}.",
+        platform_name=safe_platform_name,
+        primary_color=primary_color,
+        secondary_color=secondary_color,
+        canvas_color=canvas_color,
+        content=_INVITE_CONTENT.format(
+            link=safe_link,
+            link_text=escape(link),
+            platform_name=safe_platform_name,
+            primary_color=primary_color,
+        ),
+    )
+    text = (
+        f"Vous êtes invité·e sur {platform_name}\n\n"
+        f"Une personne vous invite à rejoindre l’espace d’administration de {platform_name}.\n\n"
+        f"Accepter l’invitation : {link}\n\n"
+        "Cette invitation expire dans 24 heures.\n"
+        "Vous n’attendiez pas cette invitation ? Ignorez ce message."
+    )
+    return _build_message(f"Vous êtes invité·e sur {platform_name}", text, html)
+
+
+def _email_colors(primary_color: str, secondary_color: str) -> tuple[str, str, str]:
+    primary = _safe_color(primary_color, _DEFAULT_PRIMARY_COLOR)
+    secondary = _safe_color(secondary_color, _DEFAULT_SECONDARY_COLOR)
+    return primary, secondary, _tint(secondary, white_ratio=0.92)
+
+
+def _safe_color(color: str, fallback: str) -> str:
+    return color.upper() if _HEX_COLOR_PATTERN.fullmatch(color) else fallback
+
+
+def _safe_platform_name(platform_name: str) -> str:
+    return " ".join(platform_name.split()) or _DEFAULT_PLATFORM_NAME
+
+
+def _tint(color: str, white_ratio: float) -> str:
+    channels = [int(color[index : index + 2], 16) for index in (1, 3, 5)]
+    tinted = [
+        round(channel * (1 - white_ratio) + 255 * white_ratio) for channel in channels
+    ]
+    return "#" + "".join(f"{channel:02X}" for channel in tinted)
+
+
+def _build_message(subject: str, text: str, html: str) -> EmailMessage:
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = f"{settings.EMAIL_FROM_NAME} <{settings.EMAIL_FROM}>"
+    message.set_content(text)
+    message.add_alternative(html, subtype="html")
+    return message
+
+
+def _send_message(to_email: str, message: EmailMessage) -> None:
+    smtp_host = settings.SMTP_HOST
+    if smtp_host is None:
+        raise RuntimeError("SMTP host is required to send an email")
+
+    message["To"] = to_email
+    with smtplib.SMTP(smtp_host, settings.SMTP_PORT) as smtp:
         if settings.SMTP_STARTTLS:
             smtp.starttls()
         if settings.SMTP_USERNAME and settings.SMTP_PASSWORD:
             smtp.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
-        smtp.sendmail(settings.EMAIL_FROM, to_email, msg.as_string())
-
-
-def _send_invite_smtp(to_email: str, link: str) -> None:
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = "Vous avez été invité·e sur ComparIA"
-    msg["From"] = f"{settings.EMAIL_FROM_NAME} <{settings.EMAIL_FROM}>"
-    msg["To"] = to_email
-    msg.attach(MIMEText(_INVITE_HTML_TEMPLATE.format(link=link), "html", "utf-8"))
-
-    with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as smtp:
-        if settings.SMTP_STARTTLS:
-            smtp.starttls()
-        if settings.SMTP_USERNAME and settings.SMTP_PASSWORD:
-            smtp.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
-        smtp.sendmail(settings.EMAIL_FROM, to_email, msg.as_string())
+        smtp.send_message(message, from_addr=settings.EMAIL_FROM, to_addrs=[to_email])

--- a/backend/auth/router.py
+++ b/backend/auth/router.py
@@ -248,7 +248,13 @@ async def email_request(body: EmailRequestBody, request: Request) -> None:
 
     code = await request_login_code(body.email)
     try:
-        await send_login_code(body.email, code)
+        await send_login_code(
+            body.email,
+            code,
+            platform_name=app_settings.platform_name,
+            primary_color=app_settings.primary_color_light,
+            secondary_color=app_settings.secondary_color_light,
+        )
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/tests/arena/test_auth_ratelimit.py
+++ b/tests/arena/test_auth_ratelimit.py
@@ -54,12 +54,17 @@ async def _fake_request_login_code(email):
     return "123456"
 
 
-async def _fake_send_login_code(email, code):
+async def _fake_send_login_code(email, code, **_colors):
     pass
 
 
 async def _fake_get_app_settings():
-    return SimpleNamespace(auth_domain_allowlist=None)
+    return SimpleNamespace(
+        auth_domain_allowlist=None,
+        platform_name="Compar:IA",
+        primary_color_light="#6464F3",
+        secondary_color_light="#FF9575",
+    )
 
 
 async def _fake_current_acceptance(**kwargs):

--- a/tests/auth/test_consent.py
+++ b/tests/auth/test_consent.py
@@ -144,7 +144,12 @@ def routed(**overrides):
     """Serve the router with the plumbing every login route needs stubbed out."""
 
     async def app_settings():
-        return SimpleNamespace(auth_domain_allowlist=[])
+        return SimpleNamespace(
+            auth_domain_allowlist=[],
+            platform_name="Compar:IA",
+            primary_color_light="#6464F3",
+            secondary_color_light="#FF9575",
+        )
 
     with patched(
         auth_router,
@@ -480,7 +485,7 @@ def test_login_code_is_not_blocked_when_nothing_is_published():
     async def request_login_code(_email):
         return "123456"
 
-    async def send_login_code(email, _code):
+    async def send_login_code(email, _code, **_colors):
         sent.append(email)
 
     with (

--- a/tests/auth/test_email.py
+++ b/tests/auth/test_email.py
@@ -1,0 +1,106 @@
+from backend.auth.email import _build_invite_message, _build_login_message
+
+
+def _parts(message):
+    return {
+        part.get_content_type(): part.get_content()
+        for part in message.walk()
+        if not part.is_multipart()
+    }
+
+
+def test_login_message_has_plain_text_and_accessible_html():
+    message = _build_login_message("123456")
+    parts = _parts(message)
+
+    assert message["Subject"] == "Votre code de connexion — Compar:IA"
+    assert "123456" in parts["text/plain"]
+    assert '<html lang="fr">' in parts["text/html"]
+    assert "Ce code expire dans 10&nbsp;minutes" in parts["text/html"]
+    assert 'role="presentation"' in parts["text/html"]
+
+
+def test_login_message_escapes_code_in_html():
+    html = _parts(_build_login_message("<123&456>"))["text/html"]
+
+    assert "&lt;123&amp;456&gt;" in html
+    assert "<123&456>" not in html
+
+
+def test_invite_message_has_fallback_link_in_both_parts():
+    link = "https://comparia.example/invite/example-token"
+    parts = _parts(_build_invite_message(link))
+
+    assert link in parts["text/plain"]
+    assert parts["text/html"].count(link) == 3
+    assert "Cette invitation expire dans 24&nbsp;heures" in parts["text/html"]
+
+
+def test_invite_message_escapes_link_attributes():
+    html = _parts(
+        _build_invite_message('https://comparia.example/invite?value="unsafe"&next=1')
+    )["text/html"]
+
+    assert "&quot;unsafe&quot;&amp;next=1" in html
+    assert 'value="unsafe"' not in html
+
+
+def test_login_message_uses_configured_platform_colors():
+    html = _parts(
+        _build_login_message(
+            "123456", primary_color="#123456", secondary_color="#ABCDEF"
+        )
+    )["text/html"]
+
+    assert "background-color: #123456" in html
+    assert "color: #123456" in html
+    assert "border-top: 6px solid #ABCDEF" in html
+    assert "background-color: #F8FBFE" in html
+
+
+def test_invite_message_rejects_unsafe_custom_colors():
+    html = _parts(
+        _build_invite_message(
+            "https://comparia.example/invite/example-token",
+            primary_color="red; display: none",
+            secondary_color="not-a-color",
+        )
+    )["text/html"]
+
+    assert "red; display: none" not in html
+    assert "not-a-color" not in html
+    assert "background-color: #6464F3" in html
+    assert "border-top: 6px solid #FF9575" in html
+
+
+def test_messages_use_the_configured_platform_name_without_fixed_subtitle():
+    platform_name = "Arène & Compagnie"
+    login = _build_login_message("123456", platform_name=platform_name)
+    invite = _build_invite_message(
+        "https://comparia.example/invite/example-token", platform_name=platform_name
+    )
+    login_parts = _parts(login)
+    invite_parts = _parts(invite)
+
+    assert login["Subject"] == "Votre code de connexion — Arène & Compagnie"
+    assert invite["Subject"] == "Vous êtes invité·e sur Arène & Compagnie"
+    assert "Arène &amp; Compagnie" in login_parts["text/html"]
+    assert "Arène &amp; Compagnie" in invite_parts["text/html"]
+    assert platform_name in login_parts["text/plain"]
+    assert platform_name in invite_parts["text/plain"]
+    assert (
+        "Comparez les modèles d’intelligence artificielle"
+        not in login_parts["text/html"]
+    )
+    assert "service numérique de l’État" not in login_parts["text/html"]
+
+
+def test_platform_name_cannot_inject_email_headers_or_html():
+    message = _build_login_message(
+        "123456", platform_name="Test\nBcc: attacker@example.test <script>"
+    )
+    html = _parts(message)["text/html"]
+
+    assert "\n" not in str(message["Subject"])
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html


### PR DESCRIPTION
## Why are these changes needed?

The authentication emails used fixed Compar:IA branding and minimal HTML, which did not adapt to customized deployments.

This change:

- refreshes the login-code and invitation email layouts;
- uses each platform’s configured name, primary color, and secondary color;
- keeps the wording deployment-neutral;
- adds accessible HTML structure and plain-text alternatives;
- escapes dynamic values and provides a visible fallback invitation link;
- adds focused tests for content, customization, accessibility, and escaping.

## Related issue number (if applicable)

N/A

## Checks

- [x] Backend test suite passes (340 passed, 15 skipped).
- [x] Python formatting and type checking pass for the updated email module.
- [x] Relevant test coverage is included.