### PR TITLE
Fix: let the LLM form render before its list keys exist

### DIFF
--- a/frontend/src/lib/components/form/Form.svelte.test.ts
+++ b/frontend/src/lib/components/form/Form.svelte.test.ts
@@ -1,0 +1,73 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import Form from './Form.svelte'
+import type { AnyFormItemProps } from '$lib/utils/form'
+
+const linkList: AnyFormItemProps = {
+  id: 'links',
+  label: 'Links',
+  component: 'fieldset-list',
+  value: [],
+  subProps: {
+    id: 'link',
+    label: 'Link',
+    value: {},
+    component: 'fieldset-item',
+    subProps: [
+      { id: 'text', label: 'Text', value: '', component: 'input', type: 'text', placeholder: '' }
+    ]
+  }
+}
+
+const modalities: AnyFormItemProps = {
+  id: 'inputs',
+  label: 'Modalities',
+  component: 'checkbox-group',
+  value: [],
+  options: [
+    { value: 'text', label: 'text' },
+    { value: 'image', label: 'image' }
+  ]
+}
+
+function renderForm(form: Record<string, any>) {
+  return render(Form, {
+    props: { id: 'llm', label: 'LLM', items: [modalities, linkList], form, onSubmit: () => {} }
+  })
+}
+
+describe('Form', () => {
+  // Creating a record starts from an empty object, so the list fields render
+  // bound to a key that is not there yet.
+  it('renders list fields the form has no key for', () => {
+    const { container } = renderForm({})
+
+    expect(container.querySelectorAll('#fieldset-links input')).toHaveLength(0)
+    expect(container.querySelectorAll('input[type="checkbox"]')).toHaveLength(2)
+  })
+
+  it('adds a link to a form that had no links key', async () => {
+    const form = $state<Record<string, any>>({})
+    const { container, getByRole } = renderForm(form)
+
+    await fireEvent.click(getByRole('button', { name: 'add' }))
+
+    expect(container.querySelectorAll('#fieldset-links input')).toHaveLength(1)
+    expect(form.links).toHaveLength(1)
+  })
+
+  it('ticks a checkbox on a form that had no key for the group', async () => {
+    const form = $state<Record<string, any>>({})
+    const { container } = renderForm(form)
+
+    const [text, image] = [
+      ...container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    ]
+    await fireEvent.click(text)
+    await fireEvent.click(image)
+    expect(form.inputs).toEqual(['text', 'image'])
+
+    await fireEvent.click(text)
+    expect(form.inputs).toEqual(['image'])
+  })
+})

--- a/frontend/src/lib/components/form/FormCheckboxGroup.svelte
+++ b/frontend/src/lib/components/form/FormCheckboxGroup.svelte
@@ -1,7 +1,10 @@
 <script module lang="ts">
   export type FormCheckboxGroupProps = {
     options: Option<string>[]
-  } & BaseFormFieldProps<'checkbox-group', string[]>
+    // The admin form only holds the keys the user touched, so the group may
+    // render before its own key exists.
+    value?: string[]
+  } & Omit<BaseFormFieldProps<'checkbox-group', string[]>, 'value'>
 </script>
 
 <script lang="ts">
@@ -9,6 +12,10 @@
   import { FormField, FormFieldset } from '.'
 
   let { value = $bindable(), disabled, options, ...props }: FormCheckboxGroupProps = $props()
+
+  function onToggle(option: string, checked: boolean) {
+    value = checked ? [...(value ?? []), option] : (value ?? []).filter((v) => v !== option)
+  }
 </script>
 
 <FormFieldset {...props} component="fieldset">
@@ -17,7 +24,15 @@
       <div class="fr-fieldset__element">
         <FormField id={`${id}-${opt.value}`} label={opt.label} component="checkbox">
           {#snippet formItem({ id })}
-            <input name={id} {id} type="checkbox" value={opt.value} {disabled} bind:group={value} />
+            <input
+              name={id}
+              {id}
+              type="checkbox"
+              value={opt.value}
+              {disabled}
+              checked={value?.includes(opt.value) ?? false}
+              onchange={(e) => onToggle(opt.value, e.currentTarget.checked)}
+            />
           {/snippet}
         </FormField>
       </div>

--- a/frontend/src/lib/components/form/FormFieldsetList.svelte
+++ b/frontend/src/lib/components/form/FormFieldsetList.svelte
@@ -13,21 +13,21 @@
   import type { AnyFormItemProps, BaseFormFieldProps } from '$lib/utils/form'
   import { FormFieldset } from '.'
 
-  let { value = $bindable([]), disabled, subProps, ...props }: FormFieldsetListProps = $props()
+  let { value = $bindable(), disabled, subProps, ...props }: FormFieldsetListProps = $props()
 
   const subIsFieldsetItem = $derived(subProps.component === 'fieldset-item')
   function onAdd() {
-    value = [...value, subIsFieldsetItem ? {} : '']
+    value = [...(value ?? []), subIsFieldsetItem ? {} : '']
   }
   function onDelete(index: number) {
-    value = value.filter((_, i) => i !== index)
+    value = (value ?? []).filter((_, i) => i !== index)
   }
 </script>
 
 <FormFieldset {...props} {disabled} component="fieldset">
   {#snippet formItem()}
     <div class="w-full">
-      {#each value as _v, i (i)}
+      {#each value ?? [] as _v, i (i)}
         <div class="fr-fieldset__element gap-3 flex w-full!">
           <div class="w-full">
             <AnyFormItem
@@ -35,7 +35,7 @@
               disabled={disabled ?? subProps.disabled}
               id="{props.id}-{subIsFieldsetItem ? i : subProps.id}"
               label="{props.label} {i}"
-              bind:value={value[i]}
+              bind:value={value![i]}
               errors={props.errors}
             />
           </div>

--- a/tests/database/test_llm_form_schema.py
+++ b/tests/database/test_llm_form_schema.py
@@ -70,3 +70,14 @@ def test_an_llm_without_an_endpoint_is_disabled():
     llm = LLMDataUpsert(**payload(status="enabled", endpoint_id=None))
 
     assert llm.status == "disabled"
+
+
+def test_links_are_not_required_in_the_admin_form():
+    """
+    An LLM card without links is fine, and the list starts empty, so the form
+    should not mark the fieldset with a required asterisk.
+    """
+    schema = LLMDataUpsert.model_json_schema(schema_generator=FormJsonSchema)
+
+    assert schema["properties"]["links"]["optional"] is True
+    assert "links" not in schema["required"]

--- a/utils/database/models/llms/llm.py
+++ b/utils/database/models/llms/llm.py
@@ -150,7 +150,11 @@ class LLMDataBase(BaseDBModel):
     ]
     links: Annotated[
         list[Link],
-        Field(sa_type=JSONB, **FIELDS["links"]),
+        Field(
+            sa_type=JSONB,
+            schema_extra={"json_schema_extra": {"optional": True}},
+            **FIELDS["links"],
+        ),
         AfterValidator(jsonable_encoder),
     ] = []
 


### PR DESCRIPTION
Follow-up to #678 and #680. Creating an LLM was still broken in the browser, for a reason no unit test could see.

The create form starts from an empty object, so a list field binds a key that is not there yet. A `$bindable` fallback cannot take that. Svelte throws:

> `props_invalid_value`: Cannot do `bind:value={undefined}` when `value` has a fallback value

That killed hydration on `/admin/llms/llms/create`, so only the last five fields rendered and the Links add button did nothing. The checkbox group had the same shape and crashed the server render first, on `value.includes` of an undefined value.

Both components now read `value` as possibly undefined and write an array back, so nothing binds a fallback. The checkbox group swaps `bind:group` for `checked` plus `onchange`, which is what `bind:group` cannot express on an undefined value.

Links is marked optional in the form schema too. An LLM card without links is fine, so the fieldset should not carry a required asterisk.

The tests in #678 passed against this bug because they render the component alone, which never binds. The new ones go through `Form` with an empty object, which is the path that breaks. All three fail if the fallback comes back.

Checked in a local instance: all 27 fields render, add appends a link, delete removes the right one and keeps the rest, and the modality checkboxes tick.