### PR TITLE
fix(ranking): rétablit le graphique du focus énergie

### DIFF
--- a/frontend/src/routes/(arena)/ranking/components/EnergyGraph.svelte
+++ b/frontend/src/routes/(arena)/ranking/components/EnergyGraph.svelte
@@ -99,19 +99,26 @@
   const xTicks = $derived(ticks(...minMaxX, 7))
   const yTicks = $derived(ticks(...minMaxY, 9))
 
-  onMount(resize)
+  onMount(() => {
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (!entry) return
 
-  function resize() {
-    ;({ width, height } = svg!.getBoundingClientRect())
-  }
+      const { width: nextWidth, height: nextHeight } = entry.contentRect
+      if (nextWidth === 0 || nextHeight === 0) return
+
+      width = nextWidth
+      height = nextHeight
+    })
+
+    resizeObserver.observe(svg!)
+    return () => resizeObserver.disconnect()
+  })
 
   function onModelHover(model: ModelGraphData) {
     hoveredModel = model.id
     tooltipPos = { x: xScale(model.x), y: yScale(model.y) }
   }
 </script>
-
-<svelte:window onresize={resize} />
 
 {#snippet legend(kind: string)}
   <div

--- a/frontend/src/routes/(arena)/ranking/components/EnergyGraph.svelte.test.ts
+++ b/frontend/src/routes/(arena)/ranking/components/EnergyGraph.svelte.test.ts
@@ -1,0 +1,90 @@
+import { render } from '@testing-library/svelte'
+import { tick } from 'svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import EnergyGraph from './EnergyGraph.svelte'
+
+const observers: ResizeObserverCallback[] = []
+
+vi.mock('$lib/models', () => ({
+  CONSO_SIZES: ['S', 'M', 'L'],
+  applyStyleControl: (models: unknown[]) => models,
+  getModelsWithDataContext: () => ({
+    models: [
+      {
+        id: 'test-model',
+        search: 'test model',
+        consumption: 100,
+        params: 8,
+        active_params: null,
+        size_class: 'XS',
+        arch: 'dense',
+        status: 'enabled',
+        license: { kind: 'open-source' },
+        lab: { name: 'Test Lab', logo: null },
+        data: {
+          elo: 1000,
+          rank: 1,
+          rankClass: '1',
+          score_p2_5: 990,
+          score_p97_5: 1010
+        }
+      }
+    ]
+  })
+}))
+
+describe('EnergyGraph', () => {
+  beforeEach(() => {
+    observers.length = 0
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          observers.push(callback)
+        }
+
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('repositions data when its hidden tab becomes visible', async () => {
+    const { container } = render(EnergyGraph)
+    const circle = container.querySelector('svg circle')!
+    const initialX = Number(circle.getAttribute('cx'))
+
+    expect(observers).toHaveLength(1)
+
+    observers[0](
+      [
+        {
+          contentRect: { width: 0, height: 0 }
+        } as ResizeObserverEntry
+      ],
+      {} as ResizeObserver
+    )
+    await tick()
+    expect(Number(circle.getAttribute('cx'))).toBe(initialX)
+
+    observers[0](
+      [
+        {
+          contentRect: { width: 900, height: 700 }
+        } as ResizeObserverEntry
+      ],
+      {} as ResizeObserver
+    )
+    await tick()
+
+    const visibleX = Number(circle.getAttribute('cx'))
+    expect(visibleX).not.toBe(initialX)
+    expect(visibleX).toBeGreaterThan(72)
+    expect(visibleX).toBeLessThan(900)
+  })
+})

--- a/frontend/vitest-setup-client.ts
+++ b/frontend/vitest-setup-client.ts
@@ -15,4 +15,17 @@ Object.defineProperty(window, 'matchMedia', {
   }))
 })
 
+// jsdom has no layout engine and therefore does not provide ResizeObserver.
+// Components may still create one during a page-level render; individual tests
+// that need resize events can replace this no-op implementation with a driver.
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  writable: true,
+  configurable: true,
+  value: class implements ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+
 // add more mocks here if you need them


### PR DESCRIPTION
## Problème

Le graphique du focus énergie mesure sa taille pendant que son onglet est masqué. Sa zone de rendu est alors calculée à `0 × 0`, ce qui regroupe les points dans le coin supérieur gauche jusqu’au prochain redimensionnement de la fenêtre.

## Correction

- observe les dimensions réelles du SVG avec `ResizeObserver` ;
- ignore les mesures nulles tant que l’onglet est masqué ;
- recalcule automatiquement les axes et les points dès que le panneau devient visible ;
- déconnecte l’observateur au démontage du composant.

## Vérification

- ajoute un test de régression couvrant le passage d’un panneau masqué à un panneau visible ;
- formatage et lint ciblés validés ;
- test ciblé validé.