### PR TITLE
Fix LLM form links and prompt validation

### DIFF
--- a/frontend/src/lib/components/form/FormFieldsetList.svelte
+++ b/frontend/src/lib/components/form/FormFieldsetList.svelte
@@ -10,15 +10,14 @@
   import type { AnyFormItemProps, BaseFormFieldProps } from '$lib/utils/form'
   import { FormFieldset } from '.'
 
-  let { value = $bindable(), disabled, subProps, ...props }: FormFieldsetListProps = $props()
+  let { value = $bindable([]), disabled, subProps, ...props }: FormFieldsetListProps = $props()
 
   const subIsFieldsetItem = $derived(subProps.component === 'fieldset-item')
   function onAdd() {
-    // FIXME
-    value.push(subIsFieldsetItem ? {} : '')
+    value = [...value, subIsFieldsetItem ? {} : '']
   }
   function onDelete(index: number) {
-    value.splice(index, 1)
+    value = value.filter((_, i) => i !== index)
   }
 </script>
 
@@ -42,6 +41,7 @@
             text="delete"
             icon="delete-line"
             iconOnly
+            type="button"
             {disabled}
             onclick={() => onDelete(i)}
             class={subIsFieldsetItem ? 'self-center!' : 'self-end!'}
@@ -49,7 +49,7 @@
         </div>
       {/each}
     </div>
-    <Button text="add" icon="add-line" iconOnly {disabled} onclick={onAdd} />
+    <Button text="add" icon="add-line" iconOnly type="button" {disabled} onclick={onAdd} />
   {/snippet}
 </FormFieldset>
 

--- a/frontend/src/lib/components/form/FormFieldsetList.svelte.test.ts
+++ b/frontend/src/lib/components/form/FormFieldsetList.svelte.test.ts
@@ -1,0 +1,32 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import FormFieldsetList from './FormFieldsetList.svelte'
+
+describe('FormFieldsetList', () => {
+  it('adds a new item and keeps the add control out of form submission', async () => {
+    const { container, getByRole } = render(FormFieldsetList, {
+      props: {
+        id: 'links',
+        label: 'Links',
+        value: [],
+        component: 'fieldset-list',
+        subProps: {
+          id: 'link',
+          label: 'Link',
+          value: '',
+          component: 'input',
+          type: 'url',
+          placeholder: ''
+        }
+      }
+    })
+
+    const addButton = getByRole('button', { name: 'add' })
+    expect(addButton).toHaveAttribute('type', 'button')
+    expect(container.querySelectorAll('input')).toHaveLength(0)
+
+    await fireEvent.click(addButton)
+
+    expect(container.querySelectorAll('input')).toHaveLength(1)
+  })
+})

--- a/tests/database/test_llm_form_schema.py
+++ b/tests/database/test_llm_form_schema.py
@@ -1,0 +1,9 @@
+from utils.database.models.llms.llm import LLMDataUpsert
+from utils.utils import FormJsonSchema
+
+
+def test_system_prompt_is_optional_in_the_admin_form_schema():
+    schema = LLMDataUpsert.model_json_schema(schema_generator=FormJsonSchema)
+
+    assert "system_prompt" not in schema["required"]
+    assert schema["properties"]["system_prompt"]["optional"] is True

--- a/utils/database/models/llms/llm.py
+++ b/utils/database/models/llms/llm.py
@@ -139,7 +139,9 @@ class LLMDataBase(BaseDBModel):
     ]
     price_in: Annotated[float, Field(**FIELDS["price_in"])]
     price_out: Annotated[float, Field(**FIELDS["price_out"])]
-    system_prompt: Annotated[NonEmptyStr | None, Field(**FIELDS["system_prompt"])]
+    system_prompt: Annotated[
+        NonEmptyStr | None, Field(default=None, **FIELDS["system_prompt"])
+    ]
     links: Annotated[
         list[Link],
         Field(sa_type=JSONB, **FIELDS["links"]),


### PR DESCRIPTION
Fixes LLM creation by making link fields reactive and keeps system prompt optional.\n\nTests: frontend regression test and backend schema test.