### PR TITLE
Show the first prompt while responses load

### DIFF
--- a/backend/arena/router.py
+++ b/backend/arena/router.py
@@ -314,23 +314,26 @@ async def add_first_text(
         )
         store_comparison_metadata(comparison.id, is_streaming=True)
 
-        yield format_sse_event({"type": "add", "turn": TurnPublic.model_validate(turn)})
-
-        # Stream both model responses
-        async for chunk in stream_comparison_messages(comparison, turn, request):
-            yield format_sse_event(chunk)
-
-        if not comparison.error:
-            increment_input_chars(
-                anonymous_user_hash,
-                get_ip(request),
-                len(args.prompt_value),
-                pricey=_is_pricey(comparison, llms_data),
+        try:
+            yield format_sse_event(
+                {"type": "add", "turn": TurnPublic.model_validate(turn)}
             )
 
-            await update_turn(turn.id, turn.llm_msg_a, turn.llm_msg_b)
+            # Stream both model responses
+            async for chunk in stream_comparison_messages(comparison, turn, request):
+                yield format_sse_event(chunk)
 
-        store_comparison_metadata(comparison.id, is_streaming=False)
+            if not comparison.error:
+                increment_input_chars(
+                    anonymous_user_hash,
+                    get_ip(request),
+                    len(args.prompt_value),
+                    pricey=_is_pricey(comparison, llms_data),
+                )
+
+                await update_turn(turn.id, turn.llm_msg_a, turn.llm_msg_b)
+        finally:
+            store_comparison_metadata(comparison.id, is_streaming=False)
 
     return create_sse_response(event_stream(comparison))
 
@@ -398,24 +401,27 @@ async def add_text(
         )
         store_comparison_metadata(comparison.id, is_streaming=True)
 
-        yield format_sse_event({"type": "add", "turn": TurnPublic.model_validate(turn)})
-
-        # Stream both model responses
-        async for chunk in stream_comparison_messages(comparison, turn, request):
-            yield format_sse_event(chunk)
-
-        if not comparison.error:
-            llms_data = await get_llms_data()
-            increment_input_chars(
-                anonymous_user_hash,
-                get_ip(request),
-                len(args.message),
-                pricey=_is_pricey(comparison, llms_data),
+        try:
+            yield format_sse_event(
+                {"type": "add", "turn": TurnPublic.model_validate(turn)}
             )
 
-            await update_turn(turn.id, turn.llm_msg_a, turn.llm_msg_b)
+            # Stream both model responses
+            async for chunk in stream_comparison_messages(comparison, turn, request):
+                yield format_sse_event(chunk)
 
-        store_comparison_metadata(comparison.id, is_streaming=False)
+            if not comparison.error:
+                llms_data = await get_llms_data()
+                increment_input_chars(
+                    anonymous_user_hash,
+                    get_ip(request),
+                    len(args.message),
+                    pricey=_is_pricey(comparison, llms_data),
+                )
+
+                await update_turn(turn.id, turn.llm_msg_a, turn.llm_msg_b)
+        finally:
+            store_comparison_metadata(comparison.id, is_streaming=False)
 
     return create_sse_response(event_stream())
 
@@ -483,22 +489,23 @@ async def retry(
             {"type": "update", "turn": TurnPublic.model_validate(turn)}
         )
 
-        # Stream both model responses
-        async for chunk in stream_comparison_messages(comparison, turn, request):
-            yield format_sse_event(chunk)
+        try:
+            # Stream both model responses
+            async for chunk in stream_comparison_messages(comparison, turn, request):
+                yield format_sse_event(chunk)
 
-        if not comparison.error:
-            llms_data = await get_llms_data()
-            increment_input_chars(
-                anonymous_user_hash,
-                get_ip(request),
-                len(turn.user_msg.content),
-                pricey=_is_pricey(comparison, llms_data),
-            )
+            if not comparison.error:
+                llms_data = await get_llms_data()
+                increment_input_chars(
+                    anonymous_user_hash,
+                    get_ip(request),
+                    len(turn.user_msg.content),
+                    pricey=_is_pricey(comparison, llms_data),
+                )
 
-            await update_turn(turn.id, turn.llm_msg_a, turn.llm_msg_b)
-
-        store_comparison_metadata(comparison.id, is_streaming=False)
+                await update_turn(turn.id, turn.llm_msg_a, turn.llm_msg_b)
+        finally:
+            store_comparison_metadata(comparison.id, is_streaming=False)
 
     return create_sse_response(event_stream(comparison))
 

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -167,13 +167,17 @@ export function parseAPIComparison(
 
   // Data loaded by a fresh page is not attached to the old SSE request. Any
   // incomplete turn therefore cannot make further progress and must not be
-  // presented as if it were still generating forever.
+  // presented as if it were still generating forever. This includes turns where
+  // only one side answered: parseAPITurn calls those 'complete', but the missing
+  // side would otherwise stay pending with no stream to fill it.
   const interruptedTurn = recoverInterrupted
-    ? parsed.turns.findLast((turn) => turn.status === 'pending')
+    ? parsed.turns.findLast((turn) => turn.a.status === 'pending' || turn.b.status === 'pending')
     : undefined
   if (interruptedTurn) {
     parsed.error ??= 'provider_error'
     interruptedTurn.status = 'error'
+    if (interruptedTurn.a.status === 'pending') interruptedTurn.a.status = 'error'
+    if (interruptedTurn.b.status === 'pending') interruptedTurn.b.status = 'error'
   }
 
   return parsed

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -1,7 +1,7 @@
 import { goto } from '$app/navigation'
 import { resolve } from '$app/paths'
 import { CaptchaError, consumeAltchaToken } from '$lib/captcha.svelte'
-import { api, ValidationError } from '$lib/fastapi-client'
+import { api, StreamTimeoutError, ValidationError } from '$lib/fastapi-client'
 import type {
   Consumption as APIConsoData,
   RevealData as APIRevealData,
@@ -155,12 +155,28 @@ function parseAPITurn(turn: APIComparisonTurn): ComparisonTurn {
   }
 }
 
-function parseAPIComparison(comparison: APIComparison): Comparison {
-  return {
+export function parseAPIComparison(
+  comparison: APIComparison,
+  recoverInterrupted = false
+): Comparison {
+  const parsed: Comparison = {
     ...comparison,
     error: comparison.error?.message,
     turns: comparison.turns.map(parseAPITurn)
   }
+
+  // Data loaded by a fresh page is not attached to the old SSE request. Any
+  // incomplete turn therefore cannot make further progress and must not be
+  // presented as if it were still generating forever.
+  const interruptedTurn = recoverInterrupted
+    ? parsed.turns.findLast((turn) => turn.status === 'pending')
+    : undefined
+  if (interruptedTurn) {
+    parsed.error ??= 'provider_error'
+    interruptedTurn.status = 'error'
+  }
+
+  return parsed
 }
 
 export function parseAPIRevealData(data: APIRevealData): RevealData {
@@ -177,7 +193,7 @@ export function parseAPIRevealData(data: APIRevealData): RevealData {
 
 export async function queryComparisons(_fetch: typeof fetch = fetch) {
   const data = await api.request<APIComparison[]>('/arena/comparison/list', { fetch: _fetch })
-  return data.map((c) => parseAPIComparison(c))
+  return data.map((c) => parseAPIComparison(c, true))
 }
 
 export function initComparisonsContext(data: ComparisonsCtx) {
@@ -280,6 +296,9 @@ export function getComparison<Id extends string | undefined>(comparisonId: Id) {
         promptError = err.errors ? err.errors[0].msg : err.message
       } else if (err instanceof CaptchaError) {
         promptError = 'Vérification anti-robot indisponible, veuillez réessayer.'
+      } else if (err instanceof StreamTimeoutError && comparison) {
+        comparison.error = 'timeout'
+        if (turn) turn.status = 'error'
       } else {
         throw err
       }

--- a/frontend/src/lib/chatService.svelte.ts
+++ b/frontend/src/lib/chatService.svelte.ts
@@ -191,9 +191,15 @@ export function parseAPIRevealData(data: APIRevealData): RevealData {
   }
 }
 
-export async function queryComparisons(_fetch: typeof fetch = fetch) {
+/**
+ * `recoverInterrupted` is only safe on a fresh page load: it rewrites any
+ * still-pending turn as interrupted. Passing it on an in-session refresh (e.g.
+ * after sign-in) would clobber a comparison that is actively streaming in this
+ * tab.
+ */
+export async function queryComparisons(_fetch: typeof fetch = fetch, recoverInterrupted = false) {
   const data = await api.request<APIComparison[]>('/arena/comparison/list', { fetch: _fetch })
-  return data.map((c) => parseAPIComparison(c, true))
+  return data.map((c) => parseAPIComparison(c, recoverInterrupted))
 }
 
 export function initComparisonsContext(data: ComparisonsCtx) {

--- a/frontend/src/lib/chatService.test.ts
+++ b/frontend/src/lib/chatService.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { parseAPIComparison, type APIComparison } from './chatService.svelte'
+
+describe('parseAPIComparison', () => {
+  it('marks a persisted incomplete turn as interrupted after a page reload', () => {
+    const comparison = {
+      id: 'comparison-id',
+      turns: [
+        {
+          id: 'turn-id',
+          user_msg: { content: 'hello' },
+          llm_msg_a: null,
+          llm_msg_b: null,
+          choice: null
+        }
+      ]
+    } as unknown as APIComparison
+
+    const parsed = parseAPIComparison(comparison, true)
+
+    expect(parsed.error).toBe('provider_error')
+    expect(parsed.turns[0].status).toBe('error')
+  })
+
+  it('keeps a newly streamed incomplete turn pending', () => {
+    const comparison = {
+      id: 'comparison-id',
+      turns: [
+        {
+          id: 'turn-id',
+          user_msg: { content: 'hello' },
+          llm_msg_a: null,
+          llm_msg_b: null,
+          choice: null
+        }
+      ]
+    } as unknown as APIComparison
+
+    expect(parseAPIComparison(comparison).turns[0].status).toBe('pending')
+  })
+})

--- a/frontend/src/lib/fastapi-client.test.ts
+++ b/frontend/src/lib/fastapi-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FastAPIClient, SSE_INACTIVITY_TIMEOUT_MS, StreamTimeoutError } from './fastapi-client'
+
+describe('FastAPIClient.stream', () => {
+  it('fails a silent SSE connection after the inactivity timeout', async () => {
+    vi.useFakeTimers()
+    const read = vi.fn(() => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}))
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: { getReader: () => ({ read, cancel }) }
+      })
+    )
+
+    const next = new FastAPIClient('https://example.test').stream('/arena', {}).next()
+    const rejection = expect(next).rejects.toBeInstanceOf(StreamTimeoutError)
+    await vi.advanceTimersByTimeAsync(SSE_INACTIVITY_TIMEOUT_MS)
+
+    await rejection
+    expect(cancel).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})

--- a/frontend/src/lib/fastapi-client.ts
+++ b/frontend/src/lib/fastapi-client.ts
@@ -84,6 +84,16 @@ export class InternalError extends Error {
   }
 }
 
+/** Longer than the backend's longest provider timeout, but still terminal. */
+export const SSE_INACTIVITY_TIMEOUT_MS = 90_000
+
+export class StreamTimeoutError extends Error {
+  constructor() {
+    super('The response stream stopped sending data')
+    this.name = 'StreamTimeoutError'
+  }
+}
+
 type PydanticValidationError = { loc: string[]; msg: string }
 
 export class ValidationError extends Error {
@@ -191,6 +201,7 @@ export class FastAPIClient {
    */
   async *stream(path: string, body: any): AsyncGenerator<SSEEvent> {
     const url = this.getUrl(path)
+    const controller = new AbortController()
 
     console.debug(`Streaming from ${path}`)
 
@@ -201,7 +212,8 @@ export class FastAPIClient {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify(body),
-        credentials: 'include'
+        credentials: 'include',
+        signal: controller.signal
       })
 
       if (!response.ok) {
@@ -214,7 +226,24 @@ export class FastAPIClient {
       let buffer = ''
 
       while (true) {
-        const { done, value } = await reader.read()
+        let timer: ReturnType<typeof setTimeout> | undefined
+        const timeout = new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new StreamTimeoutError()), SSE_INACTIVITY_TIMEOUT_MS)
+        })
+        let result: ReadableStreamReadResult<Uint8Array>
+        try {
+          result = await Promise.race([reader.read(), timeout])
+        } catch (error) {
+          if (error instanceof StreamTimeoutError) {
+            void reader.cancel(error).catch(() => undefined)
+            controller.abort(error)
+          }
+          throw error
+        } finally {
+          clearTimeout(timer)
+        }
+
+        const { done, value } = result
 
         if (done) break
 

--- a/frontend/src/routes/(arena)/+layout.ts
+++ b/frontend/src/routes/(arena)/+layout.ts
@@ -6,6 +6,6 @@ export const load: LayoutLoad = async ({ data, fetch }) => {
 
   return {
     ...data,
-    comparisons: await queryComparisons(fetch)
+    comparisons: await queryComparisons(fetch, true)
   }
 }

--- a/frontend/src/routes/(arena)/+page.svelte
+++ b/frontend/src/routes/(arena)/+page.svelte
@@ -6,7 +6,7 @@
   import { m } from '$lib/i18n/messages'
   import type { PageProps } from './$types'
   import { shouldShowInitialPrompt } from './arenaPageState'
-  import { PromptWarningModal, TOSModal, ViewChat, ViewPrompt } from './components'
+  import { ErrorDisplay, PromptWarningModal, TOSModal, ViewChat, ViewPrompt } from './components'
 
   let { data }: PageProps = $props()
 
@@ -28,7 +28,12 @@
     await tosModal?.runAfterAcceptance(action)
   }
 
+  // Kept so the error banner below can resend the exact same prompt when
+  // initialization dies before the first turn is shown.
+  let lastPromptArgs = $state<APIModeAndPromptData>()
+
   async function submitInitialPrompt(args: APIModeAndPromptData): Promise<void> {
+    lastPromptArgs = args
     await runAfterAcceptance(() => comparator.askFirst(args))
   }
 </script>
@@ -65,6 +70,17 @@
   {/snippet}
 
   {#if showInitialPrompt}
+    <!-- The stream died after /add_first_text opened but before the first turn
+         rendered: ViewPrompt has no turn to attach the error to, so surface it
+         here and let the user resend the prompt they still have typed. -->
+    {#if comparator.error && !comparator.loading}
+      <ErrorDisplay
+        error={comparator.error}
+        onRetry={() => {
+          if (lastPromptArgs) void submitInitialPrompt(lastPromptArgs)
+        }}
+      />
+    {/if}
     <ViewPrompt
       loading={comparator.loading}
       promptError={comparator.promptError}

--- a/frontend/src/routes/(arena)/+page.svelte
+++ b/frontend/src/routes/(arena)/+page.svelte
@@ -5,6 +5,7 @@
   import { getComparison, type APIModeAndPromptData } from '$lib/chatService.svelte'
   import { m } from '$lib/i18n/messages'
   import type { PageProps } from './$types'
+  import { shouldShowInitialPrompt } from './arenaPageState'
   import { PromptWarningModal, TOSModal, ViewChat, ViewPrompt } from './components'
 
   let { data }: PageProps = $props()
@@ -13,7 +14,9 @@
   fetchAndSolveSilently()
 
   const comparator = getComparison(undefined)
-  const showInitialPrompt = $derived(!comparator.comparisonId)
+  const showInitialPrompt = $derived(
+    shouldShowInitialPrompt(comparator.comparisonId, comparator.comparison)
+  )
 
   const revealed = $derived(comparator.status === 'revealed')
 
@@ -25,8 +28,8 @@
     await tosModal?.runAfterAcceptance(action)
   }
 
-  function submitInitialPrompt(args: APIModeAndPromptData): void {
-    void runAfterAcceptance(() => comparator.askFirst(args))
+  async function submitInitialPrompt(args: APIModeAndPromptData): Promise<void> {
+    await runAfterAcceptance(() => comparator.askFirst(args))
   }
 </script>
 

--- a/frontend/src/routes/(arena)/arenaPageState.test.ts
+++ b/frontend/src/routes/(arena)/arenaPageState.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowInitialPrompt } from './arenaPageState'
+
+describe('shouldShowInitialPrompt', () => {
+  it('keeps the optimistic prompt mounted between the init and add stream events', () => {
+    expect(shouldShowInitialPrompt('comparison-id', { turns: [] } as never)).toBe(true)
+  })
+
+  it('hands off to the chat once the first real turn exists', () => {
+    expect(shouldShowInitialPrompt('comparison-id', { turns: [{ id: 'turn-id' }] } as never)).toBe(
+      false
+    )
+  })
+})

--- a/frontend/src/routes/(arena)/arenaPageState.ts
+++ b/frontend/src/routes/(arena)/arenaPageState.ts
@@ -1,0 +1,8 @@
+import type { Comparison } from '$lib/chatService.svelte'
+
+export function shouldShowInitialPrompt(
+  comparisonId: string | undefined,
+  comparison: Comparison | null
+): boolean {
+  return !comparisonId || !comparison?.turns.length
+}

--- a/frontend/src/routes/(arena)/components/ViewPrompt.svelte
+++ b/frontend/src/routes/(arena)/components/ViewPrompt.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { Button, Toggle, Tooltip } from '$components/dsfr'
+  import Pending from '$components/Pending.svelte'
+  import { Button, Icon, Toggle, Tooltip } from '$components/dsfr'
   import TextPrompt from '$components/TextPrompt.svelte'
-  import type { APIModeAndPromptData } from '$lib/chatService.svelte'
+  import { modeInfos, type APIModeAndPromptData } from '$lib/chatService.svelte'
   import { useLocalStorage } from '$lib/helpers/useLocalStorage.svelte'
   import { m } from '$lib/i18n/messages.js'
   import { getModelsContext } from '$lib/models'
@@ -11,7 +12,9 @@
   import { page } from '$app/state'
   import { onMount, tick } from 'svelte'
   import { SvelteURLSearchParams } from 'svelte/reactivity'
-  import { GuidedPromptSuggestions, ModelSelector } from '.'
+  import GuidedPromptSuggestions from './GuidedPromptSuggestions.svelte'
+  import MessageUser from './MessageUser.svelte'
+  import ModelSelector from './ModelSelector.svelte'
 
   let {
     onPrompt,
@@ -19,7 +22,7 @@
     loading,
     suggestions
   }: {
-    onPrompt: (args: APIModeAndPromptData) => void
+    onPrompt: (args: APIModeAndPromptData) => void | Promise<void>
     promptError?: string
     loading: boolean
     suggestions: SuggestionCategory[]
@@ -39,8 +42,10 @@
     return []
   })
   let webSearch = $state(false)
+  let submitting = $state(false)
 
-  const disabled = $derived(prompt == '' || !!promptError || loading)
+  const disabled = $derived(prompt == '' || !!promptError || loading || submitting)
+  const selectedMode = $derived(modeInfos.find((item) => item.value === mode.value)!)
 
   onMount(() => {
     const vsParam = page.url.searchParams.get('vs')
@@ -86,13 +91,20 @@
     }
   }
 
-  function onPromptSubmit() {
-    onPrompt({
-      mode: mode.value,
-      custom_models_selection: modelsSelection.value,
-      prompt_value: prompt,
-      web_search: webSearch
-    })
+  async function onPromptSubmit() {
+    if (loading || submitting) return
+
+    submitting = true
+    try {
+      await onPrompt({
+        mode: mode.value,
+        custom_models_selection: modelsSelection.value,
+        prompt_value: prompt,
+        web_search: webSearch
+      })
+    } finally {
+      submitting = false
+    }
   }
 
   function handlePromptSelected(
@@ -134,62 +146,88 @@
   }
 </script>
 
-<div id="prompt-area" class="fr-container py-10 md:py-24">
-  <div class="fr-col-xl-8 m-auto">
-    <h2 class="fr-h3 mb-0! text-center">
-      {m['arenaHome.title']()}
-    </h2>
-    <div class="gap-3 py-10 md:grid-flow-row-dense md:grid-cols-6 md:pb-20 md:pt-12 grid">
-      <div class="md:order-none md:col-span-full order-1">
-        <TextPrompt
-          id="initial-prompt"
-          bind:el={promptEl}
-          bind:value={prompt}
-          label={m['arenaHome.prompt.label']()}
-          placeholder={m['arenaHome.prompt.placeholder']()}
-          bind:error={promptError}
-          disabled={loading}
-          submitDisabled={disabled}
-          hideLabel
-          rows={4}
-          onSubmit={() => onPromptSubmit()}
-        />
-      </div>
+<!-- Present before loading starts so assistive technology announces the state change. -->
+<p role="status" class="sr-only">{loading ? m['chatbot.loading']() : ''}</p>
 
-      <div class="gap-3 md:col-span-5 md:flex-row flex flex-col">
-        <ModelSelector
-          bind:mode={mode.value}
-          bind:modelsSelection={modelsSelection.value}
-          {models}
-          disabled={loading}
-        />
-        <Toggle
-          id="web-search"
-          bind:value={webSearch}
-          checkedLabel={m['arenaHome.webSearch.enabled']()}
-          uncheckedLabel={m['arenaHome.webSearch.disabled']()}
-          hideCheckLabel
-          labelPos="right"
-          class="font-medium w-full! text-[14px]!"
-          groupClass="grow my-auto"
+{#if loading}
+  <div id="prompt-area" class="fr-container px-4 py-2 md:px-6 md:py-5">
+    <div class="gap-2 md:gap-5 flex flex-col">
+      <div class="md:flex">
+        <div
+          class="cg-border md:me-3 rounded-lg! bg-white py-1 text-sm mb-3 md:mb-0 px-10 md:py-3 min-w-fit self-start border-dashed! text-center"
         >
-          {m['arenaHome.webSearch.label']()}
-          <Tooltip id="web-search-tooltip" size="sm" class="ms-1">
-            {@html sanitize(m['arenaHome.webSearch.tooltip']())}
-          </Tooltip>
-        </Toggle>
+          <Icon icon={selectedMode.icon} size="sm" class="text-primary" />
+          <strong>{selectedMode.title}</strong>
+          <Tooltip id="pending-mode-desc" text={selectedMode.description} size="xs" />
+        </div>
+
+        <MessageUser
+          id="pending-user-message"
+          message={{ content: prompt, user_content: prompt }}
+        />
       </div>
 
-      <Button
-        type="submit"
-        text={m['words.send']()}
-        {disabled}
-        class="md:w-auto! md:order-none order-2 h-full w-full! min-w-[130px] place-self-end"
-        onclick={() => onPromptSubmit()}
-      />
-    </div>
-    <div class="pb-10">
-      <GuidedPromptSuggestions {suggestions} onPromptSelected={handlePromptSelected} />
+      <Pending message={m['chatbot.loading']()} class="m-auto" aria-hidden="true" />
     </div>
   </div>
-</div>
+{:else}
+  <div id="prompt-area" class="fr-container py-10 md:py-24">
+    <div class="fr-col-xl-8 m-auto">
+      <h2 class="fr-h3 mb-0! text-center">
+        {m['arenaHome.title']()}
+      </h2>
+      <div class="gap-3 py-10 md:grid-flow-row-dense md:grid-cols-6 md:pb-20 md:pt-12 grid">
+        <div class="md:order-none md:col-span-full order-1">
+          <TextPrompt
+            id="initial-prompt"
+            bind:el={promptEl}
+            bind:value={prompt}
+            label={m['arenaHome.prompt.label']()}
+            placeholder={m['arenaHome.prompt.placeholder']()}
+            bind:error={promptError}
+            disabled={loading}
+            submitDisabled={disabled}
+            hideLabel
+            rows={4}
+            onSubmit={() => onPromptSubmit()}
+          />
+        </div>
+
+        <div class="gap-3 md:col-span-5 md:flex-row flex flex-col">
+          <ModelSelector
+            bind:mode={mode.value}
+            bind:modelsSelection={modelsSelection.value}
+            {models}
+            disabled={loading}
+          />
+          <Toggle
+            id="web-search"
+            bind:value={webSearch}
+            checkedLabel={m['arenaHome.webSearch.enabled']()}
+            uncheckedLabel={m['arenaHome.webSearch.disabled']()}
+            hideCheckLabel
+            labelPos="right"
+            class="font-medium w-full! text-[14px]!"
+            groupClass="grow my-auto"
+          >
+            {m['arenaHome.webSearch.label']()}
+            <Tooltip id="web-search-tooltip" size="sm" class="ms-1">
+              {@html sanitize(m['arenaHome.webSearch.tooltip']())}
+            </Tooltip>
+          </Toggle>
+        </div>
+
+        <Button
+          type="submit"
+          text={m['words.send']()}
+          {disabled}
+          class="md:w-auto! md:order-none order-2 h-full w-full! min-w-[130px] place-self-end"
+          onclick={() => onPromptSubmit()}
+        />
+      </div>
+      <div class="pb-10">
+        <GuidedPromptSuggestions {suggestions} onPromptSelected={handlePromptSelected} />
+      </div>
+    </div>
+  </div>
+{/if}

--- a/frontend/src/routes/(arena)/components/ViewPrompt.svelte.test.ts
+++ b/frontend/src/routes/(arena)/components/ViewPrompt.svelte.test.ts
@@ -1,0 +1,72 @@
+import { fireEvent, render } from '@testing-library/svelte'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ViewPrompt from './ViewPrompt.svelte'
+
+vi.mock('$lib/models', () => ({
+  getModelsContext: () => ({ models: [] })
+}))
+
+vi.mock('$lib/chatService.svelte', () => ({
+  modeInfos: [
+    {
+      value: 'random',
+      icon: 'i-ri-dice-line',
+      title: 'Aléatoire',
+      label: 'Aléatoire',
+      alt_label: 'Aléatoire',
+      description: 'Deux modèles choisis au hasard'
+    }
+  ]
+}))
+
+const props = {
+  loading: false,
+  onPrompt: vi.fn(),
+  suggestions: []
+}
+
+describe('ViewPrompt', () => {
+  beforeEach(() => {
+    const values = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+      clear: () => values.clear()
+    })
+  })
+
+  it('shows the submitted prompt and loading status while the first turn is pending', async () => {
+    const onPrompt = vi.fn(() => new Promise<void>(() => {}))
+    const view = render(ViewPrompt, { ...props, onPrompt })
+    const prompt = view.getByRole('textbox')
+
+    await fireEvent.input(prompt, { target: { value: 'Pourquoi le ciel est-il bleu ?' } })
+    await fireEvent.click(view.getByRole('button', { name: 'Envoyer' }))
+    await fireEvent.click(view.getByRole('button', { name: 'Envoyer' }))
+
+    expect(onPrompt).toHaveBeenCalledOnce()
+    expect(onPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt_value: 'Pourquoi le ciel est-il bleu ?' })
+    )
+
+    await view.rerender({ ...props, onPrompt, loading: true })
+
+    expect(view.getByText('Pourquoi le ciel est-il bleu ?')).toBeInTheDocument()
+    expect(view.getByRole('status')).toHaveTextContent('Chargement des réponses')
+    expect(view.queryByRole('button', { name: 'Envoyer' })).toBeNull()
+  })
+
+  it('restores the populated form when loading stops before initialization', async () => {
+    const view = render(ViewPrompt, props)
+
+    await fireEvent.input(view.getByRole('textbox'), {
+      target: { value: 'Une question à réessayer' }
+    })
+    await view.rerender({ ...props, loading: true })
+    await view.rerender({ ...props, loading: false, promptError: 'Réessayez' })
+
+    expect(view.getByRole('textbox')).toHaveValue('Une question à réessayer')
+    expect(view.getByText('Réessayez')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- show the submitted first prompt immediately while the conversation is being initialized
- keep the optimistic prompt visible until the first persisted turn arrives
- prevent duplicate initial submissions and announce the loading state accessibly
- preserve the populated form when initialization returns an error or warning
- stop silent response streams after 90 seconds of inactivity and expose a retryable timeout
- recover persisted incomplete turns as interrupted instead of displaying an endless loading state
- always release streaming metadata when a request is interrupted

## Tests

- `yarn test:unit --run` (234 tests passed)
- Python compilation check for `backend/arena/router.py`
- `git diff --check`
