### PR TITLE
Fix: make every optional LLM field optional to the API

### DIFF
--- a/frontend/src/lib/components/form/FormFieldsetList.svelte
+++ b/frontend/src/lib/components/form/FormFieldsetList.svelte
@@ -1,7 +1,10 @@
 <script module lang="ts">
   export type FormFieldsetListProps = {
     subProps: AnyFormItemProps
-  } & BaseFormFieldProps<'fieldset-list', any[]>
+    // The admin form only holds the keys the user touched, so the list may
+    // render before its own key exists.
+    value?: any[]
+  } & Omit<BaseFormFieldProps<'fieldset-list', any[]>, 'value'>
 </script>
 
 <script lang="ts">
@@ -41,7 +44,6 @@
             text="delete"
             icon="delete-line"
             iconOnly
-            type="button"
             {disabled}
             onclick={() => onDelete(i)}
             class={subIsFieldsetItem ? 'self-center!' : 'self-end!'}
@@ -49,7 +51,7 @@
         </div>
       {/each}
     </div>
-    <Button text="add" icon="add-line" iconOnly type="button" {disabled} onclick={onAdd} />
+    <Button text="add" icon="add-line" iconOnly {disabled} onclick={onAdd} />
   {/snippet}
 </FormFieldset>
 

--- a/frontend/src/lib/components/form/FormFieldsetList.svelte.test.ts
+++ b/frontend/src/lib/components/form/FormFieldsetList.svelte.test.ts
@@ -1,32 +1,56 @@
+import type { AnyFormItemProps } from '$lib/utils/form'
 import { fireEvent, render } from '@testing-library/svelte'
 import { describe, expect, it } from 'vitest'
 import FormFieldsetList from './FormFieldsetList.svelte'
 
+const linkSubProps: AnyFormItemProps = {
+  id: 'link',
+  label: 'Link',
+  value: {},
+  component: 'fieldset-item',
+  subProps: [
+    { id: 'text', label: 'Text', value: '', component: 'input', type: 'text', placeholder: '' },
+    { id: 'url', label: 'Url', value: '', component: 'input', type: 'url', placeholder: '' }
+  ]
+}
+
+const textSubProps: AnyFormItemProps = {
+  id: 'tag',
+  label: 'Tag',
+  value: '',
+  component: 'input',
+  type: 'text',
+  placeholder: ''
+}
+
 describe('FormFieldsetList', () => {
-  it('adds a new item and keeps the add control out of form submission', async () => {
+  it('adds an item when the parent holds no value yet', async () => {
+    // The admin form starts empty on create, so value arrives undefined.
     const { container, getByRole } = render(FormFieldsetList, {
+      props: { id: 'links', label: 'Links', component: 'fieldset-list', subProps: linkSubProps }
+    })
+
+    expect(container.querySelectorAll('input')).toHaveLength(0)
+
+    await fireEvent.click(getByRole('button', { name: 'add' }))
+
+    expect(container.querySelectorAll('input')).toHaveLength(2)
+  })
+
+  it('removes the item at the clicked index', async () => {
+    const { container, getAllByRole } = render(FormFieldsetList, {
       props: {
-        id: 'links',
-        label: 'Links',
-        value: [],
+        id: 'tags',
+        label: 'Tags',
+        value: ['a', 'b', 'c'],
         component: 'fieldset-list',
-        subProps: {
-          id: 'link',
-          label: 'Link',
-          value: '',
-          component: 'input',
-          type: 'url',
-          placeholder: ''
-        }
+        subProps: textSubProps
       }
     })
 
-    const addButton = getByRole('button', { name: 'add' })
-    expect(addButton).toHaveAttribute('type', 'button')
-    expect(container.querySelectorAll('input')).toHaveLength(0)
+    await fireEvent.click(getAllByRole('button', { name: 'delete' })[1])
 
-    await fireEvent.click(addButton)
-
-    expect(container.querySelectorAll('input')).toHaveLength(1)
+    const values = [...container.querySelectorAll('input')].map((i) => i.value)
+    expect(values).toEqual(['a', 'c'])
   })
 })

--- a/tests/database/test_llm_form_schema.py
+++ b/tests/database/test_llm_form_schema.py
@@ -1,9 +1,72 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
 from utils.database.models.llms.llm import LLMDataUpsert
 from utils.utils import FormJsonSchema
 
 
-def test_system_prompt_is_optional_in_the_admin_form_schema():
-    schema = LLMDataUpsert.model_json_schema(schema_generator=FormJsonSchema)
+def payload(**overrides):
+    return {
+        "status": "enabled",
+        "name": "Test LLM",
+        "human_id": "test-llm",
+        "api_model_id": "test-llm",
+        "endpoint_id": uuid4(),
+        "rate_limited": False,
+        "lab_id": uuid4(),
+        "release_date": datetime(2026, 1, 1),
+        "license_id": uuid4(),
+        "public_weights": True,
+        "public_training_data": False,
+        "public_training_code": False,
+        "eu_hostable": True,
+        "arch": "dense",
+        "params": 7.0,
+        "inputs": ["text"],
+        "price_in": 1.0,
+        "price_out": 2.0,
+        **overrides,
+    }
 
-    assert "system_prompt" not in schema["required"]
-    assert schema["properties"]["system_prompt"]["optional"] is True
+
+def test_fields_the_form_shows_as_optional_are_not_required_by_the_api():
+    """
+    The admin form only sends the fields the user touched, so a field it draws
+    as optional must have a default, or creating an LLM fails with 422.
+    """
+    schema = LLMDataUpsert.model_json_schema(schema_generator=FormJsonSchema)
+    optional = {k for k, v in schema["properties"].items() if v.get("optional")}
+
+    assert optional
+    assert optional & set(schema["required"]) == set()
+
+
+def test_an_llm_can_be_created_without_the_optional_fields():
+    llm = LLMDataUpsert(
+        **{
+            k: v
+            for k, v in payload().items()
+            if k not in ("api_model_id", "endpoint_id")
+        }
+    )
+
+    assert llm.system_prompt is None
+    assert llm.active_params is None
+    assert llm.context_tokens is None
+    assert llm.quantization is None
+
+
+def test_a_moe_llm_still_needs_active_params():
+    with pytest.raises(ValidationError, match="active_params"):
+        LLMDataUpsert(**payload(arch="moe"))
+
+    assert LLMDataUpsert(**payload(arch="moe", active_params=1.0)).active_params == 1.0
+
+
+def test_an_llm_without_an_endpoint_is_disabled():
+    llm = LLMDataUpsert(**payload(status="enabled", endpoint_id=None))
+
+    assert llm.status == "disabled"

--- a/utils/database/models/llms/llm.py
+++ b/utils/database/models/llms/llm.py
@@ -2,7 +2,7 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi.encoders import jsonable_encoder
-from pydantic import AfterValidator, ValidationInfo, field_validator, model_validator
+from pydantic import AfterValidator, model_validator
 from pydantic.networks import HttpUrl
 from pydantic_core import PydanticCustomError
 from sqlalchemy.dialects.postgresql import JSONB
@@ -108,10 +108,11 @@ class LLMDataBase(BaseDBModel):
         NonEmptyStr, Field(index=True, unique=True, **FIELDS["human_id"])
     ]
     api_model_id: Annotated[
-        NonEmptyStr | None, Field(**FIELDS["api_model_id"])
+        NonEmptyStr | None, Field(default=None, **FIELDS["api_model_id"])
     ]  # used to computed litellm args alongside LLMEndpoint data
     endpoint_id: Annotated[
-        UUID | None, Field(foreign_key="llm_endpoint.id", **FIELDS["endpoint_id"])
+        UUID | None,
+        Field(default=None, foreign_key="llm_endpoint.id", **FIELDS["endpoint_id"]),
     ]
     rate_limited: Annotated[bool, Field(**FIELDS["rate_limited"])]  # previous "pricey"
     lab_id: Annotated[UUID, Field(foreign_key="llm_lab.id", **FIELDS["lab_id"])]
@@ -128,10 +129,15 @@ class LLMDataBase(BaseDBModel):
     eu_hostable: Annotated[bool, Field(**FIELDS["eu_hostable"])]
     arch: Annotated[LLMArchKind, Field(sa_type=String, **FIELDS["arch"])]
     params: Annotated[float, Field(**FIELDS["params"])]
-    active_params: Annotated[float | None, Field(**FIELDS["active_params"])]
-    context_tokens: Annotated[int | None, Field(**FIELDS["context_tokens"])]
+    active_params: Annotated[
+        float | None, Field(default=None, **FIELDS["active_params"])
+    ]
+    context_tokens: Annotated[
+        int | None, Field(default=None, **FIELDS["context_tokens"])
+    ]
     quantization: Annotated[
-        Literal["q4", "q8"] | None, Field(sa_type=String, **FIELDS["quantization"])
+        Literal["q4", "q8"] | None,
+        Field(default=None, sa_type=String, **FIELDS["quantization"]),
     ]
     inputs: Annotated[
         list[Literal["text", "image", "audio", "video"]],
@@ -176,21 +182,21 @@ class LLMData(LLMDataBase, table=True):
 
 
 class LLMDataUpsert(LLMDataBase):
-    @field_validator("active_params", mode="before")
-    @classmethod
-    def check_active_params_is_defined_if_moe(
-        cls, value: float | None, info: ValidationInfo
-    ) -> int | float | None:
+    @model_validator(mode="after")
+    def check_active_params_is_defined_if_moe(self):
         """
         Assert active_params is defined if arch == "moe".
+
+        Checked on the model and not the field: active_params defaults to None,
+        and field validators do not run on a field the payload leaves out.
         """
-        if "moe" in info.data["arch"] and value is None:
+        if "moe" in self.arch and self.active_params is None:
             raise PydanticCustomError(
                 "missing_active_params",
-                f"LLM's arch is '{info.data['arch']}' and requires 'active_params' to be defined.",
+                f"LLM's arch is '{self.arch}' and requires 'active_params' to be defined.",
             )
 
-        return value
+        return self
 
     @model_validator(mode="after")
     def check_endpoint(self):
@@ -198,7 +204,7 @@ class LLMDataUpsert(LLMDataBase):
         Disable LLM if endpoint is not defined.
         """
         if self.status == "enabled" and (not self.endpoint_id or not self.api_model_id):
-            self.status == "disabled"
+            self.status = "disabled"
         return self
 
 


### PR DESCRIPTION
Follow-up to #678, which fixed `system_prompt` but left five fields with the same problem.

The admin form only sends the keys the user touched, so a field it draws as optional must have a default or creating an LLM fails with 422. `api_model_id`, `endpoint_id`, `active_params`, `context_tokens` and `quantization` now have one.

Giving `active_params` a default would have silenced the MoE check, since a field validator never runs on a key the payload leaves out, so that check moves to the model. The error now lands at model level rather than on the field, so the admin form lists it without a field label.

Also in here:

- `check_endpoint` compared `status` to `"disabled"` instead of assigning it, so an enabled LLM with no endpoint was never disabled.
- Dropped the `type="button"` attributes added in #678. `Button` already defaults to that, so they did nothing.
- `FormFieldsetList` declares `value` as optional, which is what the admin form actually passes on create.

Tests: four backend tests (schema invariant, create without the optional fields, MoE still guarded, endpoint disables) and two frontend ones (add when `value` is undefined, using the real `fieldset-item` shape, and delete-at-index). All six fail against the pre-fix code.

The schema test is an invariant rather than one field: `optional & required == set()`. It catches the next field added as `X | None` without a default.